### PR TITLE
fix: honor the limit option in listIssues

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -167,19 +167,38 @@ Deno.test({
         // Ensure at least two issues exist on the server so that a
         // `limit: 1` result can only be explained by the limit being
         // honored, not by there happening to be a single issue.
+        const subject = "E2E Limit Test Issue";
         const created = await createIssue(e2eContext, {
           projectId: project.id,
           trackerId: issuesInProject.value[0].tracker.id,
           statusId: issuesInProject.value[0].status.id,
           priorityId: issuesInProject.value[0].priority.id,
-          subject: "E2E Limit Test Issue",
+          subject,
           description: "Created by E2E test to exercise listIssues limit",
         });
         assert(created.isOk());
 
-        const result = await listIssues(e2eContext, { limit: 1 });
-        assert(result.isOk());
-        assertEquals(result.value.length, 1);
+        // Cleanup looks the issue up by subject because createIssue does
+        // not return the created id.
+        try {
+          const result = await listIssues(e2eContext, { limit: 1 });
+          assert(result.isOk());
+          assertEquals(result.value.length, 1);
+        } finally {
+          const cleanupList = await listIssues(e2eContext, {
+            projectId: project.id,
+          });
+          if (cleanupList.isOk()) {
+            // Delete every match, not just one: runs that predate this
+            // cleanup left issues with the same subject behind.
+            const leftovers = cleanupList.value.filter((i) =>
+              i.subject === subject
+            );
+            for (const leftover of leftovers) {
+              await deleteIssue(e2eContext, leftover.id);
+            }
+          }
+        }
       },
     );
 

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -188,15 +188,15 @@ Deno.test({
           const cleanupList = await listIssues(e2eContext, {
             projectId: project.id,
           });
-          if (cleanupList.isOk()) {
-            // Delete every match, not just one: runs that predate this
-            // cleanup left issues with the same subject behind.
-            const leftovers = cleanupList.value.filter((i) =>
-              i.subject === subject
-            );
-            for (const leftover of leftovers) {
-              await deleteIssue(e2eContext, leftover.id);
-            }
+          assert(cleanupList.isOk(), "cleanup listing must succeed");
+          // Delete every match, not just one: runs that predate this
+          // cleanup left issues with the same subject behind.
+          const leftovers = cleanupList.value.filter((i) =>
+            i.subject === subject
+          );
+          for (const leftover of leftovers) {
+            const deleted = await deleteIssue(e2eContext, leftover.id);
+            assert(deleted.isOk(), `cleanup must delete issue ${leftover.id}`);
           }
         }
       },

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -148,6 +148,41 @@ Deno.test({
       );
     });
 
+    await t.step(
+      "GET /issues.json with limit: 1 should return exactly one issue",
+      async () => {
+        const projectsResult = await fetchProjects(e2eContext);
+        assert(projectsResult.isOk());
+        const project = projectsResult.value.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        assert(project !== undefined);
+
+        const issuesInProject = await listIssues(e2eContext, {
+          projectId: project.id,
+        });
+        assert(issuesInProject.isOk());
+        assert(issuesInProject.value.length > 0);
+
+        // Ensure at least two issues exist on the server so that a
+        // `limit: 1` result can only be explained by the limit being
+        // honored, not by there happening to be a single issue.
+        const created = await createIssue(e2eContext, {
+          projectId: project.id,
+          trackerId: issuesInProject.value[0].tracker.id,
+          statusId: issuesInProject.value[0].status.id,
+          priorityId: issuesInProject.value[0].priority.id,
+          subject: "E2E Limit Test Issue",
+          description: "Created by E2E test to exercise listIssues limit",
+        });
+        assert(created.isOk());
+
+        const result = await listIssues(e2eContext, { limit: 1 });
+        assert(result.isOk());
+        assertEquals(result.value.length, 1);
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
       assert(listResult.isOk());

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -155,4 +155,17 @@ Deno.test("listIssues limit option", async (t) => {
       assertEquals(requests.length, 0);
     },
   );
+
+  await t.step(
+    "rejects a zero limit without requesting the server",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(5, requests));
+
+      const e = await listIssues(context, { limit: 0 });
+
+      assert(e.isErr());
+      assertEquals(requests.length, 0);
+    },
+  );
 });

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -129,4 +129,30 @@ Deno.test("listIssues limit option", async (t) => {
       ]);
     },
   );
+
+  await t.step(
+    "rejects a non-integer limit without requesting the server",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(5, requests));
+
+      const e = await listIssues(context, { limit: 1.5 });
+
+      assert(e.isErr());
+      assertEquals(requests.length, 0);
+    },
+  );
+
+  await t.step(
+    "rejects a limit below one without requesting the server",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(5, requests));
+
+      const e = await listIssues(context, { limit: -1 });
+
+      assert(e.isErr());
+      assertEquals(requests.length, 0);
+    },
+  );
 });

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -25,8 +25,7 @@ Deno.test("GET /projects/issues.json", async (t) => {
   );
 });
 
