### PR TITLE
ci: run e2e tests against Redmine 5.1, 6.0, and 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        redmine-version: ["5.1", "6.0", "6.1"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -137,6 +141,8 @@ jobs:
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
       - name: Start Redmine
         run: docker compose -f e2e/docker-compose.yml up -d --wait
+        env:
+          REDMINE_VERSION: ${{ matrix.redmine-version }}
       - name: Setup Redmine
         id: setup-redmine
         run: |

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       retries: 10
 
   redmine:
-    image: redmine:6.1@sha256:0e05e8750ece1e22eb5ab3940503ffb489dd2dbc914ade15a37375f9e70cfc42
+    image: redmine:${REDMINE_VERSION:-5.1}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI e2e job now runs across multiple Redmine versions (5.1, 6.0, 6.1) with fail-fast disabled to collect full results.
  * End-to-end environment now uses a configurable Redmine version via REDMINE_VERSION (defaults to 5.1) for greater testing flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->