### PR TITLE
fix: coerce `null` to `undefined`

### DIFF
--- a/throwable/issues/type.ts
+++ b/throwable/issues/type.ts
@@ -63,14 +63,14 @@ export type Relation = {
 export type Journal = {
   id: number;
   user: IdName;
-  notes: string;
+  notes?: string;
   createdOn: Date;
   privateNotes: boolean;
   details: {
     property: string;
     name: string;
     oldValue?: string;
-    newValue: string;
+    newValue?: string;
   }[];
 };
 

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -164,7 +164,10 @@ const journal = pipe(
   object({
     id: number(),
     user: idName,
-    notes: string(),
+    notes: pipe(
+      union([string(), null_()]),
+      transform(toUndefined),
+    ),
     created_on: dateLikeString,
     private_notes: boolean(),
     details: array(object({
@@ -174,7 +177,10 @@ const journal = pipe(
         union([string(), null_()]),
         transform(toUndefined),
       ),
-      new_value: string(),
+      new_value: pipe(
+        union([string(), null_()]),
+        transform(toUndefined),
+      ),
     })),
   }),
   transform((input) => {


### PR DESCRIPTION
If property be changed, it has `null` as `note`.

And, when delete some property, `null` be `new_value`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated journal entries to allow the notes field to be optional.
  * Details within journal entries now support an optional new value field.

* **Bug Fixes**
  * Improved validation to accept empty or missing notes and new value fields in journal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->