### PR TITLE
feat: expose response status and body on Redmine errors

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,8 +4,8 @@
     "fmt:check": "deno fmt --check ./**/*.ts",
     "check": "deno check ./**/*.ts",
     "lint": "deno lint ./**/*.ts",
-    "test": "deno test --unstable-broadcast-channel --location http://localhost --allow-env internal/ result/",
-    "test:coverage": "mkdir coverage -p && deno test --unstable-broadcast-channel --location http://localhost --coverage=coverage/coverage --allow-env internal/ result/ && deno coverage coverage/coverage --lcov --output=coverage/lcov.info",
+    "test": "deno test --unstable-broadcast-channel --location http://localhost --allow-env error.test.ts internal/ result/",
+    "test:coverage": "mkdir coverage -p && deno test --unstable-broadcast-channel --location http://localhost --coverage=coverage/coverage --allow-env error.test.ts internal/ result/ && deno coverage coverage/coverage --lcov --output=coverage/lcov.info",
     "test:e2e": "deno test --allow-net --allow-env e2e/"
   },
   "lock": false,

--- a/error.test.ts
+++ b/error.test.ts
@@ -21,6 +21,13 @@ Deno.test("RedmineResponseError.fromResponse captures status, statusText and bod
   assertEquals(error.message, "Unprocessable Entity");
 });
 
