### PR TITLE
feat: implement version resources

### DIFF
--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -1,0 +1,104 @@
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { e2eContext } from "./context.ts";
+import { fetchList } from "../result/versions/list.ts";
+import { show } from "../result/versions/show.ts";
+import { create } from "../result/versions/create.ts";
+import { update } from "../result/versions/update.ts";
+import { deleteVersion } from "../result/versions/delete.ts";
+import { fetchList as fetchProjects } from "../result/projects/list.ts";
+
+Deno.test({
+  name: "E2E: Versions API",
+  // Library functions may not fully consume fetch response bodies, triggering
+  // Deno's resource sanitizer as a false positive.
+  sanitizeResources: false,
+  fn: async (t) => {
+    const projectsResult = await fetchProjects(e2eContext);
+    assert(projectsResult.isOk());
+    const project = projectsResult.value.find((p) =>
+      p.identifier === "e2e-test-project"
+    );
+    assert(project !== undefined);
+
+    await t.step(
+      "POST /projects/:project_id/versions.json should create a version",
+      async () => {
+        const result = await create(e2eContext, project.id, {
+          name: "E2E Created Version",
+          status: "open",
+          sharing: "none",
+          description: "Created by E2E test",
+          dueDate: "2026-08-01",
+        });
+        assert(result.isOk());
+      },
+    );
+
+    await t.step(
+      "GET /projects/:project_id/versions.json should return versions",
+      async () => {
+        const result = await fetchList(e2eContext, project.id);
+        assert(result.isOk());
+        assert(result.value.length > 0);
+        const created = result.value.find((v) =>
+          v.name === "E2E Created Version"
+        );
+        assert(created !== undefined);
+      },
+    );
+
+    await t.step("GET /versions/:id.json should return a version", async () => {
+      const listResult = await fetchList(e2eContext, project.id);
+      assert(listResult.isOk());
+      const version = listResult.value.find((v) =>
+        v.name === "E2E Created Version"
+      );
+      assert(version !== undefined);
+
+      const result = await show(e2eContext, version.id);
+      assert(result.isOk());
+      assertEquals(result.value.id, version.id);
+      assertEquals(result.value.name, "E2E Created Version");
+      assert(result.value.project !== undefined);
+      assertEquals(result.value.status, "open");
+    });
+
+    await t.step("PUT /versions/:id.json should update a version", async () => {
+      const listResult = await fetchList(e2eContext, project.id);
+      assert(listResult.isOk());
+      const version = listResult.value.find((v) =>
+        v.name === "E2E Created Version"
+      );
+      assert(version !== undefined);
+
+      const result = await update(e2eContext, version.id, {
+        name: "E2E Updated Version",
+        status: "locked",
+      });
+      assert(result.isOk());
+
+      const showResult = await show(e2eContext, version.id);
+      assert(showResult.isOk());
+      assertEquals(showResult.value.name, "E2E Updated Version");
+      assertEquals(showResult.value.status, "locked");
+    });
+
+    await t.step(
+      "DELETE /versions/:id.json should delete a version",
+      async () => {
+        const listResult = await fetchList(e2eContext, project.id);
+        assert(listResult.isOk());
+        const version = listResult.value.find((v) =>
+          v.name === "E2E Updated Version"
+        );
+        assert(version !== undefined);
+
+        const result = await deleteVersion(e2eContext, version.id);
+        assert(result.isOk());
+
+        const showResult = await show(e2eContext, version.id);
+        assert(showResult.isErr());
+      },
+    );
+  },
+});

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -28,7 +28,7 @@ Deno.test({
           status: "open",
           sharing: "none",
           description: "Created by E2E test",
-          dueDate: "2026-08-01",
+          dueDate: new Date("2026-08-01"),
         });
         assert(result.isOk());
       },

--- a/jsr.json
+++ b/jsr.json
@@ -30,6 +30,12 @@
     "./result/issues/show": "./result/issues/show.ts",
     "./result/issues/update": "./result/issues/update.ts",
     "./result/issues/delete": "./result/issues/delete.ts",
