### PR TITLE
fix: preserve custom field values when creating an issue

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -60,6 +60,66 @@ Deno.test({
       assert(result.isOk());
     });
 
+    await t.step(
+      "POST /issues.json with a custom field value should persist it",
+      async () => {
+        // Look up the id instead of hardcoding it: the server has
+        // pre-existing data, and this custom field's id is an environment
+        // detail rather than something this test should assume.
+        const customFieldsResponse = await fetch(
+          `${e2eContext.endpoint}/custom_fields.json`,
+          { headers: { "X-Redmine-API-Key": e2eContext.apiKey } },
+        );
+        assert(customFieldsResponse.ok);
+        const customFieldsData = await customFieldsResponse.json() as {
+          custom_fields: { id: number; name: string }[];
+        };
+        const customField = customFieldsData.custom_fields.find(
+          (f) => f.name === "E2E CF",
+        );
+        assert(customField !== undefined);
+
+        const projectsResult = await fetchProjects(e2eContext);
+        assert(projectsResult.isOk());
+        const project = projectsResult.value.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        assert(project !== undefined);
+
+        const issuesBefore = await listIssues(e2eContext, {
+          projectId: project.id,
+        });
+        assert(issuesBefore.isOk());
+        assert(issuesBefore.value.length > 0);
+
+        const subject = "E2E Issue With Custom Field";
+        const result = await createIssue(e2eContext, {
+          projectId: project.id,
+          trackerId: issuesBefore.value[0].tracker.id,
+          statusId: issuesBefore.value[0].status.id,
+          priorityId: issuesBefore.value[0].priority.id,
+          subject,
+          customFields: [{ id: customField.id, value: "e2e custom value" }],
+        });
+        assert(result.isOk());
+
+        const listAfter = await listIssues(e2eContext, {
+          projectId: project.id,
+        });
+        assert(listAfter.isOk());
+        const created = listAfter.value.find((i) => i.subject === subject);
+        assert(created !== undefined);
+
+        const showResult = await show(e2eContext, created.id);
+        assert(showResult.isOk());
+        const persisted = showResult.value.customFields?.find(
+          (f) => f.id === customField.id,
+        );
+        assert(persisted !== undefined);
+        assertEquals(persisted.value, "e2e custom value");
+      },
+    );
+
     await t.step("PUT /issues/:id.json should update an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
       assert(listResult.isOk());

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -54,13 +54,18 @@ async function setupRedmine(): Promise<string> {
   // Single rails runner call that:
   // 1. Enables REST API
   // 2. Creates default tracker, status, and priority if missing
-  // 3. Creates API token for admin
-  // 4. Outputs the token with a prefix marker to distinguish from Rails logs
+  // 3. Creates an issue custom field usable by every tracker (needed by the
+  //    custom-field round-trip e2e test; find_or_create_by! keeps this safe
+  //    to run against an environment that already has it)
+  // 4. Creates API token for admin
+  // 5. Outputs the token with a prefix marker to distinguish from Rails logs
   const script = [
     'Setting.where(name: "rest_api_enabled").first_or_initialize.tap { |s| s.value = "1"; s.save! }',
     'Tracker.create!(name: "Bug", default_status: IssueStatus.first || IssueStatus.create!(name: "New")) if Tracker.count == 0',
     'IssueStatus.create!(name: "New") if IssueStatus.count == 0',
     'IssuePriority.create!(name: "Normal") if IssuePriority.count == 0',
+    'cf = IssueCustomField.find_or_create_by!(name: "E2E CF") { |f| f.field_format = "string"; f.is_for_all = true }',
+    "cf.update!(trackers: Tracker.all)",
     'user = User.find_by!(login: "admin")',
     'Token.where(user: user, action: "api").destroy_all',
     'token = Token.create!(user: user, action: "api")',

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -55,8 +55,10 @@ async function setupRedmine(): Promise<string> {
   // 1. Enables REST API
   // 2. Creates default tracker, status, and priority if missing
   // 3. Creates an issue custom field usable by every tracker (needed by the
-  //    custom-field round-trip e2e test; find_or_create_by! keeps this safe
-  //    to run against an environment that already has it)
+  //    custom-field round-trip e2e test). A pre-existing "E2E CF" with
+  //    drifted attributes is destroyed and recreated instead of updated in
+  //    place, because Redmine silently ignores field_format assignment on
+  //    persisted custom fields.
   // 4. Creates API token for admin
   // 5. Outputs the token with a prefix marker to distinguish from Rails logs
   const script = [
@@ -64,7 +66,9 @@ async function setupRedmine(): Promise<string> {
     'Tracker.create!(name: "Bug", default_status: IssueStatus.first || IssueStatus.create!(name: "New")) if Tracker.count == 0',
     'IssueStatus.create!(name: "New") if IssueStatus.count == 0',
     'IssuePriority.create!(name: "Normal") if IssuePriority.count == 0',
-    'cf = IssueCustomField.find_or_create_by!(name: "E2E CF") { |f| f.field_format = "string"; f.is_for_all = true }',
+    'cf = IssueCustomField.find_by(name: "E2E CF")',
+    '(cf.destroy; cf = nil) if cf && (cf.field_format != "string" || !cf.is_for_all)',
+    'cf ||= IssueCustomField.create!(name: "E2E CF", field_format: "string", is_for_all: true)',
     "cf.update!(trackers: Tracker.all)",
     'user = User.find_by!(login: "admin")',
     'Token.where(user: user, action: "api").destroy_all',

--- a/result/issues/create.test.ts
+++ b/result/issues/create.test.ts
@@ -1,0 +1,70 @@
+import { createIssue } from "./create.ts";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { context } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("POST /issues.json", async (t) => {
+  await t.step(
+    "should keep custom field id and single string value in the request body",
+    async () => {
+      let capturedBody: { issue: Record<string, unknown> } | undefined;
+      server.resetHandlers(
+        http.post(`${context.endpoint}/issues.json`, async ({ request }) => {
+          capturedBody = await request.json() as {
+            issue: Record<string, unknown>;
+          };
+          return HttpResponse.json({});
+        }),
+      );
+
+      const e = await createIssue(context, {
+        projectId: 1,
+        trackerId: 1,
+        statusId: 1,
+        priorityId: 1,
+        subject: "sample",
+        customFields: [{ id: 1, value: "hello" }],
+      });
+      assert(e.isOk());
+
+      assert(capturedBody !== undefined);
+      assertEquals(capturedBody.issue.custom_fields, [
+        { id: 1, value: "hello" },
+      ]);
+    },
+  );
+
+  await t.step(
+    "should keep custom field id and multi-value string array in the request body",
+    async () => {
+      let capturedBody: { issue: Record<string, unknown> } | undefined;
+      server.resetHandlers(
+        http.post(`${context.endpoint}/issues.json`, async ({ request }) => {
+          capturedBody = await request.json() as {
+            issue: Record<string, unknown>;
+          };
+          return HttpResponse.json({});
+        }),
+      );
+
+      const e = await createIssue(context, {
+        projectId: 1,
+        trackerId: 1,
+        statusId: 1,
+        priorityId: 1,
+        subject: "sample",
+        customFields: [{ id: 2, value: ["a", "b"] }],
+      });
+      assert(e.isOk());
+
+      assert(capturedBody !== undefined);
+      assertEquals(capturedBody.issue.custom_fields, [
+        { id: 2, value: ["a", "b"] },
+      ]);
+    },
+  );
+});

--- a/throwable/issues/create.ts
+++ b/throwable/issues/create.ts
@@ -15,7 +15,7 @@ export async function createIssue(
   context: Context,
   issue: CreateIssueQuery,
 ): Promise<void> {
-  const url = join(context.endpoint, "issues.json");
+  const url = new URL(join(context.endpoint, "issues.json"));
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/throwable/issues/type.ts
+++ b/throwable/issues/type.ts
@@ -97,6 +97,14 @@ export type UpdateOption = {
 
 export type UpdateIssueQuery = Partial<Issue & UpdateOption>;
 
+// Redmine accepts a single string for single-value custom fields and a
+// string array for multi-value ones; both are set through the same "value"
+// key on create, unlike the read-side CustomField which also carries "name".
+export type CustomFieldInput = {
+  id: number;
+  value: string | string[];
+};
+
 export type CreateIssueQuery = {
   projectId: number;
   trackerId: number;
@@ -111,7 +119,7 @@ export type CreateIssueQuery = {
   watcherUserIds?: number[];
   isPrivate?: boolean;
   estimatedHours?: number;
-  customFields?: Record<string, unknown>[];
+  customFields?: CustomFieldInput[];
 };
 
 export type ListIssueQuery = {

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -257,6 +257,14 @@ export const toUpdateRequest = pipe(
   }),
 );
 
+// object({}) has no entries, so valibot strips every key from each element
+// (see the bug this schema fixes: id/value were silently dropped, sending
+// custom_fields: [{}] to Redmine). List the fields explicitly instead.
+const createCustomField = object({
+  id: number(),
+  value: union([string(), array(string())]),
+});
+
 export const toCreateRequest = pipe(
   object({
     projectId: number(),
@@ -272,7 +280,7 @@ export const toCreateRequest = pipe(
     watcherUserIds: optional(array(number())),
     isPrivate: optional(boolean()),
     estimatedHours: optional(number()),
-    customFields: optional(array(object({}))),
+    customFields: optional(array(createCustomField)),
   }),
   transform((input: CreateIssueQuery) => {
     return { issue: objectToSnake(input) };


### PR DESCRIPTION
## Summary

Preserve custom field `id` and `value` in the request body when creating an issue.

## Details

The `customFields` schema was `optional(array(object({})))`, and an empty valibot object schema strips every key, so `createIssue()` sent `custom_fields: [{}]` and the values were silently lost.

It is replaced with an explicit `{ id, value }` schema accepting a single string or a string array (Redmine's multi-value format), and the public type is tightened from `Record<string, unknown>[]` to `CustomFieldInput[]` so the accepted shape is visible at compile time.

`create.ts` now also builds its URL with `new URL(join(...))` like every sibling module, because the raw joined string (`http:/host/...`) is not matched by msw's interceptor under the flake-pinned Deno.

## Confirmation

New unit tests capturing the POST body failed before the fix (`custom_fields: [{}]`) and pass now.

An e2e test against a real Redmine 5.1 confirmed a created issue carries the custom field value, using a custom field newly seeded by `e2e/setup.ts`, and `nix run .#check-deno` (CI parity) passes.

## Limitation

No known limitations.

Generated with: Claude

https://claude.ai/code/session_01Mea86L616D3qPpmJK7cj4K