### PR TITLE
refactor: Use `ResultAsync` instead

### DIFF
--- a/error.ts
+++ b/error.ts
@@ -1,0 +1,11 @@
+export function convertError(
+  errorMessage: string,
+  errorInstance = Error,
+): (e: unknown) => Error {
+  return (e: unknown) => {
+    if (e instanceof Error) {
+      return e;
+    }
+    return new errorInstance(errorMessage, { cause: e });
+  };
+}

--- a/issues/show.ts
+++ b/issues/show.ts
@@ -1,8 +1,9 @@
 import { object, safeParse } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import { ShowIssue, showIssueSchema } from "./type.ts";
 import type { Context } from "../context.ts";
+import { convertError } from "../error.ts";
 
 const schema = object({
   issue: showIssueSchema,
@@ -17,35 +18,44 @@ type Include =
   | "watchers"
   | "allowed_statuses";
 
-export async function show(
+export function show(
   id: number,
   context: Context,
   includes?: Include[],
-): Promise<Result<ShowIssue, Error>> {
+): ResultAsync<ShowIssue, Error> {
   const url = new URL(join(context.endpoint, "issues", `${id}.json`));
   if (includes !== undefined) {
     url.search = new URLSearchParams({ include: includes.join(",") })
       .toString();
   }
-  const response = await fetch(
-    url,
-    {
+  return ResultAsync.fromPromise(
+    fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
-    },
-  );
-  if (!response.ok) {
-    return err(new Error(`${response.status}: ${response.statusText}`));
-  }
-  const json = await response.json();
-  const parsed = safeParse(schema, json);
-  if (!parsed.success) {
-    return err(
-      new Error("Fetched project has invalid schema", { cause: parsed.issues }),
-    );
-  }
-  return ok(parsed.output.issue);
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) =>
+      r.ok ? okAsync(r) : errAsync(new Error(`${r.status}: ${r.statusText}`))
+    )
+    .andThen((r: Response) =>
+      ResultAsync.fromPromise(
+        r.json(),
+        convertError("Unexpected Error"),
+      )
+    )
+    .andThen((json: unknown) => {
+      const parsed = safeParse(schema, json);
+      if (!parsed.success) {
+        return errAsync(
+          new Error("Fetched project has invalid schema", {
+            cause: parsed.issues,
+          }),
+        );
+      }
+      return okAsync(parsed.output.issue);
+    });
 }

--- a/projects/create.ts
+++ b/projects/create.ts
@@ -1,4 +1,4 @@
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import type { Context } from "../context.ts";
 import {
@@ -8,33 +8,45 @@ import {
   string,
 } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
 import type { ProjectRequest } from "./type.ts";
+import { convertError } from "../error.ts";
 
 const errorSchema = object({
   errors: array(string()),
 });
 
-export async function create(
+export function create(
   project: ProjectRequest,
   context: Context,
-): Promise<Result<void, Error>> {
+): ResultAsync<void, Error> {
   const url = new URL(join(context.endpoint, "projects.json"));
-  const response = await fetch(
-    url,
-    {
+  return ResultAsync.fromPromise(
+    fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
       body: JSON.stringify({ project }),
-    },
-  );
-  if (!response.ok) {
-    const json = await response.json();
-    if (!is(errorSchema, json)) {
-      return err(new Error(`${response.status}: ${response.statusText}`));
-    }
-    return err(new Error(JSON.stringify(json.errors)));
-  }
-  return ok(undefined);
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) => r.ok ? okAsync(undefined) : errAsync(r))
+    .orElse((e: Response | Error) => {
+      if (e instanceof Error) {
+        return errAsync(e);
+      }
+      return ResultAsync.fromPromise(
+        e.json(),
+        convertError("Unexpected Error"),
+      );
+    })
+    .andThen((r: unknown) => {
+      if (r === undefined) {
+        return okAsync(undefined);
+      }
+      if (is(errorSchema, r)) {
+        return errAsync(new Error(JSON.stringify(r.errors)));
+      }
+      return errAsync(new Error("Unexpected Error", { cause: r }));
+    });
 }

--- a/projects/delete.ts
+++ b/projects/delete.ts
@@ -4,35 +4,47 @@ import {
   object,
   string,
 } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import type { Context } from "../context.ts";
+import { convertError } from "../error.ts";
 
 const errorSchema = object({
   errors: array(string()),
 });
 
-export async function deleteProject(
+export function deleteProject(
   id: number,
   context: Context,
-): Promise<Result<void, Error>> {
+): ResultAsync<void, Error> {
   const url = new URL(join(context.endpoint, "projects", `${id}.json`));
-  const response = await fetch(
-    url,
-    {
+  return ResultAsync.fromPromise(
+    fetch(url, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
-    },
-  );
-  if (!response.ok) {
-    const json = await response.json();
-    if (!is(errorSchema, json)) {
-      return err(new Error(`${response.status}: ${response.statusText}`));
-    }
-    return err(new Error(JSON.stringify(json.errors)));
-  }
-  return ok(undefined);
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) => r.ok ? okAsync(undefined) : errAsync(r))
+    .orElse((e: Response | Error) => {
+      if (e instanceof Error) {
+        return errAsync(e);
+      }
+      return ResultAsync.fromPromise(
+        e.json(),
+        convertError("Unexpected Error"),
+      );
+    })
+    .andThen((r: unknown) => {
+      if (r === undefined) {
+        return okAsync(undefined);
+      }
+      if (is(errorSchema, r)) {
+        return errAsync(new Error(JSON.stringify(r.errors)));
+      }
+      return errAsync(new Error("Unexpected Error", { cause: r }));
+    });
 }

--- a/projects/list.test.ts
+++ b/projects/list.test.ts
@@ -78,7 +78,8 @@ Deno.test("test for redmine project 'list' endpoint", async (t) => {
           limit: 25,
         }),
         { status: 200 },
-      );
+      )
+      .times(2);
     const e = await fetchList(context);
     assert(e.isOk());
   });

