### PR TITLE
chore: pin shared configurations

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,8 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>Omochice/personal-renovate-config",
-    "github>Omochice/renovate-config:deno",
+    "github>Omochice/personal-renovate-config#v1.9.0",
+    "github>Omochice/renovate-config:deno#v4.0.1",
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
This pull request updates the configuration references in the `renovate.json5` file to point to specific versions of the shared Renovate configs. This ensures that builds use a known, stable configuration rather than always pulling the latest.

Configuration updates:

* Updated the `github>Omochice/personal-renovate-config` reference to use version `v1.9.0` instead of the default branch.
* Updated the `github>Omochice/renovate-config:deno` reference to use version `v4.0.1` instead of the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned external configuration dependencies to specific versions for improved stability and consistency in dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->