+Deno.test("RedmineResponseError falls back to the status code when statusText is empty", async () => {
+  const response = new Response("boom", { status: 500, statusText: "" });
+  const error = await RedmineResponseError.fromResponse(response);
+
+  assertEquals(error.message, "HTTP 500");
+});
+
 Deno.test("RedmineResponseError does not populate cause", async () => {
   const response = new Response("boom", {
     status: 500,

--- a/error.test.ts
+++ b/error.test.ts
@@ -1,0 +1,61 @@
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStrictEquals,
+} from "jsr:@std/assert@1.0.19";
+import { assertResponse, RedmineResponseError } from "./error.ts";
+
+Deno.test("RedmineResponseError.fromResponse captures status, statusText and body", async () => {
+  const response = new Response("id is required", {
+    status: 422,
+    statusText: "Unprocessable Entity",
+  });
+  const error = await RedmineResponseError.fromResponse(response);
+
+  assertInstanceOf(error, RedmineResponseError);
+  assertEquals(error.name, "RedmineResponseError");
+  assertEquals(error.status, 422);
+  assertEquals(error.statusText, "Unprocessable Entity");
+  assertEquals(error.body, "id is required");
+  assertEquals(error.message, "Unprocessable Entity");
+});
+
+Deno.test("RedmineResponseError does not populate cause", async () => {
+  const response = new Response("boom", {
+    status: 500,
+    statusText: "Internal Server Error",
+  });
+  const error = await RedmineResponseError.fromResponse(response);
+
+  assertStrictEquals(error.cause, undefined);
+});
+
+Deno.test("RedmineResponseError.fromResponse falls back to empty body when the body is unreadable", async () => {
+  const response = new Response("already read", {
+    status: 500,
+    statusText: "Internal Server Error",
+  });
+  await response.text();
+
+  const error = await RedmineResponseError.fromResponse(response);
+
+  assertEquals(error.body, "");
+});
+
+Deno.test("assertResponse resolves without throwing for an ok response", async () => {
+  const response = new Response("ok", { status: 200 });
+  await assertResponse(response);
+});
+
+Deno.test("assertResponse throws RedmineResponseError carrying the response details for a non-ok response", async () => {
+  const response = new Response("not found", {
+    status: 404,
+    statusText: "Not Found",
+  });
+
+  const error = await assertRejects(() => assertResponse(response));
+  assertInstanceOf(error, RedmineResponseError);
+  assertEquals(error.status, 404);
+  assertEquals(error.body, "not found");
+});

--- a/error.ts
+++ b/error.ts
@@ -16,7 +16,9 @@ export class RedmineResponseError extends Error {
   readonly body: string;
 
   constructor(status: number, statusText: string, body: string) {
-    super(statusText);
+    // HTTP/2 drops the reason phrase, leaving statusText empty; fall back to
+    // the status code so the message is never blank.
+    super(statusText || `HTTP ${status}`);
     this.name = "RedmineResponseError";
     this.status = status;
     this.statusText = statusText;

--- a/error.ts
+++ b/error.ts
@@ -11,15 +11,43 @@ export function convertError(
 }
 
 export class RedmineResponseError extends Error {
-  constructor(response: Response) {
-    super(response.statusText, { cause: response });
+  readonly status: number;
+  readonly statusText: string;
+  readonly body: string;
+
+  constructor(status: number, statusText: string, body: string) {
+    super(statusText);
+    this.name = "RedmineResponseError";
+    this.status = status;
+    this.statusText = statusText;
+    this.body = body;
+  }
+
+  /**
+   * Build an error from a non-ok response, eagerly draining its body.
+   *
+   * The body is read here rather than kept as a live `Response` so callers
+   * get a settled string and the connection is not left dangling. Reading
+   * can fail (e.g. the body was already consumed); in that case the body is
+   * left empty so surfacing the original status is never masked by a
+   * secondary failure.
+   *
+   * @param response A non-ok response to describe
+   * @returns The error carrying the response status, statusText and body
+   */
+  static async fromResponse(response: Response): Promise<RedmineResponseError> {
+    const body = await response.text().catch(() => "");
+    return new RedmineResponseError(response.status, response.statusText, body);
   }
 }
 
-export function assertResponse(
-  response: Response,
-): asserts response is Response & { ok: true } {
+/**
+ * Assert that a Redmine REST response is ok.
+ *
+ * @throws {RedmineResponseError} When the response is not ok
+ */
+export async function assertResponse(response: Response): Promise<void> {
   if (!response.ok) {
-    throw new RedmineResponseError(response);
+    throw await RedmineResponseError.fromResponse(response);
   }
 }

--- a/error.ts
+++ b/error.ts
@@ -10,7 +10,7 @@ export function convertError(
   };
 }
 
-export class UnprocessableEntityError extends Error {
+export class RedmineResponseError extends Error {
   constructor(response: Response) {
     super(response.statusText, { cause: response });
   }
@@ -20,6 +20,6 @@ export function assertResponse(
   response: Response,
 ): asserts response is Response & { ok: true } {
   if (!response.ok) {
-    throw new UnprocessableEntityError(response);
+    throw new RedmineResponseError(response);
   }
 }

--- a/jsr.json
+++ b/jsr.json
@@ -4,6 +4,7 @@
   "version": "2.1.0",
   "exports": {
     ".": "./result/mod.ts",
+    "./error": "./error.ts",
     "./result": "./result/mod.ts",
     "./result/projects": "./result/projects/mod.ts",
     "./result/projects/archive": "./result/projects/archive.ts",

--- a/throwable/attachments/delete.ts
+++ b/throwable/attachments/delete.ts
@@ -14,7 +14,7 @@ export async function deleteAttachment(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "attachments", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/attachments/show.ts
+++ b/throwable/attachments/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).attachment;
 }

--- a/throwable/attachments/update.ts
+++ b/throwable/attachments/update.ts
@@ -29,5 +29,5 @@ export async function update(
       attachment: parse(toUpdateAttachmentQuery, attachment),
     }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/custom-fields/list.ts
+++ b/throwable/custom-fields/list.ts
@@ -25,6 +25,6 @@ export async function fetchList(context: Context): Promise<CustomField[]> {
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listCustomFieldResponse, await response.json()).custom_fields;
 }

--- a/throwable/enumerations/list.ts
+++ b/throwable/enumerations/list.ts
@@ -27,7 +27,7 @@ async function fetchEnumerations(
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return await response.json();
 }
 

--- a/throwable/files/create.ts
+++ b/throwable/files/create.ts
@@ -24,7 +24,7 @@ export async function create(
     `${projectId}`,
     "files.json",
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/files/list.ts
+++ b/throwable/files/list.ts
@@ -34,6 +34,6 @@ export async function fetchList(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).files;
 }

--- a/throwable/files/upload.ts
+++ b/throwable/files/upload.ts
@@ -33,6 +33,6 @@ export async function upload(
     // fetch body even though it is a valid one at runtime.
     body: data as BodyInit,
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(uploadResponseSchema, await response.json()).upload.token;
 }

--- a/throwable/groups/add-user.ts
+++ b/throwable/groups/add-user.ts
@@ -16,7 +16,7 @@ export async function addUser(
   userId: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "groups", `${groupId}`, "users.json");
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/groups/create.ts
+++ b/throwable/groups/create.ts
@@ -17,7 +17,7 @@ export async function create(
   group: CreateGroupQuery,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "groups.json");
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/groups/delete.ts
+++ b/throwable/groups/delete.ts
@@ -14,7 +14,7 @@ export async function deleteGroup(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "groups", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/groups/list.ts
+++ b/throwable/groups/list.ts
@@ -25,6 +25,6 @@ export async function fetchList(context: Context): Promise<IdName[]> {
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).groups;
 }

--- a/throwable/groups/remove-user.ts
+++ b/throwable/groups/remove-user.ts
@@ -22,7 +22,7 @@ export async function removeUser(
     "users",
     `${userId}.json`,
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/groups/show.ts
+++ b/throwable/groups/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).group;
 }

--- a/throwable/groups/update.ts
+++ b/throwable/groups/update.ts
@@ -27,5 +27,5 @@ export async function update(
     },
     body: JSON.stringify({ group: parse(toUpdateGroupQuery, group) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/issue-categories/create.ts
+++ b/throwable/issue-categories/create.ts
@@ -24,7 +24,7 @@ export async function create(
     `${projectId}`,
     "issue_categories.json",
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/issue-categories/delete.ts
+++ b/throwable/issue-categories/delete.ts
@@ -21,7 +21,7 @@ export async function deleteIssueCategory(
   if (reassignToId !== undefined) {
     url.searchParams.set("reassign_to_id", `${reassignToId}`);
   }
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/issue-categories/list.ts
+++ b/throwable/issue-categories/list.ts
@@ -39,6 +39,6 @@ export async function fetchList(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).issue_categories;
 }

--- a/throwable/issue-categories/show.ts
+++ b/throwable/issue-categories/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).issue_category;
 }

--- a/throwable/issue-categories/update.ts
+++ b/throwable/issue-categories/update.ts
@@ -29,5 +29,5 @@ export async function update(
       issue_category: parse(toUpdateIssueCategoryQuery, issueCategory),
     }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/issue-relations/create.ts
+++ b/throwable/issue-relations/create.ts
@@ -24,7 +24,7 @@ export async function create(
     `${issueId}`,
     "relations.json",
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/issue-relations/delete.ts
+++ b/throwable/issue-relations/delete.ts
@@ -14,7 +14,7 @@ export async function deleteRelation(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "relations", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/issue-relations/list.ts
+++ b/throwable/issue-relations/list.ts
@@ -34,6 +34,6 @@ export async function fetchList(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).relations;
 }

--- a/throwable/issue-relations/show.ts
+++ b/throwable/issue-relations/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).relation;
 }

--- a/throwable/issue-statuses/list.ts
+++ b/throwable/issue-statuses/list.ts
@@ -23,6 +23,6 @@ export async function fetchList(context: Context): Promise<IssueStatus[]> {
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listIssueStatusResponse, await response.json()).issue_statuses;
 }

--- a/throwable/issue-templates/list.ts
+++ b/throwable/issue-templates/list.ts
@@ -30,6 +30,6 @@ export async function list(
       },
     },
   );
-  assertResponse(r);
+  await assertResponse(r);
   return parse(issueTemplateResponse, await r.json());
 }

--- a/throwable/issues/add-watcher.ts
+++ b/throwable/issues/add-watcher.ts
@@ -28,5 +28,5 @@ export async function addWatcher(
     },
     body: JSON.stringify({ user_id: userId }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/issues/create.ts
+++ b/throwable/issues/create.ts
@@ -24,5 +24,5 @@ export async function createIssue(
     },
     body: JSON.stringify(parse(toCreateRequest, issue)),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/issues/delete.ts
+++ b/throwable/issues/delete.ts
@@ -13,7 +13,7 @@ export async function deleteIssue(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "issues", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/issues/list.ts
+++ b/throwable/issues/list.ts
@@ -28,7 +28,7 @@ export async function listIssues(
       ...convertedOption,
     }).toString();
     const response = await fetch(endpoint, opts);
-    assertResponse(response);
+    await assertResponse(response);
     const json = await response.json();
     return parse(listResponse, json).issues;
   };
@@ -77,6 +77,6 @@ async function fetchNumberOfIssues(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listResponse, await response.json()).totalCount;
 }

--- a/throwable/issues/remove-watcher.ts
+++ b/throwable/issues/remove-watcher.ts
@@ -21,7 +21,7 @@ export async function removeWatcher(
     "watchers",
     `${userId}.json`,
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/issues/show.ts
+++ b/throwable/issues/show.ts
@@ -31,6 +31,6 @@ export async function show(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(showIssueSchema, await response.json()).issue;
 }

--- a/throwable/issues/update.ts
+++ b/throwable/issues/update.ts
@@ -19,5 +19,5 @@ export async function update(
     },
     body: JSON.stringify({ issue: parse(toUpdateRequest, issue) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/memberships/create.ts
+++ b/throwable/memberships/create.ts
@@ -24,7 +24,7 @@ export async function create(
     `${projectId}`,
     "memberships.json",
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/memberships/delete.ts
+++ b/throwable/memberships/delete.ts
@@ -14,7 +14,7 @@ export async function deleteMembership(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "memberships", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/memberships/list.ts
+++ b/throwable/memberships/list.ts
@@ -46,7 +46,7 @@ export async function fetchList(
       offset: `${offset}`,
     }).toString();
     const response = await fetch(url, opts);
-    assertResponse(response);
+    await assertResponse(response);
     return parse(responseSchema, await response.json());
   };
 

--- a/throwable/memberships/show.ts
+++ b/throwable/memberships/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).membership;
 }

--- a/throwable/memberships/update.ts
+++ b/throwable/memberships/update.ts
@@ -29,5 +29,5 @@ export async function update(
       membership: parse(toUpdateMembershipQuery, membership),
     }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/my-account/show.ts
+++ b/throwable/my-account/show.ts
@@ -28,6 +28,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).user;
 }

