### PR TITLE
feat: add issue delete operation

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -4,6 +4,7 @@ import { listIssues } from "../result/issues/list.ts";
 import { show } from "../result/issues/show.ts";
 import { createIssue } from "../result/issues/create.ts";
 import { update } from "../result/issues/update.ts";
+import { deleteIssue } from "../result/issues/delete.ts";
 import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
@@ -75,6 +76,21 @@ Deno.test({
       const showResult = await show(e2eContext, issue.id);
       assert(showResult.isOk());
       assertEquals(showResult.value.subject, "E2E Updated Issue");
+    });
+
+    await t.step("DELETE /issues/:id.json should delete an issue", async () => {
+      const listResult = await listIssues(e2eContext, {});
+      assert(listResult.isOk());
+      const issue = listResult.value.find((i) =>
+        i.subject === "E2E Updated Issue"
+      );
+      assert(issue !== undefined);
+
+      const result = await deleteIssue(e2eContext, issue.id);
+      assert(result.isOk());
+
+      const showResult = await show(e2eContext, issue.id);
+      assert(showResult.isErr());
     });
   },
 });

--- a/jsr.json
+++ b/jsr.json
@@ -29,6 +29,7 @@
     "./result/issues/list": "./result/issues/list.ts",
     "./result/issues/show": "./result/issues/show.ts",
     "./result/issues/update": "./result/issues/update.ts",
+    "./result/issues/delete": "./result/issues/delete.ts",
     "./throwable": "./throwable/mod.ts",
     "./throwable/projects": "./throwable/projects/mod.ts",
     "./throwable/projects/archive": "./throwable/projects/archive.ts",
@@ -65,6 +66,7 @@
     "./throwable/issues/list": "./throwable/issues/list.ts",
     "./throwable/issues/show": "./throwable/issues/show.ts",
     "./throwable/issues/update": "./throwable/issues/update.ts",