--- a/projects/list.ts
+++ b/projects/list.ts
@@ -1,13 +1,15 @@
 import {
   array,
+  is,
   number,
   object,
   safeParse,
 } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import { type Project, projectSchema } from "./type.ts";
 import type { Context } from "../context.ts";
+import { convertError } from "../error.ts";
 
 const responseSchema = object({
   projects: array(projectSchema),
@@ -22,49 +24,78 @@ const responseSchema = object({
  * @param context REST endpoint context
  * @return Promise of result-type which has project or error
  */
-export async function fetchList(
-  context: Context,
-): Promise<Result<Project[], Error>> {
-  let currentOffset = 0;
+export function fetchList(context: Context): ResultAsync<Project[], Error> {
   const limit = 25;
-  const projects: Project[][] = [];
-  while (true) {
-    const endpoint = new URL(join(context.endpoint, "projects.json"));
-    endpoint.search = new URLSearchParams({
-      limit: `${limit}`,
-      offset: `${currentOffset}`,
-    }).toString();
-    const response = await fetch(
-      endpoint,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Redmine-API-Key": context.apiKey,
-        },
+
+  const opts: RequestInit = {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+  };
+  return fetchNumberOfProjects(context)
+    .andThen((n) => {
+      const results: ResultAsync<Response, Error>[] = [];
+      for (let i = 0; i < n; i += limit) {
+        const endpoint = new URL(join(context.endpoint, "projects.json"));
+        endpoint.search = new URLSearchParams({
+          limit: `${limit}`,
+          offset: `${i}`,
+        }).toString();
+        results.push(
+          ResultAsync.fromPromise(
+            fetch(endpoint, opts),
+            convertError("Unexpected Error"),
+          ),
+        );
+      }
+      return ResultAsync.combine(results);
+    })
+    .andThen((r) =>
+      ResultAsync.fromPromise(
+        Promise.all(r.map((e) => e.json())),
+        convertError("Unexpected Error"),
+      )
+    )
+    .andThen((r: unknown[]) => {
+      const projects: Project[][] = [];
+      for (const project of r) {
+        const parsed = safeParse(responseSchema, project);
+        if (!parsed.success) {
+          return errAsync(
+            new Error("Unexpected Error", { cause: parsed.issues }),
+          );
+        }
+        projects.push(parsed.output.projects);
+      }
+      return okAsync(projects.flat());
+    });
+}
+
+function fetchNumberOfProjects(context: Context): ResultAsync<number, Error> {
+  const endpoint = new URL(join(context.endpoint, "projects.json"));
+  endpoint.search = new URLSearchParams({
+    limit: "1",
+    offset: "0",
+  }).toString();
+
+  return ResultAsync.fromPromise(
+    fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
       },
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) =>
+      ResultAsync.fromPromise(r.json(), convertError("Unexpected Error"))
+    )
+    .andThen((r: unknown) =>
+      is(responseSchema, r)
+        ? okAsync(r.total_count)
+        : errAsync(new Error("Unexpected Error"))
     );
-    if (!response.ok) {
-      return err(new Error(`${response.status}: ${response.statusText}`));
-    }
-    const json = await response.json();
-
-    const parsed = safeParse(responseSchema, json);
-    if (!parsed.success) {
-      return err(
-        new Error("Fetched project has invalid schema", {
-          cause: parsed.issues,
-        }),
-      );
-    }
-
-    projects.push(parsed.output.projects);
-
-    currentOffset += limit;
-    if (currentOffset >= json.total_count) {
-      break;
-    }
-  }
-
-  return ok(projects.flat());
 }

--- a/projects/mod.ts
+++ b/projects/mod.ts
@@ -1,4 +1,4 @@
-import { Result } from "npm:neverthrow@6.1.0";
+import { ResultAsync } from "npm:neverthrow@6.1.0";
 import type { Context } from "../context.ts";
 import { fetchList } from "./list.ts";
 import { show } from "./show.ts";
@@ -20,8 +20,8 @@ export class ProjectClient {
    * Returns all projects
    * This includes all public projects and private projects where user have access to.
    */
-  async list(): Promise<Result<Project[], Error>> {
-    return await fetchList(this.#context);
+  list(): ResultAsync<Project[], Error> {
+    return fetchList(this.#context);
   }
 
   /**
@@ -29,10 +29,10 @@ export class ProjectClient {
    *
    * @param id Project identifier
    */
-  async show(
+  show(
     id: number,
-  ): Promise<Result<Project, Error>> {
-    return await show(id, this.#context);
+  ): ResultAsync<Project, Error> {
+    return show(id, this.#context);
   }
 
   /**
@@ -40,10 +40,10 @@ export class ProjectClient {
    *
    * @param project The project attributes
    */
-  async create(
+  create(
     project: ProjectRequest,
-  ): Promise<Result<void, Error>> {
-    return await create(project, this.#context);
+  ): ResultAsync<void, Error> {
+    return create(project, this.#context);
   }
 
   /**
@@ -52,11 +52,11 @@ export class ProjectClient {
    * @param id Project identifier
    * @param project The project attributes to update it
    */
-  async update(
+  update(
     id: number,
     project: ProjectUpdateInformation,
-  ): Promise<Result<void, Error>> {
-    return await update(id, project, this.#context);
+  ): ResultAsync<void, Error> {
+    return update(id, project, this.#context);
   }
 
   /**
@@ -64,8 +64,8 @@ export class ProjectClient {
    *
    * @param id Project identifier
    */
-  async delete(id: number): Promise<Result<void, Error>> {
-    return await deleteProject(id, this.#context);
+  delete(id: number): ResultAsync<void, Error> {
+    return deleteProject(id, this.#context);
   }
 
   /**
@@ -75,8 +75,8 @@ export class ProjectClient {
    *
    * @note This feature is available since Redmine 5.0.
    */
-  async archive(id: number): Promise<Result<void, Error>> {
-    return await archive(id, this.#context);
+  archive(id: number): ResultAsync<void, Error> {
+    return archive(id, this.#context);
   }
 
   /**
@@ -86,7 +86,7 @@ export class ProjectClient {
    *
    * @note This feature is available since Redmine 5.0.
    */
-  async unarchive(id: number): Promise<Result<void, Error>> {
-    return await unarchive(id, this.#context);
+  unarchive(id: number): ResultAsync<void, Error> {
+    return unarchive(id, this.#context);
   }
 }

--- a/projects/show.ts
+++ b/projects/show.ts
@@ -1,37 +1,47 @@
 import { object, safeParse } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import { type Project, projectSchema } from "./type.ts";
 import type { Context } from "../context.ts";
+import { convertError } from "../error.ts";
 
 const schema = object({
   project: projectSchema,
 });
 
-export async function show(
+export function show(
   id: number,
   context: Context,
-): Promise<Result<Project, Error>> {
+): ResultAsync<Project, Error> {
   const url = new URL(join(context.endpoint, "projects", `${id}.json`));
-  const response = await fetch(
-    url,
-    {
+  return ResultAsync.fromPromise(
+    fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
-    },
-  );
-  if (!response.ok) {
-    return err(new Error(`${response.status}: ${response.statusText}`));
-  }
-  const json = await response.json();
-  const parsed = safeParse(schema, json);
-  if (!parsed.success) {
-    return err(
-      new Error("Fetched project has invalid schema", { cause: parsed.issues }),
-    );
-  }
-  return ok(parsed.output.project);
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) =>
+      r.ok ? okAsync(r) : errAsync(new Error(`${r.status}: ${r.statusText}`))
+    )
+    .andThen((r: Response) =>
+      ResultAsync.fromPromise(
+        r.json(),
+        convertError("Unexpected Error"),
+      )
+    )
+    .andThen((json: unknown) => {
+      const parsed = safeParse(schema, json);
+      if (!parsed.success) {
+        return errAsync(
+          new Error("Fetched project has invalid schema", {
+            cause: parsed.issues,
+          }),
+        );
+      }
+      return okAsync(parsed.output.project);
+    });
 }

--- a/projects/update.ts
+++ b/projects/update.ts
@@ -1,4 +1,4 @@
-import { err, ok, Result } from "npm:neverthrow@6.1.0";
+import { errAsync, okAsync, ResultAsync } from "npm:neverthrow@6.1.0";
 import { join } from "https://deno.land/std@0.205.0/path/mod.ts";
 import type { Context } from "../context.ts";
 import type { ProjectRequest } from "./type.ts";
@@ -8,6 +8,7 @@ import {
   object,
   string,
 } from "https://deno.land/x/valibot@v0.18.0/mod.ts";
+import { convertError } from "../error.ts";
 
 const errorSchema = object({
   errors: array(string()),
@@ -17,29 +18,40 @@ export type ProjectUpdateInformation = Partial<
   Omit<ProjectRequest, "identifier">
 >;
 
-export async function update(
+export function update(
   id: number,
   project: ProjectUpdateInformation,
   context: Context,
-): Promise<Result<void, Error>> {
+): ResultAsync<void, Error> {
   const url = new URL(join(context.endpoint, "projects", `${id}.json`));
-  const response = await fetch(
-    url,
-    {
+  return ResultAsync.fromPromise(
+    fetch(url, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
       body: JSON.stringify({ project }),
-    },
-  );
-  if (!response.ok) {
-    const json = await response.json();
-    if (!is(errorSchema, json)) {
-      return err(new Error(`${response.status}: ${response.statusText}`));
-    }
-    return err(new Error(JSON.stringify(json.errors)));
-  }
-  return ok(undefined);
+    }),
+    convertError("Unexpected Error"),
+  )
+    .andThen((r: Response) => r.ok ? okAsync(undefined) : errAsync(r))
+    .orElse((e: Response | Error) => {
+      if (e instanceof Error) {
+        return errAsync(e);
+      }
+      return ResultAsync.fromPromise(
+        e.json(),
+        convertError("Unexpected Error"),
+      );
+    })
+    .andThen((r: unknown) => {
+      if (r === undefined) {
+        return okAsync(undefined);
+      }
+      if (is(errorSchema, r)) {
+        return errAsync(new Error(JSON.stringify(r.errors)));
+      }
+      return errAsync(new Error("Unexpected Error", { cause: r }));
+    });
 }


### PR DESCRIPTION
It is better than `Promise<Result<T, E>>`.

- chore: add convertError shorthand
- refactor: use ResultAsync instead (projects/show)
- refactor: use ResultAsync instead (projects/create)
- refactor: use ResultAsync instead (projects/update)
- refactor: use ResultAsync instead (projects/archive)
- refactor: use ResultAsync instead (projects/delete)
- refactor: use ResultAsync instead (projects/list.ts)
- test: fix times to intercept
- refactor: fix type annotation for projects/mod
- refactor: use ResultAsync instead (issues/show)