-// deno-lint-ignore no-explicit-any
-function sampleIssue(id: number): any {
+function sampleIssue(id: number): Record<string, unknown> {
   return {
     id,
     project: { id: 1, name: "hi" },

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -1,7 +1,8 @@
 import { listIssues } from "./list.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
 
 const server = setupServer();
@@ -20,6 +21,114 @@ Deno.test("GET /projects/issues.json", async (t) => {
       server.resetHandlers(...invalidHandlers);
       const e = await listIssues(context);
       assert(e.isErr());
+    },
+  );
+});
+
+// deno-lint-ignore no-explicit-any
+function sampleIssue(id: number): any {
+  return {
+    id,
+    project: { id: 1, name: "hi" },
+    tracker: { id: 1, name: "issue" },
+    status: { id: 1, name: "open", is_closed: false },
+    priority: { id: 1, name: "normal" },
+    author: { id: 1, name: "sample user" },
+    assigned_to: undefined,
+    category: undefined,
+    subject: `issue-${id}`,
+    description: "",
+    start_date: "2023-10-09T00:00:00Z",
+    due_date: null,
+    done_ratio: 0,
+    is_private: false,
+    estimated_hours: null,
+    total_estimated_hours: 0,
+    spent_hours: 0,
+    total_spent_hours: 0,
+    created_on: "2023-10-09T12:17:17Z",
+    updated_on: "2023-10-09T12:17:17Z",
+    closed_on: null,
+    custom_fields: undefined,
+  };
+}
+
+type RecordedRequest = { limit: string | null; offset: string | null };
+
+function pagingHandler(
+  totalAvailable: number,
+  requests: RecordedRequest[],
+) {
+  const allIssues = Array.from(
+    { length: totalAvailable },
+    (_, i) => sampleIssue(i + 1),
+  );
+  return http.get(`${context.endpoint}/issues.json`, ({ request }) => {
+    const url = new URL(request.url);
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
+    requests.push({ limit: limitParam, offset: offsetParam });
+    const limit = Number(limitParam);
+    const offset = Number(offsetParam);
+    const page = allIssues.slice(offset, offset + limit);
+    return HttpResponse.json({
+      issues: page,
+      total_count: allIssues.length,
+      offset,
+      limit,
+    });
+  });
+}
+
+Deno.test("listIssues limit option", async (t) => {
+  await t.step(
+    "returns at most `limit` issues with a single page request when limit <= page size",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(5, requests));
+
+      const e = await listIssues(context, { limit: 1 });
+
+      assert(e.isOk());
+      assertEquals(e.value.length, 1);
+      assertEquals(requests.length, 1);
+      assertEquals(requests[0], { limit: "1", offset: "0" });
+    },
+  );
+
+  await t.step(
+    "fetches only as many pages as needed to satisfy a limit spanning multiple pages",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(300, requests));
+
+      const e = await listIssues(context, { limit: 150 });
+
+      assert(e.isOk());
+      assertEquals(e.value.length, 150);
+      assertEquals(requests, [
+        { limit: "100", offset: "0" },
+        { limit: "50", offset: "100" },
+      ]);
+    },
+  );
+
+  await t.step(
+    "without a limit, still paginates over the full total and returns every issue",
+    async () => {
+      const requests: RecordedRequest[] = [];
+      server.resetHandlers(pagingHandler(150, requests));
+
+      const e = await listIssues(context, {});
+
+      assert(e.isOk());
+      assertEquals(e.value.length, 150);
+      // one count request (limit=1) followed by two full pages (limit=100 each)
+      assertEquals(requests, [
+        { limit: "1", offset: "0" },
+        { limit: "100", offset: "0" },
+        { limit: "100", offset: "100" },
+      ]);
     },
   );
 });

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -123,7 +123,6 @@ Deno.test("listIssues limit option", async (t) => {
 
       assert(e.isOk());
       assertEquals(e.value.length, 150);
-      // one count request (limit=1) followed by two full pages (limit=100 each)
       assertEquals(requests, [
         { limit: "1", offset: "0" },
         { limit: "100", offset: "0" },

--- a/throwable/issues/list.ts
+++ b/throwable/issues/list.ts
@@ -5,11 +5,12 @@ import type { Issue, ListIssueQuery } from "./type.ts";
 import { assertResponse } from "../../error.ts";
 import { listResponse, toListOption } from "./validator.ts";
 
+const pageSize = 100;
+
 export async function listIssues(
   context: Context,
   option: Partial<ListIssueQuery> = {},
 ): Promise<Issue[]> {
-  const limit = 100;
   const opts: RequestInit = {
     method: "GET",
     headers: {
@@ -18,9 +19,8 @@ export async function listIssues(
     },
   };
   const convertedOption = parse(toListOption, option);
-  const n = await fetchNumberOfIssues(context, option);
-  const results: Response[] = [];
-  for (let offset = 0; offset < n; offset += limit) {
+
+  const fetchPage = async (limit: number, offset: number): Promise<Issue[]> => {
     const endpoint = new URL(join(context.endpoint, "issues.json"));
     endpoint.search = new URLSearchParams({
       limit: `${limit}`,
@@ -29,13 +29,34 @@ export async function listIssues(
     }).toString();
     const response = await fetch(endpoint, opts);
     assertResponse(response);
-    results.push(response);
-  }
-  const issues: Issue[] = [];
-  for (const response of results) {
     const json = await response.json();
-    const parsed = parse(listResponse, json);
-    issues.push(...parsed.issues);
+    return parse(listResponse, json).issues;
+  };
+
+  // When a limit is requested, the caller does not care about the server's
+  // total_count, so the extra count request that the unbounded path needs
+  // (to know how many pages to walk) is unnecessary and would over-fetch.
+  if (option.limit !== undefined) {
+    const limit = option.limit;
+    const issues: Issue[] = [];
+    let offset = 0;
+    while (issues.length < limit) {
+      const fetchSize = Math.min(pageSize, limit - issues.length);
+      const page = await fetchPage(fetchSize, offset);
+      issues.push(...page);
+      offset += fetchSize;
+      if (page.length < fetchSize) {
+        // Server ran out of issues before reaching the requested limit.
+        break;
+      }
+    }
+    return issues.slice(0, limit);
+  }
+
+  const n = await fetchNumberOfIssues(context, option);
+  const issues: Issue[] = [];
+  for (let offset = 0; offset < n; offset += pageSize) {
+    issues.push(...await fetchPage(pageSize, offset));
   }
   return issues;
 }

--- a/throwable/issues/list.ts
+++ b/throwable/issues/list.ts
@@ -39,12 +39,10 @@ export async function listIssues(
   if (option.limit !== undefined) {
     const limit = option.limit;
     const issues: Issue[] = [];
-    let offset = 0;
     while (issues.length < limit) {
       const fetchSize = Math.min(pageSize, limit - issues.length);
-      const page = await fetchPage(fetchSize, offset);
+      const page = await fetchPage(fetchSize, issues.length);
       issues.push(...page);
-      offset += fetchSize;
       if (page.length < fetchSize) {
         break;
       }

--- a/throwable/issues/list.ts
+++ b/throwable/issues/list.ts
@@ -46,7 +46,6 @@ export async function listIssues(
       issues.push(...page);
       offset += fetchSize;
       if (page.length < fetchSize) {
-        // Server ran out of issues before reaching the requested limit.
         break;
       }
     }

--- a/throwable/issues/validator.ts
+++ b/throwable/issues/validator.ts
@@ -2,7 +2,9 @@ import {
   array,
   boolean,
   date,
+  integer,
   literal,
+  minValue,
   null_,
   number,
   object,
@@ -301,7 +303,7 @@ export const listResponse = pipe(
 
 const listIssueQuery = partial(
   object({
-    limit: number(),
+    limit: pipe(number(), integer(), minValue(1)),
     include: picklist(["attachment", "relations"]),
     issueId: union([array(number()), number()]),
     projectId: number(),


### PR DESCRIPTION
## Summary

`listIssues` now returns at most `limit` issues instead of always fetching every issue.

## Details

`limit` was stripped from the outgoing query and the pagination loop always walked the server's full `total_count` with a hardcoded page size of 100, so `listIssues(ctx, { limit: 1 })` returned everything.

When `limit` is given, the extra `total_count` request is skipped and only the pages needed to satisfy the limit are fetched, because the caller does not need the total in that case; the no-limit path is unchanged.

## Confirmation

New unit tests counting the actual requests failed before the fix and pass now, covering a single-page limit, a limit spanning two pages, and the unlimited regression case.

An e2e test against a real Redmine 5.1 confirmed `listIssues({ limit: 1 })` returns exactly one issue, and `nix run .#check-deno` (CI parity) passes.

## Limitation

No known limitations.

Generated with: Claude

https://claude.ai/code/session_01Mea86L616D3qPpmJK7cj4K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for limiting issue list results to a specified number of items.
  * Issue listing now retrieves only the pages needed to satisfy the requested limit.
  * Unbounded requests continue to retrieve the complete issue set.

* **Bug Fixes**
  * Invalid limits, including decimals, zero, and negative values, are now rejected with validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->