### PR TITLE
refactor: use lib.pipe insteadof pipe-operators

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
             deno task lint
             deno task test
           '' [ (runAs "check-deno" devPackages.deno) ];
-          test-coverage = pkgs.ib.pipe ''
+          test-coverage = pkgs.lib.pipe ''
             deno task test:coverage
           '' [ (runAs "test-coverage" devPackages.deno) ];
         };


### PR DESCRIPTION
pipe-operators break renovate update task, because `pipe-operators` is not enabled in renovate environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured development environment configuration system
  * Updated how development shells are assembled and composed
  * Modified application building and runtime dependency handling for development tools

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->