### PR TITLE
feat: implement my account resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Redmine rest api wrapper for deno.
   - [ ] [`/projects/:project_id/files.:format`](https://www.redmine.org/projects/redmine/wiki/Rest_Files#projectsproject_idfilesformat)
     - [ ] [`GET`](https://www.redmine.org/projects/redmine/wiki/Rest_Files#GET)
     - [ ] [`POST`](https://www.redmine.org/projects/redmine/wiki/Rest_Files#POST)
-- [ ] [My account](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount)
-  - [ ] [`/my/account.:format`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#myaccountformat)
-    - [ ] [`GET`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#GET)
-    - [ ] [`PUT`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#PUT)
+- [x] [My account](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount)
+  - [x] [`/my/account.:format`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#myaccountformat)
+    - [x] [`GET`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#GET)
+    - [x] [`PUT`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#PUT)
 - [ ] [Journals](https://www.redmine.org/projects/redmine/wiki/Rest_Journals)
   - Official Page is not found...:
     https://www.redmine.org/projects/redmine/wiki/Rest_Journals

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -1,0 +1,47 @@
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { e2eContext } from "./context.ts";
+import { show } from "../result/my-account/show.ts";
+import { update } from "../result/my-account/update.ts";
+
+Deno.test({
+  name: "E2E: My Account API",
+  // Library functions may not fully consume fetch response bodies, triggering
+  // Deno's resource sanitizer as a false positive.
+  sanitizeResources: false,
+  fn: async (t) => {
+    const initialResult = await show(e2eContext);
+    assert(initialResult.isOk());
+    const originalFirstname = initialResult.value.firstname;
+
+    await t.step(
+      "GET /my/account.json should return the authenticated user's account",
+      async () => {
+        const result = await show(e2eContext);
+        assert(result.isOk());
+        assert(typeof result.value.login === "string");
+        assert(typeof result.value.mail === "string");
+      },
+    );
+
+    await t.step(
+      "PUT /my/account.json should update the account",
+      async () => {
+        const result = await update(e2eContext, {
+          firstname: "E2E Updated Firstname",
+        });
+        assert(result.isOk());
+
+        const showResult = await show(e2eContext);
+        assert(showResult.isOk());
+        assertEquals(showResult.value.firstname, "E2E Updated Firstname");
+      },
+    );
+
+    // Restore the original firstname so this test has no lasting side
+    // effects on the seeded e2e user.
+    const restoreResult = await update(e2eContext, {
+      firstname: originalFirstname,
+    });
+    assert(restoreResult.isOk());
+  },
+});

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -13,35 +13,37 @@ Deno.test({
     assert(initialResult.isOk());
     const originalFirstname = initialResult.value.firstname;
 
-    await t.step(
-      "GET /my/account.json should return the authenticated user's account",
-      async () => {
-        const result = await show(e2eContext);
-        assert(result.isOk());
-        assert(typeof result.value.login === "string");
-        assert(typeof result.value.mail === "string");
-      },
-    );
+    try {
+      await t.step(
+        "GET /my/account.json should return the authenticated user's account",
+        async () => {
+          const result = await show(e2eContext);
+          assert(result.isOk());
+          assert(typeof result.value.login === "string");
+          assert(typeof result.value.mail === "string");
+        },
+      );
 
-    await t.step(
-      "PUT /my/account.json should update the account",
-      async () => {
-        const result = await update(e2eContext, {
-          firstname: "E2E Updated Firstname",
-        });
-        assert(result.isOk());
+      await t.step(
+        "PUT /my/account.json should update the account",
+        async () => {
+          const result = await update(e2eContext, {
+            firstname: "E2E Updated Firstname",
+          });
+          assert(result.isOk());
 
-        const showResult = await show(e2eContext);
-        assert(showResult.isOk());
-        assertEquals(showResult.value.firstname, "E2E Updated Firstname");
-      },
-    );
-
-    // Restore the original firstname so this test has no lasting side
-    // effects on the seeded e2e user.
-    const restoreResult = await update(e2eContext, {
-      firstname: originalFirstname,
-    });
-    assert(restoreResult.isOk());
+          const showResult = await show(e2eContext);
+          assert(showResult.isOk());
+          assertEquals(showResult.value.firstname, "E2E Updated Firstname");
+        },
+      );
+    } finally {
+      // Restore the original firstname so this test has no lasting side effects
+      // on the seeded e2e user, even if a step above threw.
+      const restoreResult = await update(e2eContext, {
+        firstname: originalFirstname,
+      });
+      assert(restoreResult.isOk());
+    }
   },
 });

--- a/jsr.json
+++ b/jsr.json
@@ -72,6 +72,9 @@
     "./result/memberships/show": "./result/memberships/show.ts",
     "./result/memberships/update": "./result/memberships/update.ts",
     "./result/memberships/delete": "./result/memberships/delete.ts",
+    "./result/my-account": "./result/my-account/mod.ts",
+    "./result/my-account/show": "./result/my-account/show.ts",
+    "./result/my-account/update": "./result/my-account/update.ts",
     "./throwable": "./throwable/mod.ts",
     "./throwable/projects": "./throwable/projects/mod.ts",
     "./throwable/projects/archive": "./throwable/projects/archive.ts",
@@ -171,7 +174,12 @@
     "./throwable/memberships/show": "./throwable/memberships/show.ts",
     "./throwable/memberships/update": "./throwable/memberships/update.ts",
     "./throwable/memberships/delete": "./throwable/memberships/delete.ts",
-    "./throwable/memberships/validator": "./throwable/memberships/validator.ts"
+    "./throwable/memberships/validator": "./throwable/memberships/validator.ts",
+    "./throwable/my-account": "./throwable/my-account/mod.ts",
+    "./throwable/my-account/type": "./throwable/my-account/type.ts",
+    "./throwable/my-account/show": "./throwable/my-account/show.ts",
+    "./throwable/my-account/update": "./throwable/my-account/update.ts",
+    "./throwable/my-account/validator": "./throwable/my-account/validator.ts"
   },
   "publish": {
     "include": [

--- a/result/mod.ts
+++ b/result/mod.ts
@@ -15,6 +15,7 @@ import { Client as User } from "./users/mod.ts";
 import { Client as TimeEntry } from "./time-entries/mod.ts";
 import { Client as IssueCategory } from "./issue-categories/mod.ts";
 import { Client as Membership } from "./memberships/mod.ts";
+import { Client as MyAccount } from "./my-account/mod.ts";
 
 export class Redmine {
   readonly #context: Context;
@@ -34,6 +35,7 @@ export class Redmine {
   readonly timeEntry: TimeEntry;
   readonly issueCategory: IssueCategory;
   readonly membership: Membership;
+  readonly myAccount: MyAccount;
 
   constructor(context: Context) {
     this.#context = context;
@@ -53,5 +55,6 @@ export class Redmine {
     this.timeEntry = new TimeEntry(this.#context);
     this.issueCategory = new IssueCategory(this.#context);
     this.membership = new Membership(this.#context);
+    this.myAccount = new MyAccount(this.#context);
   }
 }

--- a/result/my-account/_mock.ts
+++ b/result/my-account/_mock.ts
@@ -1,0 +1,64 @@
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+
+export const context = {
+  apiKey: "sample",
+  endpoint: "http://redmine.example.com",
+};
+
+export const validHandlers = [
+  http.get(`${context.endpoint}/my/account.json`, () => {
+    const user = {
+      id: 1,
+      login: "jsmith",
+      admin: true,
+      firstname: "John",
+      lastname: "Smith",
+      mail: "jsmith@example.com",
+      created_on: "2026-01-01T00:00:00.000Z",
+      last_login_on: "2026-07-13T00:00:00.000Z",
+      api_key: "sample-api-key",
+      mail_notification: "only_my_events",
+      custom_fields: [
+        { id: 1, name: "Phone", value: "090-0000-0000" },
+      ],
+    } as const;
+    return HttpResponse.json({ user });
+  }),
+  http.put(`${context.endpoint}/my/account.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NoContent });
+  }),
+];
+
+export const invalidHandlers = [
+  http.get(`${context.endpoint}/my/account.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.put(`${context.endpoint}/my/account.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+];
+
+export const notFoundHandlers = [
+  http.get(`${context.endpoint}/my/account.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.put(`${context.endpoint}/my/account.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+];

--- a/result/my-account/mod.ts
+++ b/result/my-account/mod.ts
@@ -1,0 +1,30 @@
+import type { Context } from "../../context.ts";
+import { show } from "./show.ts";
+import type { UpdateMyAccountQuery } from "../../throwable/my-account/type.ts";
+import { update } from "./update.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Returns the authenticated user's account.
+   */
+  show(): ReturnType<typeof show> {
+    return show(this.#context);
+  }
+
+  /**
+   * Updates the authenticated user's account.
+   *
+   * @param account The account attributes to update it
+   */
+  update(
+    account: UpdateMyAccountQuery,
+  ): ReturnType<typeof update> {
+    return update(this.#context, account);
+  }
+}

--- a/result/my-account/show.test.ts
+++ b/result/my-account/show.test.ts
@@ -1,0 +1,52 @@
+import { show } from "./show.ts";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import {
+  context,
+  invalidHandlers,
+  notFoundHandlers,
+  validHandlers,
+} from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("GET /my/account.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await show(context);
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if got 200, should return the account with camelCase fields",
+    async () => {
+      server.resetHandlers(...validHandlers);
+      const e = await show(context);
+      assert(e.isOk());
+      assertEquals(e.value.login, "jsmith");
+      assertEquals(e.value.mailNotification, "only_my_events");
+      assertEquals(e.value.apiKey, "sample-api-key");
+      assertEquals(e.value.customFields?.[0], {
+        id: 1,
+        name: "Phone",
+        value: "090-0000-0000",
+      });
+    },
+  );
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.resetHandlers(...invalidHandlers);
+      const e = await show(context);
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.resetHandlers(...notFoundHandlers);
+    const e = await show(context);
+    assert(e.isErr());
+  });
+});

--- a/result/my-account/show.ts
+++ b/result/my-account/show.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { show as showWithError } from "../../throwable/my-account/show.ts";
+import { convertError } from "../../error.ts";
+
+export const show = ResultAsync.fromThrowable(
+  showWithError,
+  convertError("unknown error show my account"),
+);

--- a/result/my-account/update.test.ts
+++ b/result/my-account/update.test.ts
@@ -1,0 +1,64 @@
+import { update } from "./update.ts";
+import {
+  context,
+  invalidHandlers,
+  notFoundHandlers,
+  validHandlers,
+} from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("PUT /my/account.json", async (t) => {
+  await t.step("if got 204, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await update(context, { firstname: "Jane" });
+    assert(e.isOk());
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.resetHandlers(...invalidHandlers);
+      const e = await update(context, { firstname: "Jane" });
+      assert(e.isErr());
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.resetHandlers(...notFoundHandlers);
+    const e = await update(context, { firstname: "Jane" });
+    assert(e.isErr());
+  });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.resetHandlers(
+        http.put(
+          `${context.endpoint}/my/account.json`,
+          async ({ request }) => {
+            const body = await request.json() as { user: typeof captured };
+            captured = body.user;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await update(context, {
+        firstname: "Jane",
+        lastname: "Doe",
+        mail: "jane@example.com",
+        customFieldValues: { "1": "090-1111-2222" },
+      });
+      assert(e.isOk());
+      assertEquals(captured?.firstname, "Jane");
+      assertEquals(captured?.lastname, "Doe");
+      assertEquals(captured?.mail, "jane@example.com");
+      assertEquals(captured?.custom_field_values, { "1": "090-1111-2222" });
+    },
+  );
+});

--- a/result/my-account/update.ts
+++ b/result/my-account/update.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { update as updateWithError } from "../../throwable/my-account/update.ts";
+import { convertError } from "../../error.ts";
+
+export const update = ResultAsync.fromThrowable(
+  updateWithError,
+  convertError("unknown error update my account"),
+);

--- a/throwable/mod.ts
+++ b/throwable/mod.ts
@@ -15,6 +15,7 @@ import { Client as User } from "./users/mod.ts";
 import { Client as TimeEntry } from "./time-entries/mod.ts";
 import { Client as IssueCategory } from "./issue-categories/mod.ts";
 import { Client as Membership } from "./memberships/mod.ts";
+import { Client as MyAccount } from "./my-account/mod.ts";
 
 export class Redmine {
   readonly #context: Context;
@@ -34,6 +35,7 @@ export class Redmine {
   readonly timeEntry: TimeEntry;
   readonly issueCategory: IssueCategory;
   readonly membership: Membership;
+  readonly myAccount: MyAccount;
 
   constructor(context: Context) {
     this.#context = context;
@@ -53,5 +55,6 @@ export class Redmine {
     this.timeEntry = new TimeEntry(this.#context);
     this.issueCategory = new IssueCategory(this.#context);
     this.membership = new Membership(this.#context);
+    this.myAccount = new MyAccount(this.#context);
   }
 }

--- a/throwable/my-account/mod.ts
+++ b/throwable/my-account/mod.ts
@@ -1,0 +1,30 @@
+import type { Context } from "../../context.ts";
+import { show } from "./show.ts";
+import type { UpdateMyAccountQuery } from "./type.ts";
+import { update } from "./update.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Returns the authenticated user's account.
+   */
+  show(): ReturnType<typeof show> {
+    return show(this.#context);
+  }
+
+  /**
+   * Updates the authenticated user's account.
+   *
+   * @param account The account attributes to update it
+   */
+  update(
+    account: UpdateMyAccountQuery,
+  ): ReturnType<typeof update> {
+    return update(this.#context, account);
+  }
+}

--- a/throwable/my-account/show.ts
+++ b/throwable/my-account/show.ts
@@ -1,0 +1,33 @@
+import { buildUrl } from "../../internal/url.ts";
+import type { Context } from "../../context.ts";
+import type { MyAccount } from "./type.ts";
+import { myAccountSchema } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+import { object, parse } from "jsr:@valibot/valibot@1.4.2";
+
+const schema = object({
+  user: myAccountSchema,
+});
+
+/**
+ * Show the authenticated user's account
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @returns MyAccount object
+ */
+export async function show(
+  context: Context,
+): Promise<MyAccount> {
+  const url = buildUrl(context.endpoint, "my", "account.json");
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+  });
+
+  assertResponse(response);
+  return parse(schema, await response.json()).user;
+}

--- a/throwable/my-account/type.ts
+++ b/throwable/my-account/type.ts
@@ -1,0 +1,26 @@
+export type CustomFieldValue = {
+  id: number;
+  name: string;
+  value: unknown;
+};
+
+export type MyAccount = {
+  id: number;
+  login: string;
+  firstname: string;
+  lastname: string;
+  mail: string;
+  createdOn: Date;
+  lastLoginOn?: Date;
+  apiKey?: string;
+  admin?: boolean;
+  mailNotification?: string;
+  customFields?: CustomFieldValue[];
+};
+
+export type UpdateMyAccountQuery = {
+  firstname?: string;
+  lastname?: string;
+  mail?: string;
+  customFieldValues?: Record<string, unknown>;
+};

--- a/throwable/my-account/update.ts
+++ b/throwable/my-account/update.ts
@@ -1,0 +1,29 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
+import { buildUrl } from "../../internal/url.ts";
+import type { Context } from "../../context.ts";
+import type { UpdateMyAccountQuery } from "./type.ts";
+import { toUpdateMyAccountQuery } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+
+/**
+ * Update the authenticated user's account
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param account Account attributes to update it
+ */
+export async function update(
+  context: Context,
+  account: UpdateMyAccountQuery,
+): Promise<void> {
+  const url = buildUrl(context.endpoint, "my", "account.json");
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+    body: JSON.stringify({ user: parse(toUpdateMyAccountQuery, account) }),
+  });
+  assertResponse(response);
+}

--- a/throwable/my-account/validator.ts
+++ b/throwable/my-account/validator.ts
@@ -1,0 +1,58 @@
+import {
+  array,
+  boolean,
+  nullish,
+  number,
+  object,
+  partial,
+  pipe,
+  record,
+  string,
+  transform,
+  unknown,
+} from "jsr:@valibot/valibot@1.4.2";
+import { dateLikeString, toUndefined } from "../../internal/validator.ts";
+import { objectToCamel, objectToSnake } from "npm:ts-case-convert@2.3.1";
+import type { MyAccount } from "./type.ts";
+
+const customFieldValueSchema = object({
+  id: number(),
+  name: string(),
+  value: unknown(),
+});
+
+export const myAccountSchema = pipe(
+  object({
+    id: number(),
+    login: string(),
+    firstname: string(),
+    lastname: string(),
+    mail: string(),
+    created_on: dateLikeString,
+    last_login_on: pipe(nullish(dateLikeString), transform(toUndefined)),
+    api_key: pipe(nullish(string()), transform(toUndefined)),
+    admin: pipe(nullish(boolean()), transform(toUndefined)),
+    mail_notification: pipe(nullish(string()), transform(toUndefined)),
+    custom_fields: pipe(
+      nullish(array(customFieldValueSchema)),
+      transform(toUndefined),
+    ),
+  }),
+  transform((input) => {
+    return objectToCamel(input) satisfies MyAccount;
+  }),
+);
+
+const updateMyAccountQuerySchema = partial(object({
+  firstname: string(),
+  lastname: string(),
+  mail: string(),
+  customFieldValues: record(string(), unknown()),
+}));
+
+export const toUpdateMyAccountQuery = pipe(
+  updateMyAccountQuerySchema,
+  transform((input) => {
+    return objectToSnake(input);
+  }),
+);


### PR DESCRIPTION
## Summary

Add support for the Redmine My Account REST resource (`GET /my/account.json` and `PUT /my/account.json`) across both the `throwable` and `result` layers.

## Details

My Account was unimplemented in the README status matrix.

It is a singleton resource (no id), exposed as `show()` and `update(account)`. Types are defined locally because this branch predates the Users resource, and custom field values are typed loosely since Redmine returns either a string or a string array.

## Confirmation

Ran `nix run .#check-deno` (typecheck, lint, and the msw-based unit tests) and it passed with 30 tests green. `deno fmt --check` is clean.

## Limitation

The `e2e/my-account.test.ts` test is authored to the existing pattern but was not executed locally, since it requires the docker Redmine instance (`deno task test:e2e`); it restores the original firstname after updating to avoid side effects.

Generated with: Claude

https://claude.ai/code/session_01NYXQ42B1p55X1NvLenU2yp
