### PR TITLE
test: drop low-value typeof assertions in e2e tests

### DIFF
--- a/e2e/custom-fields.test.ts
+++ b/e2e/custom-fields.test.ts
@@ -9,12 +9,6 @@ Deno.test("E2E: Custom Fields API", async (t) => {
       const result = await fetchList(e2eContext);
       assert(result.isOk());
       assert(Array.isArray(result.value));
-      for (const customField of result.value) {
-        assert(typeof customField.id === "number");
-        assert(typeof customField.name === "string");
-        assert(typeof customField.customizedType === "string");
-        assert(typeof customField.fieldFormat === "string");
-      }
       // e2e/setup.ts seeds an "E2E CF" issue custom field, so the list is
       // non-empty and contains it.
       const seeded = result.value.find((cf) => cf.name === "E2E CF");

--- a/e2e/enumerations.test.ts
+++ b/e2e/enumerations.test.ts
@@ -8,20 +8,14 @@ import {
 
 Deno.test("E2E: Enumerations API", async (t) => {
   // The e2e Redmine is provisioned without loading Redmine's default data, so
-  // these enumeration listings can be empty; assert the shape and only inspect
-  // fields when an entry actually exists.
+  // these enumeration listings can be empty; a successful parse already
+  // proves the response matches the schema regardless of length.
   await t.step(
     "GET /enumerations/issue_priorities.json should return an array",
     async () => {
       const result = await listIssuePriorities(e2eContext);
       assert(result.isOk());
       assert(Array.isArray(result.value));
-      if (result.value.length > 0) {
-        assert(typeof result.value[0].id === "number");
-        assert(typeof result.value[0].name === "string");
-        assert(typeof result.value[0].isDefault === "boolean");
-        assert(typeof result.value[0].active === "boolean");
-      }
     },
   );
 
@@ -31,12 +25,6 @@ Deno.test("E2E: Enumerations API", async (t) => {
       const result = await listTimeEntryActivities(e2eContext);
       assert(result.isOk());
       assert(Array.isArray(result.value));
-      if (result.value.length > 0) {
-        assert(typeof result.value[0].id === "number");
-        assert(typeof result.value[0].name === "string");
-        assert(typeof result.value[0].isDefault === "boolean");
-        assert(typeof result.value[0].active === "boolean");
-      }
     },
   );
 
@@ -46,12 +34,6 @@ Deno.test("E2E: Enumerations API", async (t) => {
       const result = await listDocumentCategories(e2eContext);
       assert(result.isOk());
       assert(Array.isArray(result.value));
-      if (result.value.length > 0) {
-        assert(typeof result.value[0].id === "number");
-        assert(typeof result.value[0].name === "string");
-        assert(typeof result.value[0].isDefault === "boolean");
-        assert(typeof result.value[0].active === "boolean");
-      }
     },
   );
 });

--- a/e2e/issue-statuses.test.ts
+++ b/e2e/issue-statuses.test.ts
@@ -12,9 +12,6 @@ Deno.test("E2E: Issue Statuses API", async (t) => {
         result.value.length > 0,
         "Redmine should have default issue statuses",
       );
-      assert(typeof result.value[0].id === "number");
-      assert(typeof result.value[0].name === "string");
-      assert(typeof result.value[0].isClosed === "boolean");
     },
   );
 });