--- a/throwable/my-account/update.ts
+++ b/throwable/my-account/update.ts
@@ -25,5 +25,5 @@ export async function update(
     },
     body: JSON.stringify({ user: parse(toUpdateMyAccountQuery, account) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/news/list-by-project.ts
+++ b/throwable/news/list-by-project.ts
@@ -32,6 +32,6 @@ export async function fetchListByProject(
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listNewsResponse, await response.json()).news;
 }

--- a/throwable/news/list.ts
+++ b/throwable/news/list.ts
@@ -23,6 +23,6 @@ export async function fetchList(context: Context): Promise<News[]> {
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listNewsResponse, await response.json()).news;
 }

--- a/throwable/projects/archive.ts
+++ b/throwable/projects/archive.ts
@@ -15,7 +15,7 @@ async function internal(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
 }
 
 export async function archive(context: Context, id: number): Promise<void> {

--- a/throwable/projects/create.ts
+++ b/throwable/projects/create.ts
@@ -10,7 +10,7 @@ export async function create(
   project: ProjectQuery,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "projects.json");
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/projects/delete.ts
+++ b/throwable/projects/delete.ts
@@ -7,7 +7,7 @@ export async function deleteProject(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "projects", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/projects/list.ts
+++ b/throwable/projects/list.ts
@@ -34,7 +34,7 @@ export async function fetchList(context: Context): Promise<Project[]> {
   const responses = await Promise.all(promises);
   const results: Project[][] = [];
   for (const response of responses) {
-    assertResponse(response);
+    await assertResponse(response);
     results.push(parse(responseSchema, await response.json()).projects);
   }
   return results.flat();
@@ -54,6 +54,6 @@ async function fetchNumberOfProjects(context: Context): Promise<number> {
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).total_count;
 }

--- a/throwable/projects/show.ts
+++ b/throwable/projects/show.ts
@@ -22,6 +22,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).project;
 }

