### PR TITLE
chore: disable no-import-prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -10,5 +10,12 @@
   "lock": false,
   "fmt": {
     "exclude": ["CHANGELOG.md"]
+  },
+  "lint": {
+    "rules": {
+      "exclude": [
+        "no-import-prefix"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This pull request updates the linting configuration in `deno.jsonc` to exclude the `no-import-prefix` rule, providing more flexibility in import statements.

Configuration changes:

* Updated the `lint` section to exclude the `no-import-prefix` rule, allowing import statements with prefixes that would otherwise be flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude specific import-related checks from code quality validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->