### PR TITLE
build: add git-hooks to flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -60,3 +60,6 @@ Temporary Items
 
 ## coverage
 coverage
+
+## git-hooks.nix generated symlink
+.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +31,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
@@ -58,6 +95,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
         "nur": "nur",
         "treefmt-nix": "treefmt-nix_2"

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nur = {
       url = "github:Omochice/nur-packages";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -20,6 +24,7 @@
       nixpkgs,
       treefmt-nix,
       flake-utils,
+      git-hooks,
       nur,
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -64,6 +69,38 @@
             # keep-sorted end
           }
         );
+        gitHooks = git-hooks.lib.${system}.run {
+          src = self;
+          default_stages = [
+            "pre-commit"
+            "pre-push"
+          ];
+          hooks = {
+            treefmt = {
+              enable = true;
+              packageOverrides.treefmt = treefmt.config.build.wrapper;
+              stages = [ "pre-commit" ];
+              # formatjson5 rewrites files unconditionally, updating their mtime
+              # even when the content is unchanged, which trips treefmt's
+              # mtime-based --fail-on-change. Let treefmt only format and rely on
+              # pre-commit's own content-based change detection to block commits.
+              settings.fail-on-change = false;
+            };
+            denolint = {
+              enable = true;
+              package = pkgs.deno;
+              stages = [ "pre-commit" ];
+            };
+            deno-check = {
+              enable = true;
+              name = "deno check";
+              entry = "${pkgs.deno}/bin/deno check ./**/*.ts";
+              files = "\\.ts$";
+              pass_filenames = false;
+              stages = [ "pre-push" ];
+            };
+          };
+        };
         runAs =
           name: runtimeInputs: text:
           let
@@ -112,9 +149,20 @@
         };
         checks = {
           formatting = treefmt.config.build.check self;
+          git-hooks = gitHooks;
         };
         devShells = pkgs.lib.pipe devPackages [
           (pkgs.lib.attrsets.mapAttrs (name: buildInputs: pkgs.mkShell { inherit buildInputs; }))
+          (
+            shells:
+            shells
+            // {
+              default = pkgs.mkShell {
+                buildInputs = devPackages.default ++ gitHooks.enabledPackages;
+                inherit (gitHooks) shellHook;
+              };
+            }
+          )
         ];
         formatter = treefmt.config.build.wrapper;
       }

--- a/flake.nix
+++ b/flake.nix
@@ -94,8 +94,10 @@
             deno-check = {
               enable = true;
               name = "deno check";
-              entry = "${pkgs.deno}/bin/deno check ./**/*.ts";
-              files = "\\.ts$";
+              # Reuse the deno.jsonc task so the glob is expanded by deno's task
+              # runner and stays aligned with CI. No files filter: type checking
+              # must run on every push, even when only non-TS files change.
+              entry = "${pkgs.lib.getExe pkgs.deno} task check";
               pass_filenames = false;
               stages = [ "pre-push" ];
             };


### PR DESCRIPTION
## Summary

Add pre-commit/pre-push git hooks to the nix flake via cachix/git-hooks.nix.

## Details

Formatting and lint issues were only caught in CI, so this wires treefmt and deno lint into pre-commit and deno type checking into pre-push, surfacing them locally.

treefmt's mtime-based `--fail-on-change` is disabled because formatjson5 rewrites files unconditionally and would false-trip it; pre-commit's own content-based change detection blocks commits instead.

## Confirmation

Ran `nix flake check` and built `checks.git-hooks` (denolint/treefmt Passed), and confirmed in the devShell that the pre-commit stage runs treefmt+deno lint and the pre-push stage runs deno check.

The pre-commit hook also ran live on this branch's commit and passed.

## Limitation

No known limitations.

Generated with: Claude

https://claude.ai/code/session_01Mea86L616D3qPpmJK7cj4K