--- a/throwable/projects/update.ts
+++ b/throwable/projects/update.ts
@@ -23,5 +23,5 @@ export async function update(
     },
     body: JSON.stringify({ project: parse(toProjectUpdateQuery, project) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/queries/list.ts
+++ b/throwable/queries/list.ts
@@ -23,6 +23,6 @@ export async function fetchList(context: Context): Promise<Query[]> {
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listQueryResponse, await response.json()).queries;
 }

--- a/throwable/roles/list.ts
+++ b/throwable/roles/list.ts
@@ -21,6 +21,6 @@ export async function fetchList(context: Context): Promise<IdName[]> {
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(roleListResponse, await response.json()).roles;
 }

--- a/throwable/roles/show.ts
+++ b/throwable/roles/show.ts
@@ -26,6 +26,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(roleShowResponse, await response.json()).role;
 }

--- a/throwable/search/search.ts
+++ b/throwable/search/search.ts
@@ -46,7 +46,7 @@ export async function search(
   const responses = await Promise.all(promises);
   const results: SearchResult[][] = [];
   for (const response of responses) {
-    assertResponse(response);
+    await assertResponse(response);
     results.push(parse(responseSchema, await response.json()).results);
   }
   return results.flat();
@@ -64,6 +64,6 @@ async function fetchNumberOfResults(
   endpoint.search = params.toString();
 
   const response = await fetch(endpoint, opts);
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).total_count;
 }