+    "./throwable/issues/delete": "./throwable/issues/delete.ts",
     "./throwable/issues/validator": "./throwable/issues/validator.ts"
   },
   "publish": {

--- a/result/issues/_mock.ts
+++ b/result/issues/_mock.ts
@@ -120,6 +120,9 @@ export const validHandlers = [
   http.put(`${context.endpoint}/issues/:id.json`, () => {
     return HttpResponse.json({});
   }),
+  http.delete(`${context.endpoint}/issues/:id.json`, () => {
+    return HttpResponse.json({});
+  }),
 ];
 
 export const invalidHandlers = [
@@ -151,6 +154,21 @@ export const invalidHandlers = [
     });
   }),
   http.put(`${context.endpoint}/issues/404.json`, () => {
+    return HttpResponse.json({}, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.NotFound,
+    });
+  }),
+  http.delete(`${context.endpoint}/issues/422.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.delete(`${context.endpoint}/issues/404.json`, () => {
     return HttpResponse.json({}, {
       // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
       status: STATUS_CODE.NotFound,

--- a/result/issues/delete.test.ts
+++ b/result/issues/delete.test.ts
@@ -1,7 +1,7 @@
 import { deleteIssue } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.18";
+import { assert } from "jsr:@std/assert@1.0.19";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
-import { setupServer } from "npm:msw@2.12.10/node";
+import { setupServer } from "npm:msw@2.15.0/node";
 
 const server = setupServer();
 server.listen();

--- a/result/issues/delete.test.ts
+++ b/result/issues/delete.test.ts
@@ -1,0 +1,30 @@
+import { deleteIssue } from "./delete.ts";
+import { assert } from "jsr:@std/assert@1.0.18";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.12.10/node";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("DELETE /issues/:id.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.use(...validHandlers);
+    const e = await deleteIssue(context, 1);
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await deleteIssue(context, 422);
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await deleteIssue(context, 404);
+    assert(e.isErr());
+  });
+});

--- a/result/issues/delete.ts
+++ b/result/issues/delete.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { deleteIssue as deleteWithError } from "../../throwable/issues/delete.ts";
+import { convertError } from "../../error.ts";
+
+export const deleteIssue = ResultAsync.fromThrowable(
+  deleteWithError,
+  convertError("unknown error delete an issue"),
+);

--- a/result/issues/mod.ts
+++ b/result/issues/mod.ts
@@ -3,6 +3,7 @@ import { listIssues } from "./list.ts";
 import { show } from "./show.ts";
 import { update } from "./update.ts";
 import { createIssue } from "./create.ts";
+import { deleteIssue } from "./delete.ts";
 import type { Include } from "../../throwable/issues/show.ts";
 import type {
   CreateIssueQuery,
@@ -56,5 +57,14 @@ export class Client {
    */
   create(issue: CreateIssueQuery): ReturnType<typeof createIssue> {
     return createIssue(this.#context, issue);
+  }
+
+  /**
+   * Deletes the issue of given id.
+   *
+   * @param id The issue id
+   */
+  delete(id: number): ReturnType<typeof deleteIssue> {
+    return deleteIssue(this.#context, id);
   }
 }

--- a/throwable/issues/delete.ts
+++ b/throwable/issues/delete.ts
@@ -1,4 +1,4 @@
-import { join } from "jsr:@std/path@1.1.4/posix/join";
+import { join } from "jsr:@std/path@1.1.6/posix/join";
 import type { Context } from "../../context.ts";
 import { assertResponse } from "../../error.ts";
 

--- a/throwable/issues/delete.ts
+++ b/throwable/issues/delete.ts
@@ -1,0 +1,25 @@
+import { join } from "jsr:@std/path@1.1.4/posix/join";
+import type { Context } from "../../context.ts";
+import { assertResponse } from "../../error.ts";
+
+/**
+ * Delete the issue of given id.
+ *
+ * @param context REST endpoint context
+ * @param id The issue id
+ */
+export async function deleteIssue(
+  context: Context,
+  id: number,
+): Promise<void> {
+  const url = new URL(join(context.endpoint, "issues", `${id}.json`));
+  assertResponse(
+    await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+    }),
+  );
+}

--- a/throwable/issues/mod.ts
+++ b/throwable/issues/mod.ts
@@ -8,6 +8,7 @@ import { listIssues } from "./list.ts";
 import { type Include, show } from "./show.ts";
 import { update } from "./update.ts";
 import { createIssue } from "./create.ts";
+import { deleteIssue } from "./delete.ts";
 
 export class Client {
   readonly #context: Context;
@@ -55,5 +56,14 @@ export class Client {
    */
   create(issue: CreateIssueQuery): ReturnType<typeof createIssue> {
     return createIssue(this.#context, issue);
+  }
+
+  /**
+   * Deletes the issue of given id.
+   *
+   * @param id The issue id
+   */
+  delete(id: number): ReturnType<typeof deleteIssue> {
+    return deleteIssue(this.#context, id);
   }
 }


### PR DESCRIPTION
## Summary

Add a `delete` operation for issues to both the `throwable` and `result` clients.

## Details

The client could create, show, list, and update issues but had no way to delete one.

This adds `deleteIssue` following the existing pattern: a `throwable` implementation that issues a `DELETE /issues/:id.json` request and asserts the response, wrapped by a `neverthrow`-based `result` variant, exposed through both `Client` classes and the `jsr.json` exports.

## Confirmation

Ran the unit tests (`deno task test`) and confirmed `delete.test.ts` passes for success, error-object, and unexpected-format responses.

Ran the full e2e suite against a local Redmine 5.1 container and confirmed the new `DELETE /issues/:id.json` step deletes an issue and that a subsequent show returns an error.

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete issues through the client.
  - Issue deletion is available in both standard and throwable workflows.
  - Deletion requests now provide clear success or error results.

- **Tests**
  - Added coverage for successful deletion and common failure responses.
  - End-to-end tests now confirm deleted issues can no longer be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->