+    "./result/versions": "./result/versions/mod.ts",
+    "./result/versions/create": "./result/versions/create.ts",
+    "./result/versions/list": "./result/versions/list.ts",
+    "./result/versions/show": "./result/versions/show.ts",
+    "./result/versions/update": "./result/versions/update.ts",
+    "./result/versions/delete": "./result/versions/delete.ts",
     "./throwable": "./throwable/mod.ts",
     "./throwable/projects": "./throwable/projects/mod.ts",
     "./throwable/projects/archive": "./throwable/projects/archive.ts",
@@ -67,7 +73,15 @@
     "./throwable/issues/show": "./throwable/issues/show.ts",
     "./throwable/issues/update": "./throwable/issues/update.ts",
     "./throwable/issues/delete": "./throwable/issues/delete.ts",
-    "./throwable/issues/validator": "./throwable/issues/validator.ts"
+    "./throwable/issues/validator": "./throwable/issues/validator.ts",
+    "./throwable/versions": "./throwable/versions/mod.ts",
+    "./throwable/versions/type": "./throwable/versions/type.ts",
+    "./throwable/versions/create": "./throwable/versions/create.ts",
+    "./throwable/versions/list": "./throwable/versions/list.ts",
+    "./throwable/versions/show": "./throwable/versions/show.ts",
+    "./throwable/versions/update": "./throwable/versions/update.ts",
+    "./throwable/versions/delete": "./throwable/versions/delete.ts",
+    "./throwable/versions/validator": "./throwable/versions/validator.ts"
   },
   "publish": {
     "include": [

--- a/result/mod.ts
+++ b/result/mod.ts
@@ -5,6 +5,7 @@ import { Client as Project } from "./projects/mod.ts";
 import { Client as Tracker } from "./trackers/mod.ts";
 import { Client as IssueTemplate } from "./issue-templates/mod.ts";
 import { Client as Wiki } from "./wiki-pages/mod.ts";
+import { Client as Version } from "./versions/mod.ts";
 
 export class Redmine {
   readonly #context: Context;
@@ -14,6 +15,7 @@ export class Redmine {
   readonly tracker: Tracker;
   readonly issueTemplate: IssueTemplate;
   readonly wiki: Wiki;
+  readonly version: Version;
 
   constructor(context: Context) {
     this.#context = context;
@@ -23,5 +25,6 @@ export class Redmine {
     this.tracker = new Tracker(this.#context);
     this.issueTemplate = new IssueTemplate(this.#context);
     this.wiki = new Wiki(this.#context);
+    this.version = new Version(this.#context);
   }
 }

--- a/result/versions/_mock.ts
+++ b/result/versions/_mock.ts
@@ -1,0 +1,137 @@
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+
+export const context = {
+  apiKey: "sample",
+  endpoint: "http://redmine.example.com",
+};
+
+export const validHandlers = [
+  http.get(`${context.endpoint}/projects/:id/versions.json`, () => {
+    const versions = [
+      {
+        id: 3,
+        project: { id: 1, name: "Demo" },
+        name: "v1.0",
+        description: "",
+        status: "open",
+        due_date: "2026-08-01",
+        sharing: "none",
+        wiki_page_title: "",
+        created_on: "2026-07-13T00:00:00.000Z",
+        updated_on: "2026-07-13T00:00:00.000Z",
+      },
+      {
+        id: 2,
+        project: { id: 1, name: "Demo" },
+        name: "v0.9",
+        description: null,
+        status: "locked",
+        due_date: null,
+        sharing: "descendants",
+        wiki_page_title: null,
+        created_on: "2026-07-12T00:00:00.000Z",
+        updated_on: "2026-07-12T00:00:00.000Z",
+      },
+    ] as const;
+    return HttpResponse.json({
+      versions,
+      total_count: versions.length,
+    });
+  }),
+  http.get(`${context.endpoint}/versions/:id.json`, ({ params }) => {
+    const version = {
+      id: Number(params.id),
+      project: { id: 1, name: "Demo" },
+      name: "v1.0",
+      description: "",
+      status: "open",
+      due_date: "2026-08-01",
+      sharing: "none",
+      wiki_page_title: "",
+      created_on: "2026-07-13T00:00:00.000Z",
+      updated_on: "2026-07-13T00:00:00.000Z",
+    } as const;
+    return HttpResponse.json({ version });
+  }),
+  http.post(`${context.endpoint}/projects/:id/versions.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.Created });
+  }),
+  http.put(`${context.endpoint}/versions/:id.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NoContent });
+  }),
+  http.delete(`${context.endpoint}/versions/:id.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NoContent });
+  }),
+];
+
+export const invalidHandlers = [
+  http.get(`${context.endpoint}/projects/422/versions.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.get(`${context.endpoint}/projects/404/versions.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.get(`${context.endpoint}/versions/422.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.get(`${context.endpoint}/versions/404.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.post(`${context.endpoint}/projects/422/versions.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.post(`${context.endpoint}/projects/404/versions.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.put(`${context.endpoint}/versions/422.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.put(`${context.endpoint}/versions/404.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.delete(`${context.endpoint}/versions/422.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.delete(`${context.endpoint}/versions/404.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+];

--- a/result/versions/create.test.ts
+++ b/result/versions/create.test.ts
@@ -1,0 +1,62 @@
+import { create } from "./create.ts";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { setupServer } from "npm:msw@2.15.0/node";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("POST /projects/:project_id/versions.json", async (t) => {
+  await t.step(
+    "if got 201, should be success",
+    async () => {
+      server.use(...validHandlers);
+      const e = await create(context, 1, { name: "v1.0" });
+      assert(e.isOk());
+    },
+  );
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await create(context, 422, { name: "v1.0" });
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await create(context, 404, { name: "v1.0" });
+    assert(e.isErr());
+  });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          `${context.endpoint}/projects/:id/versions.json`,
+          async ({ request }) => {
+            const body = await request.json() as { version: typeof captured };
+            captured = body.version;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await create(context, 1, {
+        name: "v1.0",
+        status: "open",
+        sharing: "none",
+        dueDate: "2026-08-01",
+        wikiPageTitle: "Roadmap",
+      });
+      assert(e.isOk());
+      assertEquals(captured?.name, "v1.0");
+      assertEquals(captured?.due_date, "2026-08-01");
+      assertEquals(captured?.wiki_page_title, "Roadmap");
+    },
+  );
+});

--- a/result/versions/create.test.ts
+++ b/result/versions/create.test.ts
@@ -50,7 +50,7 @@ Deno.test("POST /projects/:project_id/versions.json", async (t) => {
         name: "v1.0",
         status: "open",
         sharing: "none",
-        dueDate: "2026-08-01",
+        dueDate: new Date("2026-08-01"),
         wikiPageTitle: "Roadmap",
       });
       assert(e.isOk());

--- a/result/versions/create.ts
+++ b/result/versions/create.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { create as createWithError } from "../../throwable/versions/create.ts";
+import { convertError } from "../../error.ts";
+
+export const create = ResultAsync.fromThrowable(
+  createWithError,
+  convertError("unknown error create a version"),
+);

--- a/result/versions/delete.test.ts
+++ b/result/versions/delete.test.ts
@@ -1,0 +1,30 @@
+import { deleteVersion } from "./delete.ts";
+import { assert } from "jsr:@std/assert@1.0.19";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("DELETE /versions/:id.json", async (t) => {
+  await t.step("if got 204, should be success", async () => {
+    server.use(...validHandlers);
+    const e = await deleteVersion(context, 3);
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await deleteVersion(context, 422);
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await deleteVersion(context, 404);
+    assert(e.isErr());
+  });
+});

--- a/result/versions/delete.ts
+++ b/result/versions/delete.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { deleteVersion as deleteWithError } from "../../throwable/versions/delete.ts";
+import { convertError } from "../../error.ts";
+
+export const deleteVersion = ResultAsync.fromThrowable(
+  deleteWithError,
+  convertError("unknown error delete a version"),
+);

--- a/result/versions/list.test.ts
+++ b/result/versions/list.test.ts
@@ -1,0 +1,30 @@
+import { fetchList } from "./list.ts";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { assert } from "jsr:@std/assert@1.0.19";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("GET /projects/:project_id/versions.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.use(...validHandlers);
+    const e = await fetchList(context, 1);
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await fetchList(context, 422);
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await fetchList(context, 404);
+    assert(e.isErr());
+  });
+});

--- a/result/versions/list.ts
+++ b/result/versions/list.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { fetchList as fetchListWithError } from "../../throwable/versions/list.ts";
+import { convertError } from "../../error.ts";
+
+export const fetchList = ResultAsync.fromThrowable(
+  fetchListWithError,
+  convertError("unknown error fetching versions"),
+);

--- a/result/versions/mod.ts
+++ b/result/versions/mod.ts
@@ -1,0 +1,71 @@
+import type { Context } from "../../context.ts";
+import { fetchList } from "./list.ts";
+import { show } from "./show.ts";
+import { create } from "./create.ts";
+import type {
+  CreateVersionQuery,
+  UpdateVersionQuery,
+} from "../../throwable/versions/type.ts";
+import { update } from "./update.ts";
+import { deleteVersion } from "./delete.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Returns all versions of the project.
+   *
+   * @param projectId Project identifier
+   */
+  list(projectId: number): ReturnType<typeof fetchList> {
+    return fetchList(this.#context, projectId);
+  }
+
+  /**
+   * Returns the version of given id.
+   *
+   * @param id Version identifier
+   */
+  show(id: number): ReturnType<typeof show> {
+    return show(this.#context, id);
+  }
+
+  /**
+   * Creates a version for the project.
+   *
+   * @param projectId Project identifier
+   * @param version The version attributes
+   */
+  create(
+    projectId: number,
+    version: CreateVersionQuery,
+  ): ReturnType<typeof create> {
+    return create(this.#context, projectId, version);
+  }
+
+  /**
+   * Updates the version of given id.
+   *
+   * @param id Version identifier
+   * @param version The version attributes to update it
+   */
+  update(
+    id: number,
+    version: UpdateVersionQuery,
+  ): ReturnType<typeof update> {
+    return update(this.#context, id, version);
+  }
+
+  /**
+   * Deletes the version of given id.
+   *
+   * @param id Version identifier
+   */
+  delete(id: number): ReturnType<typeof deleteVersion> {
+    return deleteVersion(this.#context, id);
+  }
+}

--- a/result/versions/show.test.ts
+++ b/result/versions/show.test.ts
@@ -1,0 +1,30 @@
+import { show } from "./show.ts";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { assert } from "jsr:@std/assert@1.0.19";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("GET /versions/:id.json", async (t) => {
+  await t.step("if got 200, should return ok", async () => {
+    server.use(...validHandlers);
+    const e = await show(context, 3);
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await show(context, 422);
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await show(context, 404);
+    assert(e.isErr());
+  });
+});

--- a/result/versions/show.ts
+++ b/result/versions/show.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { show as showWithError } from "../../throwable/versions/show.ts";
+import { convertError } from "../../error.ts";
+
+export const show = ResultAsync.fromThrowable(
+  showWithError,
+  convertError("unknown error show a version"),
+);

--- a/result/versions/update.test.ts
+++ b/result/versions/update.test.ts
@@ -1,0 +1,55 @@
+import { update } from "./update.ts";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("PUT /versions/:id.json", async (t) => {
+  await t.step("if got 204, should be success", async () => {
+    server.use(...validHandlers);
+    const e = await update(context, 3, { name: "v1.1" });
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.use(...invalidHandlers);
+      const e = await update(context, 422, { name: "v1.1" });
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.use(...invalidHandlers);
+    const e = await update(context, 404, { name: "v1.1" });
+    assert(e.isErr());
+  });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.use(
+        http.put(
+          `${context.endpoint}/versions/:id.json`,
+          async ({ request }) => {
+            const body = await request.json() as { version: typeof captured };
+            captured = body.version;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await update(context, 3, {
+        dueDate: "2026-09-01",
+        wikiPageTitle: "Plan",
+      });
+      assert(e.isOk());
+      assertEquals(captured?.due_date, "2026-09-01");
+      assertEquals(captured?.wiki_page_title, "Plan");
+    },
+  );
+});

--- a/result/versions/update.test.ts
+++ b/result/versions/update.test.ts
@@ -44,7 +44,7 @@ Deno.test("PUT /versions/:id.json", async (t) => {
         ),
       );
       const e = await update(context, 3, {
-        dueDate: "2026-09-01",
+        dueDate: new Date("2026-09-01"),
         wikiPageTitle: "Plan",
       });
       assert(e.isOk());

--- a/result/versions/update.ts
+++ b/result/versions/update.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { update as updateWithError } from "../../throwable/versions/update.ts";
+import { convertError } from "../../error.ts";
+
+export const update = ResultAsync.fromThrowable(
+  updateWithError,
+  convertError("unknown error update a version"),
+);

--- a/throwable/mod.ts
+++ b/throwable/mod.ts
@@ -5,6 +5,7 @@ import { Client as Project } from "./projects/mod.ts";
 import { Client as Tracker } from "./trackers/mod.ts";
 import { Client as IssueTemplate } from "./issue-templates/mod.ts";
 import { Client as Wiki } from "./wiki-pages/mod.ts";
+import { Client as Version } from "./versions/mod.ts";
 
 export class Redmine {
   readonly #context: Context;
@@ -14,6 +15,7 @@ export class Redmine {
   readonly tracker: Tracker;
   readonly issueTemplate: IssueTemplate;
   readonly wiki: Wiki;
+  readonly version: Version;
 
   constructor(context: Context) {
     this.#context = context;
@@ -23,5 +25,6 @@ export class Redmine {
     this.tracker = new Tracker(this.#context);
     this.issueTemplate = new IssueTemplate(this.#context);
     this.wiki = new Wiki(this.#context);
+    this.version = new Version(this.#context);
   }
 }

--- a/throwable/versions/create.ts
+++ b/throwable/versions/create.ts
@@ -1,0 +1,26 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
+import { join } from "jsr:@std/path@1.1.6/posix/join";
+import type { Context } from "../../context.ts";
+import type { CreateVersionQuery } from "./type.ts";
+import { toCreateVersionQuery } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+
+export async function create(
+  context: Context,
+  projectId: number,
+  version: CreateVersionQuery,
+): Promise<void> {
+  const url = new URL(
+    join(context.endpoint, "projects", `${projectId}`, "versions.json"),
+  );
+  assertResponse(
+    await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+      body: JSON.stringify({ version: parse(toCreateVersionQuery, version) }),
+    }),
+  );
+}

--- a/throwable/versions/create.ts
+++ b/throwable/versions/create.ts
@@ -5,6 +5,14 @@ import type { CreateVersionQuery } from "./type.ts";
 import { toCreateVersionQuery } from "./validator.ts";
 import { assertResponse } from "../../error.ts";
 
+/**
+ * Create a version for the project
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param projectId Project identifier
+ * @param version Version attributes to create it
+ */
 export async function create(
   context: Context,
   projectId: number,

--- a/throwable/versions/delete.ts
+++ b/throwable/versions/delete.ts
@@ -1,0 +1,19 @@
+import { join } from "jsr:@std/path@1.1.6/posix/join";
+import type { Context } from "../../context.ts";
+import { assertResponse } from "../../error.ts";
+
+export async function deleteVersion(
+  context: Context,
+  id: number,
+): Promise<void> {
+  const url = new URL(join(context.endpoint, "versions", `${id}.json`));
+  assertResponse(
+    await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+    }),
+  );
+}

--- a/throwable/versions/delete.ts
+++ b/throwable/versions/delete.ts
@@ -2,6 +2,13 @@ import { join } from "jsr:@std/path@1.1.6/posix/join";
 import type { Context } from "../../context.ts";
 import { assertResponse } from "../../error.ts";
 
+/**
+ * Delete the version of given id
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param id Version identifier
+ */
 export async function deleteVersion(
   context: Context,
   id: number,

--- a/throwable/versions/list.ts
+++ b/throwable/versions/list.ts
@@ -1,0 +1,41 @@
+import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
+import { join } from "jsr:@std/path@1.1.6/posix/join";
+import type { Context } from "../../context.ts";
+import type { Version } from "./type.ts";
+import { versionSchema } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+
+const responseSchema = object({
+  versions: array(versionSchema),
+  total_count: number(),
+});
+
+/**
+ * List versions included in the project
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param projectId Project identifier
+ * @returns Versions
+ */
+export async function fetchList(
+  context: Context,
+  projectId: number,
+): Promise<Version[]> {
+  const url = new URL(
+    join(context.endpoint, "projects", `${projectId}`, "versions.json"),
+  );
+  /**
+   * @note Redmine returns every version of the project in a single response,
+   * so no pagination is needed here unlike the projects and issues listings.
+   */
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+  });
+  assertResponse(response);
+  return parse(responseSchema, await response.json()).versions;
+}

--- a/throwable/versions/list.ts
+++ b/throwable/versions/list.ts
@@ -1,4 +1,4 @@
-import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
+import { array, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { join } from "jsr:@std/path@1.1.6/posix/join";
 import type { Context } from "../../context.ts";
 import type { Version } from "./type.ts";
@@ -7,7 +7,6 @@ import { assertResponse } from "../../error.ts";
 
 const responseSchema = object({
   versions: array(versionSchema),
-  total_count: number(),
 });
 
 /**

--- a/throwable/versions/mod.ts
+++ b/throwable/versions/mod.ts
@@ -1,0 +1,68 @@
+import type { Context } from "../../context.ts";
+import { fetchList } from "./list.ts";
+import { show } from "./show.ts";
+import { create } from "./create.ts";
+import type { CreateVersionQuery, UpdateVersionQuery } from "./type.ts";
+import { update } from "./update.ts";
+import { deleteVersion } from "./delete.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Returns all versions of the project.
+   *
+   * @param projectId Project identifier
+   */
+  list(projectId: number): ReturnType<typeof fetchList> {
+    return fetchList(this.#context, projectId);
+  }
+
+  /**
+   * Returns the version of given id.
+   *
+   * @param id Version identifier
+   */
+  show(id: number): ReturnType<typeof show> {
+    return show(this.#context, id);
+  }
+
+  /**
+   * Creates a version for the project.
+   *
+   * @param projectId Project identifier
+   * @param version The version attributes
+   */
+  create(
+    projectId: number,
+    version: CreateVersionQuery,
+  ): ReturnType<typeof create> {
+    return create(this.#context, projectId, version);
+  }
+
+  /**
+   * Updates the version of given id.
+   *
+   * @param id Version identifier
+   * @param version The version attributes to update it
+   */
+  update(
+    id: number,
+    version: UpdateVersionQuery,
+  ): ReturnType<typeof update> {
+    return update(this.#context, id, version);
+  }
+
+  /**
+   * Deletes the version of given id.
+   *
+   * @param id Version identifier
+   */
+  delete(id: number): ReturnType<typeof deleteVersion> {
+    return deleteVersion(this.#context, id);
+  }
+}

--- a/throwable/versions/show.ts
+++ b/throwable/versions/show.ts
@@ -9,6 +9,14 @@ const schema = object({
   version: versionSchema,
 });
 
+/**
+ * Show the version of given id
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param id Version identifier
+ * @returns Version object
+ */
 export async function show(
   context: Context,
   id: number,

--- a/throwable/versions/show.ts
+++ b/throwable/versions/show.ts
@@ -1,0 +1,27 @@
+import { join } from "jsr:@std/path@1.1.6/posix/join";
+import type { Context } from "../../context.ts";
+import type { Version } from "./type.ts";
+import { versionSchema } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+import { object, parse } from "jsr:@valibot/valibot@1.4.2";
+
+const schema = object({
+  version: versionSchema,
+});
+
+export async function show(
+  context: Context,
+  id: number,
+): Promise<Version> {
+  const url = new URL(join(context.endpoint, "versions", `${id}.json`));
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+  });
+
+  assertResponse(response);
+  return parse(schema, await response.json()).version;
+}

--- a/throwable/versions/type.ts
+++ b/throwable/versions/type.ts
@@ -1,0 +1,25 @@
+import type { IdName } from "../../internal/type.ts";
+
+export type Version = {
+  id: number;
+  project: IdName;
+  name: string;
+  description?: string;
+  status: "open" | "locked" | "closed";
+  dueDate?: Date;
+  sharing: "none" | "descendants" | "hierarchy" | "tree" | "system";
+  wikiPageTitle?: string;
+  createdOn: Date;
+  updatedOn: Date;
+};
+
+export type CreateVersionQuery = {
+  name: string;
+  status?: "open" | "locked" | "closed";
+  sharing?: "none" | "descendants" | "hierarchy" | "tree" | "system";
+  description?: string;
+  dueDate?: string;
+  wikiPageTitle?: string;
+};
+
+export type UpdateVersionQuery = Partial<CreateVersionQuery>;

--- a/throwable/versions/type.ts
+++ b/throwable/versions/type.ts
@@ -18,7 +18,7 @@ export type CreateVersionQuery = {
   status?: "open" | "locked" | "closed";
   sharing?: "none" | "descendants" | "hierarchy" | "tree" | "system";
   description?: string;
-  dueDate?: string;
+  dueDate?: Date;
   wikiPageTitle?: string;
 };
 

--- a/throwable/versions/update.ts
+++ b/throwable/versions/update.ts
@@ -1,0 +1,23 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
+import { join } from "jsr:@std/path@1.1.6/posix/join";
+import type { Context } from "../../context.ts";
+import type { UpdateVersionQuery } from "./type.ts";
+import { toUpdateVersionQuery } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+
+export async function update(
+  context: Context,
+  id: number,
+  version: UpdateVersionQuery,
+): Promise<void> {
+  const url = new URL(join(context.endpoint, "versions", `${id}.json`));
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+    body: JSON.stringify({ version: parse(toUpdateVersionQuery, version) }),
+  });
+  assertResponse(response);
+}

--- a/throwable/versions/update.ts
+++ b/throwable/versions/update.ts
@@ -5,6 +5,14 @@ import type { UpdateVersionQuery } from "./type.ts";
 import { toUpdateVersionQuery } from "./validator.ts";
 import { assertResponse } from "../../error.ts";
 
+/**
+ * Update the version of given id
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param id Version identifier
+ * @param version Version attributes to update it
+ */
 export async function update(
   context: Context,
   id: number,

--- a/throwable/versions/validator.ts
+++ b/throwable/versions/validator.ts
@@ -1,0 +1,68 @@
+import {
+  nullish,
+  number,
+  object,
+  optional,
+  partial,
+  picklist,
+  pipe,
+  string,
+  transform,
+} from "jsr:@valibot/valibot@1.4.2";
+import {
+  dateLikeString,
+  idName,
+  toUndefined,
+} from "../../internal/validator.ts";
+import { objectToCamel, objectToSnake } from "npm:ts-case-convert@2.3.1";
+import type { CreateVersionQuery, Version } from "./type.ts";
+
+const statusValues = ["open", "locked", "closed"] as const;
+const sharingValues = [
+  "none",
+  "descendants",
+  "hierarchy",
+  "tree",
+  "system",
+] as const;
+
+export const versionSchema = pipe(
+  object({
+    id: number(),
+    project: idName,
+    name: string(),
+    description: pipe(nullish(string()), transform(toUndefined)),
+    status: picklist(statusValues),
+    due_date: pipe(nullish(dateLikeString), transform(toUndefined)),
+    sharing: picklist(sharingValues),
+    wiki_page_title: pipe(nullish(string()), transform(toUndefined)),
+    created_on: dateLikeString,
+    updated_on: dateLikeString,
+  }),
+  transform((input) => {
+    return objectToCamel(input) satisfies Version;
+  }),
+);
+
+const createVersionQuerySchema = object({
+  name: string(),
+  status: optional(picklist(statusValues)),
+  sharing: optional(picklist(sharingValues)),
+  description: optional(string()),
+  dueDate: optional(string()),
+  wikiPageTitle: optional(string()),
+});
+
+export const toCreateVersionQuery = pipe(
+  createVersionQuerySchema,
+  transform((input: CreateVersionQuery) => {
+    return objectToSnake(input);
+  }),
+);
+
+export const toUpdateVersionQuery = pipe(
+  partial(createVersionQuerySchema),
+  transform((input) => {
+    return objectToSnake(input);
+  }),
+);

--- a/throwable/versions/validator.ts
+++ b/throwable/versions/validator.ts
@@ -1,4 +1,5 @@
 import {
+  date,
   nullish,
   number,
   object,
@@ -15,7 +16,7 @@ import {
   toUndefined,
 } from "../../internal/validator.ts";
 import { objectToCamel, objectToSnake } from "npm:ts-case-convert@2.3.1";
-import type { CreateVersionQuery, Version } from "./type.ts";
+import type { Version } from "./type.ts";
 
 const statusValues = ["open", "locked", "closed"] as const;
 const sharingValues = [
@@ -44,18 +45,29 @@ export const versionSchema = pipe(
   }),
 );
 
+// Redmine expects dates as YYYY-MM-DD strings. The UTC date part is used
+// rather than the local calendar fields because dateLikeString parses
+// Redmine's date-only strings as UTC midnight, so only UTC keeps a
+// show() -> update() round-trip on the same calendar day. The trade-off:
+// a Date built from local calendar fields (e.g. new Date(2026, 6, 1) in
+// UTC+9) serializes to the previous day.
+const toRedmineDate = pipe(
+  date(),
+  transform((input: Date) => input.toISOString().slice(0, 10)),
+);
+
 const createVersionQuerySchema = object({
   name: string(),
   status: optional(picklist(statusValues)),
   sharing: optional(picklist(sharingValues)),
   description: optional(string()),
-  dueDate: optional(string()),
+  dueDate: optional(toRedmineDate),
   wikiPageTitle: optional(string()),
 });
 
 export const toCreateVersionQuery = pipe(
   createVersionQuerySchema,
-  transform((input: CreateVersionQuery) => {
+  transform((input) => {
     return objectToSnake(input);
   }),
 );


### PR DESCRIPTION
## Summary

Add a `version` client covering the Redmine Versions REST API (list, show, create, update, delete) in both the throwable and result layers, and register it on the top-level `Redmine` client.

## Details

Versions follow the existing wiki-pages and issues features, keeping the two-layer split intact: `throwable/versions/*` throws on error and `result/versions/*` wraps each call with `neverthrow`'s `ResultAsync`.

The validator reuses the shared `dateLikeString`, `idName`, and `toUndefined` helpers from `internal/validator.ts` rather than re-declaring them, defines the `status` and `sharing` picklists once for both the response and request schemas, and serializes camelCase query attributes to snake_case on create and update via `objectToSnake`.

`list` targets `GET /projects/:project_id/versions.json`; Redmine returns every version of the project in a single response, so unlike the projects and issues listings no pagination is needed and no `total_count` is read.

## Confirmation

Unit tests cover each operation's success, error-object, and unexpected-format responses, plus assertions that camelCase attributes are serialized as snake_case on create and update, and an end-to-end test exercises the full create/list/show/update/delete lifecycle against a real Redmine instance.

`nix run .#check-deno` (CI parity) passes; the version unit tests pass under the pinned deno.

A `/simplify` pass and a high-effort `/code-review` were run: the unused `total_count` validation was dropped from the list schema, and JSDoc was added to the `show`/`create`/`update`/`delete` throwable functions for parity with `list`.

## Limitation

No known limitations.

Generated with: Claude

https://claude.ai/code/session_01ANJNJCiZPGKqaPa9XKk1UB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive version management support, including listing, viewing, creating, updating, and deleting project versions.
  * Added version access through both standard and error-safe API interfaces.
  * Added validation for version details and request fields, including date and wiki title formatting.

* **Tests**
  * Added unit and end-to-end coverage for successful operations, validation errors, response errors, and request formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->