--- a/throwable/time-entries/create.ts
+++ b/throwable/time-entries/create.ts
@@ -17,7 +17,7 @@ export async function create(
   timeEntry: CreateTimeEntryQuery,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "time_entries.json");
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/time-entries/delete.ts
+++ b/throwable/time-entries/delete.ts
@@ -14,7 +14,7 @@ export async function deleteTimeEntry(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "time_entries", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/time-entries/list.ts
+++ b/throwable/time-entries/list.ts
@@ -47,7 +47,7 @@ export async function fetchList(
   const responses = await Promise.all(promises);
   const results: TimeEntry[][] = [];
   for (const response of responses) {
-    assertResponse(response);
+    await assertResponse(response);
     results.push(parse(responseSchema, await response.json()).time_entries);
   }
   return results.flat();
@@ -71,6 +71,6 @@ async function fetchNumberOfTimeEntries(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).total_count;
 }

--- a/throwable/time-entries/show.ts
+++ b/throwable/time-entries/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).time_entry;
 }

--- a/throwable/time-entries/update.ts
+++ b/throwable/time-entries/update.ts
@@ -29,5 +29,5 @@ export async function update(
       time_entry: parse(toUpdateTimeEntryQuery, timeEntry),
     }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/trackers/list.ts
+++ b/throwable/trackers/list.ts
@@ -23,6 +23,6 @@ export async function fetchList(context: Context): Promise<Tracker[]> {
       },
     },
   );
-  assertResponse(response);
+  await assertResponse(response);
   return parse(listTrackerResponse, await response.json()).trackers;
 }

--- a/throwable/users/create.ts
+++ b/throwable/users/create.ts
@@ -17,7 +17,7 @@ export async function create(
   user: CreateUserQuery,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "users.json");
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/users/delete.ts
+++ b/throwable/users/delete.ts
@@ -14,7 +14,7 @@ export async function deleteUser(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "users", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/users/list.ts
+++ b/throwable/users/list.ts
@@ -41,7 +41,7 @@ export async function fetchList(context: Context): Promise<User[]> {
   const responses = await Promise.all(promises);
   const results: User[][] = [];
   for (const response of responses) {
-    assertResponse(response);
+    await assertResponse(response);
     results.push(parse(responseSchema, await response.json()).users);
   }
   return results.flat();
@@ -61,6 +61,6 @@ async function fetchNumberOfUsers(context: Context): Promise<number> {
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).total_count;
 }

--- a/throwable/users/show.ts
+++ b/throwable/users/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).user;
 }

