### PR TITLE
fix: send camelCase issue update fields as snake_case

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -70,12 +70,22 @@ Deno.test({
 
       const result = await update(e2eContext, issue.id, {
         subject: "E2E Updated Issue",
+        doneRatio: 90,
+        isPrivate: true,
+        startDate: new Date("2026-07-01"),
       });
       assert(result.isOk());
 
       const showResult = await show(e2eContext, issue.id);
       assert(showResult.isOk());
       assertEquals(showResult.value.subject, "E2E Updated Issue");
+      assertEquals(showResult.value.doneRatio, 90);
+      assertEquals(showResult.value.isPrivate, true);
+      assert(showResult.value.startDate !== undefined);
+      assertEquals(
+        showResult.value.startDate?.toISOString().slice(0, 10),
+        "2026-07-01",
+      );
     });
 
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {

--- a/result/issues/update.test.ts
+++ b/result/issues/update.test.ts
@@ -69,4 +69,36 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
       assertEquals(issue.due_date, "2026-07-31");
     },
   );
+
+  await t.step(
+    "should keep custom field values in the request body",
+    async () => {
+      let capturedBody: { issue: Record<string, unknown> } | undefined;
+      server.resetHandlers(
+        http.put(
+          `${context.endpoint}/issues/:id.json`,
+          async ({ request }) => {
+            capturedBody = await request.json() as {
+              issue: Record<string, unknown>;
+            };
+            return HttpResponse.json({});
+          },
+        ),
+      );
+
+      const e = await update(context, 1, {
+        customFields: [
+          { id: 1, name: "text field", value: "hello" },
+          { id: 2, name: "list field", multiple: true, value: ["a", "b"] },
+        ],
+      });
+      assert(e.isOk());
+
+      assert(capturedBody !== undefined);
+      assertEquals(capturedBody.issue.custom_fields, [
+        { id: 1, value: "hello" },
+        { id: 2, value: ["a", "b"] },
+      ]);
+    },
+  );
 });

--- a/result/issues/update.test.ts
+++ b/result/issues/update.test.ts
@@ -1,7 +1,8 @@
 import { update } from "./update.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
+import { http, HttpResponse } from "npm:msw@2.15.0";
 
 const server = setupServer();
 server.listen();
@@ -27,4 +28,45 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
     const e = await update(context, 404, { notes: "sample" });
     assert(e.isErr());
   });
+
+  await t.step(
+    "should send camelCase fields as snake_case in the request body",
+    async () => {
+      let capturedBody: { issue: Record<string, unknown> } | undefined;
+      server.resetHandlers(
+        http.put(
+          `${context.endpoint}/issues/:id.json`,
+          async ({ request }) => {
+            capturedBody = await request.json() as {
+              issue: Record<string, unknown>;
+            };
+            return HttpResponse.json({});
+          },
+        ),
+      );
+
+      const e = await update(context, 1, {
+        subject: "updated subject",
+        notes: "a note",
+        privateNotes: true,
+        doneRatio: 90,
+        isPrivate: true,
+        estimatedHours: 8,
+        startDate: new Date("2026-07-01"),
+        dueDate: new Date("2026-07-31"),
+      });
+      assert(e.isOk());
+
+      assert(capturedBody !== undefined);
+      const { issue } = capturedBody;
+      assertEquals(issue.subject, "updated subject");
+      assertEquals(issue.notes, "a note");
+      assertEquals(issue.private_notes, true);
+      assertEquals(issue.done_ratio, 90);
+      assertEquals(issue.is_private, true);
+      assertEquals(issue.estimated_hours, 8);
+      assertEquals(issue.start_date, "2026-07-01");
+      assertEquals(issue.due_date, "2026-07-31");
+    },
+  );
 });

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -222,8 +222,12 @@ export const showIssueSchema = object({
   issue: showIssue,
 });
 
-// Redmine expects dates as YYYY-MM-DD strings; the UTC date part is used so
-// the serialized value matches the calendar day the Date instance represents.
+// Redmine expects dates as YYYY-MM-DD strings. The UTC date part is used
+// rather than the local calendar fields because dateLikeString parses
+// Redmine's date-only strings as UTC midnight, so only UTC keeps a
+// show() -> update() round-trip on the same calendar day. The trade-off:
+// a Date built from local calendar fields (e.g. new Date(2026, 6, 1) in
+// UTC+9) serializes to the previous day.
 const toRedmineDate = pipe(
   date(),
   transform((input: Date) => input.toISOString().slice(0, 10)),

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -1,6 +1,7 @@
 import {
   array,
   boolean,
+  date,
   literal,
   null_,
   number,
@@ -221,11 +222,27 @@ export const showIssueSchema = object({
   issue: showIssue,
 });
 
+// Redmine expects dates as YYYY-MM-DD strings; the UTC date part is used so
+// the serialized value matches the calendar day the Date instance represents.
+const toRedmineDate = pipe(
+  date(),
+  transform((input: Date) => input.toISOString().slice(0, 10)),
+);
+
+// The schema keys are camelCase to match the public UpdateIssueQuery input.
+// valibot's object() strips unknown keys, so a snake_case schema would drop
+// every camelCase-only field before objectToSnake could convert it.
 export const toUpdateRequest = pipe(
   partial(object({
-    ...issueSchema.entries,
+    subject: string(),
+    description: string(),
     notes: string(),
     privateNotes: boolean(),
+    doneRatio: number(),
+    isPrivate: boolean(),
+    estimatedHours: number(),
+    startDate: toRedmineDate,
+    dueDate: toRedmineDate,
   })),
   transform((input) => {
     return objectToSnake(input);

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -243,6 +243,10 @@ export const toUpdateRequest = pipe(
     estimatedHours: number(),
     startDate: toRedmineDate,
     dueDate: toRedmineDate,
+    customFields: array(object({
+      id: number(),
+      value: optional(union([string(), array(string())])),
+    })),
   })),
   transform((input) => {
     return objectToSnake(input);


### PR DESCRIPTION
## Summary

Send the multi-word issue update fields (`doneRatio`, `isPrivate`, `estimatedHours`, `startDate`, `dueDate`) to Redmine instead of silently dropping them.

## Details

`toUpdateRequest` was built from snake_case schema entries while the public `UpdateIssueQuery` type is camelCase, so valibot stripped every multi-word field and the PUT body became `{"issue":{}}` — the call reported success but nothing changed on the server.

The schema is now defined over the camelCase input keys and converted to snake_case, with `Date` values serialized as `YYYY-MM-DD`, because that is the only point where the public type and the wire format meet.

## Confirmation

A new unit test capturing the PUT body via msw failed on the previous implementation and passes now.

An e2e test against a real Redmine 5.1 confirmed `doneRatio` / `isPrivate` / `startDate` round-trip to the server, and `nix run .#check-deno` (CI parity) passes.

## Limitation

Object-typed fields (`assignedTo`, `category`, ...) are still dropped: Redmine expects `*_id` keys for them, which is an API design change left as follow-up.

Generated with: Claude

https://claude.ai/code/session_01Mea86L616D3qPpmJK7cj4K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue updates now support completion percentage, privacy status, start and due dates, notes, estimated hours, and custom fields.
  * Custom field values can be provided as text or multiple values.

* **Bug Fixes**
  * Date values are consistently formatted for issue update requests.
  * Updated issue details now correctly preserve and display the newly supported fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->