--- a/e2e/issue-templates.test.ts
+++ b/e2e/issue-templates.test.ts
@@ -20,7 +20,6 @@ Deno.test({
           result.value;
 
         assertEquals(issueTemplates.length, 1);
-        assert(typeof issueTemplates[0].id === "number");
         assertEquals(issueTemplates[0].title, "E2E Bug Template");
         assertEquals(issueTemplates[0].issueTitle, "Bug: ");
         assertEquals(issueTemplates[0].description, "Template for bug reports");
@@ -30,7 +29,6 @@ Deno.test({
         assert(issueTemplates[0].updatedOn instanceof Date);
 
         assertEquals(globalIssueTemplates.length, 1);
-        assert(typeof globalIssueTemplates[0].id === "number");
         assertEquals(globalIssueTemplates[0].title, "E2E Global Template");
         assertEquals(globalIssueTemplates[0].issueTitle, "Global: ");
         assertEquals(

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -25,7 +25,6 @@ Deno.test({
       const result = await show(e2eContext, issueId);
       assert(result.isOk());
       assertEquals(result.value.id, issueId);
-      assert(typeof result.value.subject === "string");
       assert(result.value.project !== undefined);
       assert(result.value.tracker !== undefined);
       assert(result.value.status !== undefined);

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -16,8 +16,9 @@ Deno.test({
         async () => {
           const result = await show(e2eContext);
           assert(result.isOk());
-          assert(typeof result.value.login === "string");
-          assert(typeof result.value.mail === "string");
+          // e2e/setup.ts authenticates as the "admin" user, so the account
+          // returned here is always that user.
+          assertEquals(result.value.login, "admin");
         },
       );
 

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -25,8 +25,6 @@ Deno.test({
       const result = await show(e2eContext, projectId);
       assert(result.isOk());
       assertEquals(result.value.id, projectId);
-      assert(typeof result.value.name === "string");
-      assert(typeof result.value.identifier === "string");
     });
 
     await t.step("POST /projects.json should create a project", async () => {

--- a/e2e/queries.test.ts
+++ b/e2e/queries.test.ts
@@ -8,14 +8,10 @@ Deno.test("E2E: Queries API", async (t) => {
     async () => {
       const result = await fetchList(e2eContext);
       assert(result.isOk());
-      assert(Array.isArray(result.value));
       // Saved queries are user-created, so a freshly provisioned Redmine has
-      // none; assert the shape and only inspect fields when one exists.
-      if (result.value.length > 0) {
-        assert(typeof result.value[0].id === "number");
-        assert(typeof result.value[0].name === "string");
-        assert(typeof result.value[0].isPublic === "boolean");
-      }
+      // none; a successful parse already proves the response matches the
+      // schema regardless of length.
+      assert(Array.isArray(result.value));
     },
   );
 });

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -12,10 +12,6 @@ Deno.test({
         const result = await fetchList(e2eContext);
         assert(result.isOk());
         assert(Array.isArray(result.value));
-        for (const role of result.value) {
-          assert(typeof role.id === "number");
-          assert(typeof role.name === "string");
-        }
       },
     );
 
@@ -37,10 +33,6 @@ Deno.test({
         assert(result.isOk());
         assert(result.value.id === role.id);
         assert(result.value.name === role.name);
-        assert(typeof result.value.assignable === "boolean");
-        assert(typeof result.value.issuesVisibility === "string");
-        assert(typeof result.value.timeEntriesVisibility === "string");
-        assert(typeof result.value.usersVisibility === "string");
         assert(Array.isArray(result.value.permissions));
       },
     );

--- a/e2e/search.test.ts
+++ b/e2e/search.test.ts
@@ -14,8 +14,6 @@ Deno.test({
         assert(result.isOk());
         assert(Array.isArray(result.value));
         for (const item of result.value) {
-          assert(typeof item.id === "number");
-          assert(typeof item.type === "string");
           assert(item.datetime instanceof Date);
         }
       },

--- a/e2e/trackers.test.ts
+++ b/e2e/trackers.test.ts
@@ -9,8 +9,6 @@ Deno.test("E2E: Trackers API", async (t) => {
       const result = await fetchList(e2eContext);
       assert(result.isOk());
       assert(result.value.length > 0, "Redmine should have default trackers");
-      assert(typeof result.value[0].id === "number");
-      assert(typeof result.value[0].name === "string");
     },
   );
 });

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -58,7 +58,7 @@ Deno.test({
         const result = await show(e2eContext, projectId, "E2ECreatedPage");
         assert(result.isOk());
         assertEquals(result.value.title, "E2ECreatedPage");
-        assert(typeof result.value.text === "string");
+        assertEquals(result.value.text, "Created by E2E test");
         assert(result.value.version >= 1);
       },
     );


### PR DESCRIPTION
## Summary

Remove `assert(typeof x === "...")` chains from e2e tests where the shape is already proven by `isOk()` (valibot `parse` success) plus TypeScript's static types.

## Details

Per the design memo `.momomo/tasks/test-typeof-assertions.md`. 40 typeof assertions across 12 e2e files were removed (38) or converted to value assertions (2: the created wiki page text; the authenticated account login, always `admin` per `e2e/setup.ts`). Round-trip, transform-logic, and seeded-data assertions are untouched. Test-only; no production changes.

## Confirmation

`nix run .#check-deno` green (85 tests / 266 steps / 0 failed). Full e2e suite run locally against a live Redmine: 23 passed (79 steps), 0 failed.

## Limitation

Some e2e files still enumerate seeded fields individually where that carries real signal beyond schema shape; left as-is.

Generated with: Claude

https://claude.ai/code/session_01NYXQ42B1p55X1NvLenU2yp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined end-to-end API coverage to focus on response success, expected collections, seeded records, and meaningful field values.
  * Strengthened checks for authenticated account details, issue relationships, custom field formatting, and wiki page content.
  * Reduced brittle assertions based solely on runtime property types while retaining response schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->