--- a/throwable/users/update.ts
+++ b/throwable/users/update.ts
@@ -27,5 +27,5 @@ export async function update(
     },
     body: JSON.stringify({ user: parse(toUpdateUserQuery, user) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/versions/create.ts
+++ b/throwable/versions/create.ts
@@ -24,7 +24,7 @@ export async function create(
     `${projectId}`,
     "versions.json",
   );
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "POST",
       headers: {

--- a/throwable/versions/delete.ts
+++ b/throwable/versions/delete.ts
@@ -14,7 +14,7 @@ export async function deleteVersion(
   id: number,
 ): Promise<void> {
   const url = buildUrl(context.endpoint, "versions", `${id}.json`);
-  assertResponse(
+  await assertResponse(
     await fetch(url, {
       method: "DELETE",
       headers: {

--- a/throwable/versions/list.ts
+++ b/throwable/versions/list.ts
@@ -38,6 +38,6 @@ export async function fetchList(
       "X-Redmine-API-Key": context.apiKey,
     },
   });
-  assertResponse(response);
+  await assertResponse(response);
   return parse(responseSchema, await response.json()).versions;
 }

--- a/throwable/versions/show.ts
+++ b/throwable/versions/show.ts
@@ -30,6 +30,6 @@ export async function show(
     },
   });
 
-  assertResponse(response);
+  await assertResponse(response);
   return parse(schema, await response.json()).version;
 }

--- a/throwable/versions/update.ts
+++ b/throwable/versions/update.ts
@@ -27,5 +27,5 @@ export async function update(
     },
     body: JSON.stringify({ version: parse(toUpdateVersionQuery, version) }),
   });
-  assertResponse(response);
+  await assertResponse(response);
 }

--- a/throwable/wiki-pages/create.ts
+++ b/throwable/wiki-pages/create.ts
@@ -33,5 +33,5 @@ export async function create(
     "wiki",
     `${sanitizeTitle(wiki.title)}.json`,
   );
-  assertResponse(await fetch(url, opts));
+  await assertResponse(await fetch(url, opts));
 }

--- a/throwable/wiki-pages/delete.ts
+++ b/throwable/wiki-pages/delete.ts
@@ -30,5 +30,5 @@ export async function deleteWiki(
     "wiki",
     `${sanitizeTitle(title)}.json`,
   );
-  assertResponse(await fetch(url, opts));
+  await assertResponse(await fetch(url, opts));
 }

--- a/throwable/wiki-pages/list.ts
+++ b/throwable/wiki-pages/list.ts
@@ -33,6 +33,6 @@ export async function fetchList(
   );
 
   const r = await fetch(url, opts);
-  assertResponse(r);
+  await assertResponse(r);
   return parse(wikis, await r.json());
 }

--- a/throwable/wiki-pages/show.ts
+++ b/throwable/wiki-pages/show.ts
@@ -45,6 +45,6 @@ export async function show(
     );
 
   const r = await fetch(url, opts);
-  assertResponse(r);
+  await assertResponse(r);
   return parse(wikiDetail, await r.json());
 }


### PR DESCRIPTION
## Summary

Redmine API errors now carry the HTTP status code and raw response body as typed fields on an importable error type.

## Details

The thrown error previously kept only the `Response` in `cause`, which nothing read and which left the body unconsumed, so callers could not inspect the status or body of a failed request.

The error is renamed from `UnprocessableEntityError` to `RedmineResponseError` since it wraps every non-ok response, not only 422, and it now exposes typed `status` / `statusText` / `body` populated eagerly; reading the body also drains the connection, freeing `cause` for genuine error chaining.

Because the body read is async, `assertResponse` becomes async and every throwable call site awaits it, and `./error` is published so consumers can narrow a caught error with `instanceof` and read the fields.

## Confirmation

Ran `nix run .#check-deno` (fmt, lint, type-check, tests): 39 unit tests pass, including new `error.test.ts` coverage for `fromResponse` and `assertResponse`.

## Limitation

The error path body is now consumed, but void mutations and other resource-leak sites remain; e2e still uses `sanitizeResources: false` pending a separate cross-cutting request-helper change.

Generated with: Claude

https://claude.ai/code/session_01NYXQ42B1p55X1NvLenU2yp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured response errors containing HTTP status, status text, and response body.
  * Exposed the response error utilities for direct use.
* **Bug Fixes**
  * Improved handling of failed requests, including unreadable response bodies.
  * Ensured API operations complete response validation before parsing results or returning.
* **Tests**
  * Added coverage for successful responses, error details, fallback behavior, and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->