### PR TITLE
fix: serialize project attributes to snake_case on create and update

### DIFF
--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -69,14 +69,17 @@ Deno.test({
         });
         assert(createResult.isOk());
 
-        const listResult = await fetchList(e2eContext);
-        assert(listResult.isOk());
-        const created = listResult.value.find((p) =>
-          p.identifier === identifier
-        );
-        assert(created !== undefined);
-
+        // Cleanup wraps everything after the create succeeds, and re-resolves
+        // the project by identifier itself: reusing an id resolved inside the
+        // try block would skip deletion when the lookup is what failed.
         try {
+          const listResult = await fetchList(e2eContext);
+          assert(listResult.isOk());
+          const created = listResult.value.find((p) =>
+            p.identifier === identifier
+          );
+          assert(created !== undefined);
+
           const createdShow = await show(e2eContext, created.id);
           assert(createdShow.isOk());
           assertEquals(
@@ -98,7 +101,15 @@ Deno.test({
             "update must flip is_public on the server",
           );
         } finally {
-          await deleteProject(e2eContext, created.id);
+          const cleanupList = await fetchList(e2eContext);
+          if (cleanupList.isOk()) {
+            const leftover = cleanupList.value.find((p) =>
+              p.identifier === identifier
+            );
+            if (leftover !== undefined) {
+              await deleteProject(e2eContext, leftover.id);
+            }
+          }
         }
       },
     );

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -69,9 +69,9 @@ Deno.test({
         });
         assert(createResult.isOk());
 
-        // Cleanup wraps everything after the create succeeds, and re-resolves
-        // the project by identifier itself: reusing an id resolved inside the
-        // try block would skip deletion when the lookup is what failed.
+        // Cleanup re-resolves the project by identifier instead of reusing
+        // an id from the try block: that id is unavailable exactly when the
+        // lookup is the step that failed.
         try {
           const listResult = await fetchList(e2eContext);
           assert(listResult.isOk());

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -59,6 +59,51 @@ Deno.test({
     });
 
     await t.step(
+      "snake_case attributes reach the server on create and update",
+      async () => {
+        const identifier = `e2e-serialization-${Date.now()}`;
+        const createResult = await create(e2eContext, {
+          name: "E2E Serialization Project",
+          identifier,
+          isPublic: false,
+        });
+        assert(createResult.isOk());
+
+        const listResult = await fetchList(e2eContext);
+        assert(listResult.isOk());
+        const created = listResult.value.find((p) =>
+          p.identifier === identifier
+        );
+        assert(created !== undefined);
+
+        try {
+          const createdShow = await show(e2eContext, created.id);
+          assert(createdShow.isOk());
+          assertEquals(
+            createdShow.value.isPublic,
+            false,
+            "isPublic:false must be stored as private on the server",
+          );
+
+          const updateResult = await update(e2eContext, created.id, {
+            isPublic: true,
+          });
+          assert(updateResult.isOk());
+
+          const updatedShow = await show(e2eContext, created.id);
+          assert(updatedShow.isOk());
+          assertEquals(
+            updatedShow.value.isPublic,
+            true,
+            "update must flip is_public on the server",
+          );
+        } finally {
+          await deleteProject(e2eContext, created.id);
+        }
+      },
+    );
+
+    await t.step(
       "PUT /projects/:id/archive.json should archive and unarchive",
       async () => {
         const listResult = await fetchList(e2eContext);

--- a/result/projects/create.test.ts
+++ b/result/projects/create.test.ts
@@ -1,6 +1,7 @@
 import { create } from "./create.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
 
 const server = setupServer();
@@ -35,4 +36,49 @@ Deno.test("POST /projects.json", async (t) => {
     const e = await create(c, { name: "sample", identifier: "sample" });
     assert(e.isErr());
   });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.use(
+        http.post(`${context.endpoint}/projects.json`, async ({ request }) => {
+          const body = await request.json() as { project: typeof captured };
+          captured = body.project;
+          return HttpResponse.json({});
+        }),
+      );
+      const e = await create(context, {
+        name: "sample",
+        identifier: "sample",
+        isPublic: false,
+        parentId: 42,
+        inheritMembers: true,
+      });
+      assert(e.isOk());
+      assertEquals(captured?.is_public, false);
+      assertEquals(captured?.parent_id, 42);
+      assertEquals(captured?.inherit_members, true);
+    },
+  );
+
+  await t.step(
+    "should accept a name containing spaces",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.use(
+        http.post(`${context.endpoint}/projects.json`, async ({ request }) => {
+          const body = await request.json() as { project: typeof captured };
+          captured = body.project;
+          return HttpResponse.json({});
+        }),
+      );
+      const e = await create(context, {
+        name: "My Project",
+        identifier: "my-project",
+      });
+      assert(e.isOk());
+      assertEquals(captured?.name, "My Project");
+    },
+  );
 });

--- a/result/projects/create.test.ts
+++ b/result/projects/create.test.ts
@@ -54,11 +54,13 @@ Deno.test("POST /projects.json", async (t) => {
         isPublic: false,
         parentId: 42,
         inheritMembers: true,
+        trackerIds: [1, 2],
       });
       assert(e.isOk());
       assertEquals(captured?.is_public, false);
       assertEquals(captured?.parent_id, 42);
       assertEquals(captured?.inherit_members, true);
+      assertEquals(captured?.tracker_ids, [1, 2]);
     },
   );
 

--- a/result/projects/update.test.ts
+++ b/result/projects/update.test.ts
@@ -1,7 +1,8 @@
 import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
 
 const server = setupServer();
 server.listen();
