### PR TITLE
test: drop obsolete sanitizeResources:false from e2e tests

### DIFF
--- a/e2e/attachments.test.ts
+++ b/e2e/attachments.test.ts
@@ -86,9 +86,6 @@ async function findAttachmentId(issueId: number): Promise<number | undefined> {
 
 Deno.test({
   name: "E2E: Attachments API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const issueId = await findSeededIssueId();
     if (issueId === undefined) {

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -7,9 +7,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Files API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/groups.test.ts
+++ b/e2e/groups.test.ts
@@ -28,9 +28,6 @@ async function currentUserId(): Promise<number | undefined> {
 
 Deno.test({
   name: "E2E: Groups API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     // A unique name avoids clashing with groups left over from prior runs.
     const groupName = `E2E Group ${Date.now()}`;

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -9,9 +9,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Categories API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -9,9 +9,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Relations API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/issue-templates.test.ts
+++ b/e2e/issue-templates.test.ts
@@ -4,7 +4,6 @@ import { list } from "../result/issue-templates/list.ts";
 
 Deno.test({
   name: "E2E: Issue Templates API",
-  sanitizeResources: false,
   fn: async (t) => {
     await t.step(
       "GET /projects/:id/issue_templates.json should return templates",

--- a/e2e/issue-watchers.test.ts
+++ b/e2e/issue-watchers.test.ts
@@ -21,9 +21,6 @@ async function fetchCurrentUserId(): Promise<number | undefined> {
 
 Deno.test({
   name: "E2E: Issue watchers API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const issuesResult = await listIssues(e2eContext, { limit: 1 });
     assert(issuesResult.isOk());

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -9,9 +9,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Issues API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     await t.step("GET /issues.json should return issues", async () => {
       const result = await listIssues(e2eContext, {});

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -42,9 +42,6 @@ async function fetchFirstRoleId(): Promise<number | undefined> {
 
 Deno.test({
   name: "E2E: Memberships API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -5,9 +5,6 @@ import { update } from "../result/my-account/update.ts";
 
 Deno.test({
   name: "E2E: My Account API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const initialResult = await show(e2eContext);
     assert(initialResult.isOk());

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -6,9 +6,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: News API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -9,9 +9,6 @@ import { archive, unarchive } from "../result/projects/archive.ts";
 
 Deno.test({
   name: "E2E: Projects API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     await t.step("GET /projects.json should return projects", async () => {
       const result = await fetchList(e2eContext);

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -5,9 +5,6 @@ import { show } from "../result/roles/show.ts";
 
 Deno.test({
   name: "E2E: Roles API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     await t.step(
       "GET /roles.json should return a list of roles",

--- a/e2e/search.test.ts
+++ b/e2e/search.test.ts
@@ -4,9 +4,6 @@ import { search } from "../result/search/search.ts";
 
 Deno.test({
   name: "E2E: Search API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     await t.step(
       "GET /search.json should return an array of results",

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -10,9 +10,6 @@ import { listIssues } from "../result/issues/list.ts";
 
 Deno.test({
   name: "E2E: Time Entries API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/users.test.ts
+++ b/e2e/users.test.ts
@@ -8,9 +8,6 @@ import { deleteUser } from "../result/users/delete.ts";
 
 Deno.test({
   name: "E2E: Users API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     // Unique per run so repeated E2E executions never collide on login/mail.
     const unique = Date.now();

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -9,9 +9,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Versions API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
     assert(projectsResult.isOk());

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -8,9 +8,6 @@ import { fetchList as fetchProjects } from "../result/projects/list.ts";
 
 Deno.test({
   name: "E2E: Wiki Pages API",
-  // Library functions may not fully consume fetch response bodies, triggering
-  // Deno's resource sanitizer as a false positive.
-  sanitizeResources: false,
   fn: async (t) => {
     let projectId: number;
 


### PR DESCRIPTION
## Summary

Remove the `sanitizeResources: false` workaround (and its "false positive" comment) from all e2e test files.

## Details

The option dates from Deno 1.x, whose resource sanitizer flagged unconsumed fetch response bodies. Deno 2.x no longer tracks those resources at all, so the option suppresses a warning that can no longer fire — it is dead config.

Verified empirically with the flake-pinned `deno 2.8.0` (same as CI): under the default sanitizer, both a deliberately leaked open file and an unconsumed fetch body pass without a leak report. The full e2e suite also stays green with the option removed and no body-draining changes.

This supersedes the earlier request-helper approach on this branch: since the sanitizer no longer reports these leaks, no request helper or body-draining is needed — only the removal of the dead workaround.

## Confirmation

`nix run .#check-deno` green (85 tests / 266 steps / 0 failed). Full e2e suite run locally against a live Redmine with the default sanitizer active: 23 passed (79 steps), 0 failed.

## Limitation

If a genuine per-request resource concern resurfaces under a future Deno, it would need separate handling; this PR only removes config that currently does nothing.

Generated with: Claude

https://claude.ai/code/session_01NYXQ42B1p55X1NvLenU2yp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end test suites to use default resource-sanitization behavior.
  - Existing API test coverage and assertions remain unchanged.
  - Improved detection of resource-handling issues during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->