@@ -27,4 +28,24 @@ Deno.test("PUT /projects/:id.json", async (t) => {
     const e = await update(context, 404, { name: "sample" });
     assert(e.isErr());
   });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.use(
+        http.put(
+          `${context.endpoint}/projects/:id.json`,
+          async ({ request }) => {
+            const body = await request.json() as { project: typeof captured };
+            captured = body.project;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await update(context, 1, { isPublic: false });
+      assert(e.isOk());
+      assertEquals(captured?.is_public, false);
+    },
+  );
 });

--- a/throwable/projects/create.ts
+++ b/throwable/projects/create.ts
@@ -1,6 +1,8 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
 import { join } from "jsr:@std/path@1.1.6/posix/join";
 import type { Context } from "../../context.ts";
 import type { ProjectQuery } from "./type.ts";
+import { toProjectQuery } from "./validator.ts";
 import { assertResponse } from "../../error.ts";
 
 export async function create(
@@ -15,7 +17,7 @@ export async function create(
         "Content-Type": "application/json",
         "X-Redmine-API-Key": context.apiKey,
       },
-      body: JSON.stringify({ project }),
+      body: JSON.stringify({ project: parse(toProjectQuery, project) }),
     }),
   );
 }

--- a/throwable/projects/type.ts
+++ b/throwable/projects/type.ts
@@ -27,7 +27,7 @@ export type ProjectQuery = {
   inheritMembers?: boolean;
   defaultAssignedToId?: number;
   defaultVersionId?: string;
-  trackerids?: number[];
+  trackerIds?: number[];
   enableModuleNames?: string[];
   issueCustomFieldIds?: string[];
   customFieldValues?: Record<string, unknown>;

--- a/throwable/projects/update.ts
+++ b/throwable/projects/update.ts
@@ -1,6 +1,8 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
 import { join } from "jsr:@std/path@1.1.6/posix/join";
 import type { Context } from "../../context.ts";
 import type { ProjectQuery } from "./type.ts";
+import { toProjectUpdateQuery } from "./validator.ts";
 import { assertResponse } from "../../error.ts";
 
 export type ProjectUpdateInformation = Partial<
@@ -19,7 +21,7 @@ export async function update(
       "Content-Type": "application/json",
       "X-Redmine-API-Key": context.apiKey,
     },
-    body: JSON.stringify({ project }),
+    body: JSON.stringify({ project: parse(toProjectUpdateQuery, project) }),
   });
   assertResponse(response);
 }

--- a/throwable/projects/validator.ts
+++ b/throwable/projects/validator.ts
@@ -4,10 +4,11 @@ import {
   nullish,
   number,
   object,
+  omit,
   optional,
+  partial,
   pipe,
   record,
-  regex,
   string,
   transform,
   unknown,
@@ -42,27 +43,32 @@ export const projectSchema = pipe(
   }),
 );
 
+const projectQuerySchema = object({
+  name: string(),
+  identifier: string(),
+  description: optional(string()),
+  homepage: optional(string()),
+  isPublic: optional(boolean()),
+  parentId: optional(number()),
+  inheritMembers: optional(boolean()),
+  defaultAssignedToId: optional(number()),
+  defaultVersionId: optional(string()),
+  trackerIds: optional(array(number())),
+  enableModuleNames: optional(array(string())),
+  issueCustomFieldIds: optional(array(string())),
+  customFieldValues: optional(record(string(), unknown())),
+});
+
 export const toProjectQuery = pipe(
-  object({
-    name: pipe(
-      string(),
-      /** need match /^[a-zA-Z0-9\-_]{1,100}$/ */
-      regex(/^[a-zA-Z0-9\-_]{1,100}$/),
-    ),
-    identifier: string(),
-    description: optional(string()),
-    homepage: optional(string()),
-    isPublic: optional(boolean()),
-    parentId: optional(number()),
-    inheritMembers: optional(boolean()),
-    defaultAssignedToId: optional(number()),
-    defaultVersionId: optional(string()),
-    trackerIds: optional(array(number())),
-    enableModuleNames: optional(array(string())),
-    issueCustomFieldIds: optional(array(string())),
-    customFieldValues: optional(record(string(), unknown())),
-  }),
+  projectQuerySchema,
   transform((input: ProjectQuery) => {
+    return objectToSnake(input);
+  }),
+);
+
+export const toProjectUpdateQuery = pipe(
+  partial(omit(projectQuerySchema, ["identifier"])),
+  transform((input) => {
     return objectToSnake(input);
   }),
 );


### PR DESCRIPTION
## Summary

Send project attributes (`isPublic`, `parentId`, `inheritMembers`, ...) in the snake_case form Redmine expects on create and update.

## Details

The converter `toProjectQuery` existed but had zero call sites, so `create` and `update` sent raw camelCase JSON that Redmine silently ignored — `create({ isPublic: false })` produced a public project.

The converter is now wired into `create`, a partial variant (`partial(omit(..., ["identifier"]))`) built from a shared schema serves `update`, and the `^[a-zA-Z0-9\-_]{1,100}$` constraint on `name` is removed because Redmine allows spaces in project names and validates `identifier` server-side.

## Confirmation

New unit tests capturing the request bodies failed before the fix and pass now, including a name containing spaces.

An e2e test against a real Redmine 5.1 confirmed `isPublic: false` creates a private project and `update` flips the flag server-side, and `nix run .#check-deno` (CI parity) passes.

## Limitation

Attributes other than those covered by the tests (`isPublic`, `parentId`, `inheritMembers`, `name`) were not individually verified against a real server.

Generated with: Claude

https://claude.ai/code/session_01Mea86L616D3qPpmJK7cj4K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project creation and updates now correctly serialize attributes, including privacy, parent, and member inheritance settings.
  - Project names containing spaces are supported.

- **Bug Fixes**
  - Improved validation and request formatting for project creation and updates.
  - Updates now support partial changes while preserving correct API field naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->