### PR TITLE
test: use expect instead of std/assert in tests

### DIFF
--- a/e2e/attachments.test.ts
+++ b/e2e/attachments.test.ts
@@ -116,10 +116,13 @@ Deno.test({
       async () => {
         const result = await show(e2eContext, attachmentId);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id).toEqual(attachmentId);
-        expect(result._unsafeUnwrap().filename).toEqual("e2e-attachment.txt");
-        expect(result._unsafeUnwrap().contentType).toEqual("text/plain");
-        expect(result._unsafeUnwrap().author !== undefined).toBe(true);
+        const attachment = result._unsafeUnwrap();
+        expect(attachment.id).toStrictEqual(attachmentId);
+        expect(attachment.filename).toStrictEqual(
+          "e2e-attachment.txt",
+        );
+        expect(attachment.contentType).toStrictEqual("text/plain");
+        expect(attachment.author).toBeDefined();
       },
     );
 
@@ -133,7 +136,7 @@ Deno.test({
 
         const showResult = await show(e2eContext, attachmentId);
         expect(showResult.isOk()).toBe(true);
-        expect(showResult._unsafeUnwrap().description).toEqual(
+        expect(showResult._unsafeUnwrap().description).toStrictEqual(
           "Updated by E2E test",
         );
       },

--- a/e2e/attachments.test.ts
+++ b/e2e/attachments.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { show } from "../result/attachments/show.ts";
 import { update } from "../result/attachments/update.ts";
@@ -115,11 +115,11 @@ Deno.test({
       "GET /attachments/:id.json should return an attachment",
       async () => {
         const result = await show(e2eContext, attachmentId);
-        assert(result.isOk());
-        assertEquals(result.value.id, attachmentId);
-        assertEquals(result.value.filename, "e2e-attachment.txt");
-        assertEquals(result.value.contentType, "text/plain");
-        assert(result.value.author !== undefined);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id).toEqual(attachmentId);
+        expect(result._unsafeUnwrap().filename).toEqual("e2e-attachment.txt");
+        expect(result._unsafeUnwrap().contentType).toEqual("text/plain");
+        expect(result._unsafeUnwrap().author !== undefined).toBe(true);
       },
     );
 
@@ -129,11 +129,13 @@ Deno.test({
         const result = await update(e2eContext, attachmentId, {
           description: "Updated by E2E test",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const showResult = await show(e2eContext, attachmentId);
-        assert(showResult.isOk());
-        assertEquals(showResult.value.description, "Updated by E2E test");
+        expect(showResult.isOk()).toBe(true);
+        expect(showResult._unsafeUnwrap().description).toEqual(
+          "Updated by E2E test",
+        );
       },
     );
 
@@ -141,10 +143,10 @@ Deno.test({
       "DELETE /attachments/:id.json should delete an attachment",
       async () => {
         const result = await deleteAttachment(e2eContext, attachmentId);
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const showResult = await show(e2eContext, attachmentId);
-        assert(showResult.isErr());
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/custom-fields.test.ts
+++ b/e2e/custom-fields.test.ts
@@ -12,8 +12,8 @@ Deno.test("E2E: Custom Fields API", async (t) => {
       // e2e/setup.ts seeds an "E2E CF" issue custom field, so the list is
       // non-empty and contains it.
       const seeded = result._unsafeUnwrap().find((cf) => cf.name === "E2E CF");
-      expect(seeded !== undefined).toBe(true);
-      expect(seeded!.fieldFormat).toEqual("string");
+      expect(seeded).toBeDefined();
+      expect(seeded!.fieldFormat).toStrictEqual("string");
     },
   );
 });

--- a/e2e/custom-fields.test.ts
+++ b/e2e/custom-fields.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/custom-fields/list.ts";
 
@@ -7,13 +7,13 @@ Deno.test("E2E: Custom Fields API", async (t) => {
     "GET /custom_fields.json should return an array of custom fields",
     async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      assert(Array.isArray(result.value));
+      expect(result.isOk()).toBe(true);
+      expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
       // e2e/setup.ts seeds an "E2E CF" issue custom field, so the list is
       // non-empty and contains it.
-      const seeded = result.value.find((cf) => cf.name === "E2E CF");
-      assert(seeded !== undefined);
-      assertEquals(seeded.fieldFormat, "string");
+      const seeded = result._unsafeUnwrap().find((cf) => cf.name === "E2E CF");
+      expect(seeded !== undefined).toBe(true);
+      expect(seeded!.fieldFormat).toEqual("string");
     },
   );
 });

--- a/e2e/enumerations.test.ts
+++ b/e2e/enumerations.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import {
   listDocumentCategories,
@@ -14,8 +14,8 @@ Deno.test("E2E: Enumerations API", async (t) => {
     "GET /enumerations/issue_priorities.json should return an array",
     async () => {
       const result = await listIssuePriorities(e2eContext);
-      assert(result.isOk());
-      assert(Array.isArray(result.value));
+      expect(result.isOk()).toBe(true);
+      expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
     },
   );
 
@@ -23,8 +23,8 @@ Deno.test("E2E: Enumerations API", async (t) => {
     "GET /enumerations/time_entry_activities.json should return an array",
     async () => {
       const result = await listTimeEntryActivities(e2eContext);
-      assert(result.isOk());
-      assert(Array.isArray(result.value));
+      expect(result.isOk()).toBe(true);
+      expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
     },
   );
 
@@ -32,8 +32,8 @@ Deno.test("E2E: Enumerations API", async (t) => {
     "GET /enumerations/document_categories.json should return an array",
     async () => {
       const result = await listDocumentCategories(e2eContext);
-      assert(result.isOk());
-      assert(Array.isArray(result.value));
+      expect(result.isOk()).toBe(true);
+      expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
     },
   );
 });

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/files/list.ts";
 import { create } from "../result/files/create.ts";
@@ -9,11 +9,11 @@ Deno.test({
   name: "E2E: Files API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     const filename = "e2e-file.txt";
 
@@ -26,31 +26,33 @@ Deno.test({
           new TextEncoder().encode("e2e file content"),
           filename,
         );
-        assert(result.isOk());
-        token = result.value;
+        expect(result.isOk()).toBe(true);
+        token = result._unsafeUnwrap();
       },
     );
 
     await t.step(
       "POST /projects/:project_id/files.json should create a file",
       async () => {
-        assert(token !== undefined);
-        const result = await create(e2eContext, project.id, {
-          token,
+        expect(token !== undefined).toBe(true);
+        const result = await create(e2eContext, project!.id, {
+          token: token!,
           filename,
           description: "Created by E2E test",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "GET /projects/:project_id/files.json should return files",
       async () => {
-        const result = await fetchList(e2eContext, project.id);
-        assert(result.isOk());
-        const created = result.value.find((f) => f.filename === filename);
-        assert(created !== undefined);
+        const result = await fetchList(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
+        const created = result._unsafeUnwrap().find((f) =>
+          f.filename === filename
+        );
+        expect(created !== undefined).toBe(true);
       },
     );
   },

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -13,7 +13,7 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     const filename = "e2e-file.txt";
 
@@ -34,7 +34,7 @@ Deno.test({
     await t.step(
       "POST /projects/:project_id/files.json should create a file",
       async () => {
-        expect(token !== undefined).toBe(true);
+        expect(token).toBeDefined();
         const result = await create(e2eContext, project!.id, {
           token: token!,
           filename,
@@ -52,7 +52,7 @@ Deno.test({
         const created = result._unsafeUnwrap().find((f) =>
           f.filename === filename
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
       },
     );
   },

--- a/e2e/groups.test.ts
+++ b/e2e/groups.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/groups/list.ts";
 import { show } from "../result/groups/show.ts";
@@ -34,63 +34,63 @@ Deno.test({
 
     await t.step("POST /groups.json should create a group", async () => {
       const result = await create(e2eContext, { name: groupName });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
     });
 
     let groupId: number | undefined;
     await t.step("GET /groups.json should list the created group", async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      const created = result.value.find((g) => g.name === groupName);
-      assert(created !== undefined);
-      groupId = created.id;
+      expect(result.isOk()).toBe(true);
+      const created = result._unsafeUnwrap().find((g) => g.name === groupName);
+      expect(created !== undefined).toBe(true);
+      groupId = created!.id;
     });
 
     await t.step("GET /groups/:id.json should return the group", async () => {
-      assert(groupId !== undefined);
-      const result = await show(e2eContext, groupId);
-      assert(result.isOk());
-      assertEquals(result.value.id, groupId);
-      assertEquals(result.value.name, groupName);
+      expect(groupId !== undefined).toBe(true);
+      const result = await show(e2eContext, groupId!);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().id).toEqual(groupId);
+      expect(result._unsafeUnwrap().name).toEqual(groupName);
     });
 
     const updatedName = `${groupName} Updated`;
     await t.step("PUT /groups/:id.json should update the group", async () => {
-      assert(groupId !== undefined);
-      const result = await update(e2eContext, groupId, { name: updatedName });
-      assert(result.isOk());
+      expect(groupId !== undefined).toBe(true);
+      const result = await update(e2eContext, groupId!, { name: updatedName });
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, groupId);
-      assert(showResult.isOk());
-      assertEquals(showResult.value.name, updatedName);
+      const showResult = await show(e2eContext, groupId!);
+      expect(showResult.isOk()).toBe(true);
+      expect(showResult._unsafeUnwrap().name).toEqual(updatedName);
     });
 
     await t.step(
       "POST /groups/:id/users.json should add the current user",
       async () => {
-        assert(groupId !== undefined);
+        expect(groupId !== undefined).toBe(true);
         const userId = await currentUserId();
         // Skip gracefully when the current user cannot be resolved.
         if (userId === undefined) {
           return;
         }
-        const addResult = await addUser(e2eContext, groupId, userId);
-        assert(addResult.isOk());
+        const addResult = await addUser(e2eContext, groupId!, userId);
+        expect(addResult.isOk()).toBe(true);
 
-        const removeResult = await removeUser(e2eContext, groupId, userId);
-        assert(removeResult.isOk());
+        const removeResult = await removeUser(e2eContext, groupId!, userId);
+        expect(removeResult.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "DELETE /groups/:id.json should delete the group",
       async () => {
-        assert(groupId !== undefined);
-        const result = await deleteGroup(e2eContext, groupId);
-        assert(result.isOk());
+        expect(groupId !== undefined).toBe(true);
+        const result = await deleteGroup(e2eContext, groupId!);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, groupId);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, groupId!);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/groups.test.ts
+++ b/e2e/groups.test.ts
@@ -42,33 +42,33 @@ Deno.test({
       const result = await fetchList(e2eContext);
       expect(result.isOk()).toBe(true);
       const created = result._unsafeUnwrap().find((g) => g.name === groupName);
-      expect(created !== undefined).toBe(true);
+      expect(created).toBeDefined();
       groupId = created!.id;
     });
 
     await t.step("GET /groups/:id.json should return the group", async () => {
-      expect(groupId !== undefined).toBe(true);
+      expect(groupId).toBeDefined();
       const result = await show(e2eContext, groupId!);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().id).toEqual(groupId);
-      expect(result._unsafeUnwrap().name).toEqual(groupName);
+      expect(result._unsafeUnwrap().id).toStrictEqual(groupId);
+      expect(result._unsafeUnwrap().name).toStrictEqual(groupName);
     });
 
     const updatedName = `${groupName} Updated`;
     await t.step("PUT /groups/:id.json should update the group", async () => {
-      expect(groupId !== undefined).toBe(true);
+      expect(groupId).toBeDefined();
       const result = await update(e2eContext, groupId!, { name: updatedName });
       expect(result.isOk()).toBe(true);
 
       const showResult = await show(e2eContext, groupId!);
       expect(showResult.isOk()).toBe(true);
-      expect(showResult._unsafeUnwrap().name).toEqual(updatedName);
+      expect(showResult._unsafeUnwrap().name).toStrictEqual(updatedName);
     });
 
     await t.step(
       "POST /groups/:id/users.json should add the current user",
       async () => {
-        expect(groupId !== undefined).toBe(true);
+        expect(groupId).toBeDefined();
         const userId = await currentUserId();
         // Skip gracefully when the current user cannot be resolved.
         if (userId === undefined) {
@@ -85,7 +85,7 @@ Deno.test({
     await t.step(
       "DELETE /groups/:id.json should delete the group",
       async () => {
-        expect(groupId !== undefined).toBe(true);
+        expect(groupId).toBeDefined();
         const result = await deleteGroup(e2eContext, groupId!);
         expect(result.isOk()).toBe(true);
 

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -15,7 +15,7 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     await t.step(
       "POST /projects/:project_id/issue_categories.json should create an issue category",
@@ -32,11 +32,11 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext, project!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
         const created = result._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
       },
     );
 
@@ -48,13 +48,16 @@ Deno.test({
         const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        expect(category !== undefined).toBe(true);
+        expect(category).toBeDefined();
 
         const result = await show(e2eContext, category!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id).toEqual(category!.id);
-        expect(result._unsafeUnwrap().name).toEqual("E2E Created Category");
-        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
+        const shown = result._unsafeUnwrap();
+        expect(shown.id).toStrictEqual(category!.id);
+        expect(shown.name).toStrictEqual(
+          "E2E Created Category",
+        );
+        expect(shown.project).toBeDefined();
       },
     );
 
@@ -66,7 +69,7 @@ Deno.test({
         const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        expect(category !== undefined).toBe(true);
+        expect(category).toBeDefined();
 
         const result = await update(e2eContext, category!.id, {
           name: "E2E Updated Category",
@@ -75,7 +78,9 @@ Deno.test({
 
         const showResult = await show(e2eContext, category!.id);
         expect(showResult.isOk()).toBe(true);
-        expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Category");
+        expect(showResult._unsafeUnwrap().name).toStrictEqual(
+          "E2E Updated Category",
+        );
       },
     );
 
@@ -87,7 +92,7 @@ Deno.test({
         const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Updated Category"
         );
-        expect(category !== undefined).toBe(true);
+        expect(category).toBeDefined();
 
         const result = await deleteIssueCategory(e2eContext, category!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/issue-categories/list.ts";
 import { show } from "../result/issue-categories/show.ts";
@@ -11,89 +11,89 @@ Deno.test({
   name: "E2E: Issue Categories API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     await t.step(
       "POST /projects/:project_id/issue_categories.json should create an issue category",
       async () => {
-        const result = await create(e2eContext, project.id, {
+        const result = await create(e2eContext, project!.id, {
           name: "E2E Created Category",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "GET /projects/:project_id/issue_categories.json should return issue categories",
       async () => {
-        const result = await fetchList(e2eContext, project.id);
-        assert(result.isOk());
-        assert(result.value.length > 0);
-        const created = result.value.find((c) =>
+        const result = await fetchList(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        const created = result._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        assert(created !== undefined);
+        expect(created !== undefined).toBe(true);
       },
     );
 
     await t.step(
       "GET /issue_categories/:id.json should return an issue category",
       async () => {
-        const listResult = await fetchList(e2eContext, project.id);
-        assert(listResult.isOk());
-        const category = listResult.value.find((c) =>
+        const listResult = await fetchList(e2eContext, project!.id);
+        expect(listResult.isOk()).toBe(true);
+        const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        assert(category !== undefined);
+        expect(category !== undefined).toBe(true);
 
-        const result = await show(e2eContext, category.id);
-        assert(result.isOk());
-        assertEquals(result.value.id, category.id);
-        assertEquals(result.value.name, "E2E Created Category");
-        assert(result.value.project !== undefined);
+        const result = await show(e2eContext, category!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id).toEqual(category!.id);
+        expect(result._unsafeUnwrap().name).toEqual("E2E Created Category");
+        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
       },
     );
 
     await t.step(
       "PUT /issue_categories/:id.json should update an issue category",
       async () => {
-        const listResult = await fetchList(e2eContext, project.id);
-        assert(listResult.isOk());
-        const category = listResult.value.find((c) =>
+        const listResult = await fetchList(e2eContext, project!.id);
+        expect(listResult.isOk()).toBe(true);
+        const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Created Category"
         );
-        assert(category !== undefined);
+        expect(category !== undefined).toBe(true);
 
-        const result = await update(e2eContext, category.id, {
+        const result = await update(e2eContext, category!.id, {
           name: "E2E Updated Category",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, category.id);
-        assert(showResult.isOk());
-        assertEquals(showResult.value.name, "E2E Updated Category");
+        const showResult = await show(e2eContext, category!.id);
+        expect(showResult.isOk()).toBe(true);
+        expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Category");
       },
     );
 
     await t.step(
       "DELETE /issue_categories/:id.json should delete an issue category",
       async () => {
-        const listResult = await fetchList(e2eContext, project.id);
-        assert(listResult.isOk());
-        const category = listResult.value.find((c) =>
+        const listResult = await fetchList(e2eContext, project!.id);
+        expect(listResult.isOk()).toBe(true);
+        const category = listResult._unsafeUnwrap().find((c) =>
           c.name === "E2E Updated Category"
         );
-        assert(category !== undefined);
+        expect(category !== undefined).toBe(true);
 
-        const result = await deleteIssueCategory(e2eContext, category.id);
-        assert(result.isOk());
+        const result = await deleteIssueCategory(e2eContext, category!.id);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, category.id);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, category!.id);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -15,13 +15,13 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     const issuesResult = await listIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issuesResult.isOk()).toBe(true);
-    expect(issuesResult._unsafeUnwrap().length > 0).toBe(true);
+    expect(issuesResult._unsafeUnwrap().length).toBeGreaterThan(0);
     const firstIssue = issuesResult._unsafeUnwrap()[0];
 
     // A relation needs two distinct issues. Seed a second one via a raw POST
@@ -51,7 +51,7 @@ Deno.test({
       const created = await response.json() as { issue: { id: number } };
       secondIssueId = created.issue.id;
     }
-    expect(secondIssueId !== undefined).toBe(true);
+    expect(secondIssueId).toBeDefined();
     const targetIssueId = secondIssueId;
 
     await t.step(
@@ -73,8 +73,8 @@ Deno.test({
         const relation = result._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        expect(relation !== undefined).toBe(true);
-        expect(relation!.issueId).toEqual(firstIssue.id);
+        expect(relation).toBeDefined();
+        expect(relation!.issueId).toStrictEqual(firstIssue.id);
       },
     );
 
@@ -86,14 +86,15 @@ Deno.test({
         const relation = listResult._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        expect(relation !== undefined).toBe(true);
+        expect(relation).toBeDefined();
 
         const result = await show(e2eContext, relation!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id).toEqual(relation!.id);
-        expect(result._unsafeUnwrap().issueId).toEqual(firstIssue.id);
-        expect(result._unsafeUnwrap().issueToId).toEqual(targetIssueId);
-        expect(result._unsafeUnwrap().relationType).toEqual("relates");
+        const shown = result._unsafeUnwrap();
+        expect(shown.id).toStrictEqual(relation!.id);
+        expect(shown.issueId).toStrictEqual(firstIssue.id);
+        expect(shown.issueToId).toStrictEqual(targetIssueId);
+        expect(shown.relationType).toStrictEqual("relates");
       },
     );
 
@@ -105,7 +106,7 @@ Deno.test({
         const relation = listResult._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        expect(relation !== undefined).toBe(true);
+        expect(relation).toBeDefined();
 
         const result = await deleteRelation(e2eContext, relation!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/issue-relations/list.ts";
 import { show } from "../result/issue-relations/show.ts";
@@ -11,25 +11,25 @@ Deno.test({
   name: "E2E: Issue Relations API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     const issuesResult = await listIssues(e2eContext, {
-      projectId: project.id,
+      projectId: project!.id,
     });
-    assert(issuesResult.isOk());
-    assert(issuesResult.value.length > 0);
-    const firstIssue = issuesResult.value[0];
+    expect(issuesResult.isOk()).toBe(true);
+    expect(issuesResult._unsafeUnwrap().length > 0).toBe(true);
+    const firstIssue = issuesResult._unsafeUnwrap()[0];
 
     // A relation needs two distinct issues. Seed a second one via a raw POST
     // when the project has only one, reusing the first issue's tracker,
     // status and priority so the created issue is valid for this project.
-    let secondIssueId: number | undefined = issuesResult.value.find((i) =>
-      i.id !== firstIssue.id
-    )?.id;
+    let secondIssueId: number | undefined = issuesResult._unsafeUnwrap().find((
+      i,
+    ) => i.id !== firstIssue.id)?.id;
     if (secondIssueId === undefined) {
       const response = await fetch(`${e2eContext.endpoint}/issues.json`, {
         method: "POST",
@@ -39,7 +39,7 @@ Deno.test({
         },
         body: JSON.stringify({
           issue: {
-            project_id: project.id,
+            project_id: project!.id,
             tracker_id: firstIssue.tracker.id,
             status_id: firstIssue.status.id,
             priority_id: firstIssue.priority.id,
@@ -47,11 +47,11 @@ Deno.test({
           },
         }),
       });
-      assert(response.ok);
+      expect(response.ok).toBe(true);
       const created = await response.json() as { issue: { id: number } };
       secondIssueId = created.issue.id;
     }
-    assert(secondIssueId !== undefined);
+    expect(secondIssueId !== undefined).toBe(true);
     const targetIssueId = secondIssueId;
 
     await t.step(
@@ -61,7 +61,7 @@ Deno.test({
           issueToId: targetIssueId,
           relationType: "relates",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
@@ -69,12 +69,12 @@ Deno.test({
       "GET /issues/:issue_id/relations.json should return relations",
       async () => {
         const result = await fetchList(e2eContext, firstIssue.id);
-        assert(result.isOk());
-        const relation = result.value.find((r) =>
+        expect(result.isOk()).toBe(true);
+        const relation = result._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        assert(relation !== undefined);
-        assertEquals(relation.issueId, firstIssue.id);
+        expect(relation !== undefined).toBe(true);
+        expect(relation!.issueId).toEqual(firstIssue.id);
       },
     );
 
@@ -82,18 +82,18 @@ Deno.test({
       "GET /relations/:id.json should return a relation",
       async () => {
         const listResult = await fetchList(e2eContext, firstIssue.id);
-        assert(listResult.isOk());
-        const relation = listResult.value.find((r) =>
+        expect(listResult.isOk()).toBe(true);
+        const relation = listResult._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        assert(relation !== undefined);
+        expect(relation !== undefined).toBe(true);
 
-        const result = await show(e2eContext, relation.id);
-        assert(result.isOk());
-        assertEquals(result.value.id, relation.id);
-        assertEquals(result.value.issueId, firstIssue.id);
-        assertEquals(result.value.issueToId, targetIssueId);
-        assertEquals(result.value.relationType, "relates");
+        const result = await show(e2eContext, relation!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id).toEqual(relation!.id);
+        expect(result._unsafeUnwrap().issueId).toEqual(firstIssue.id);
+        expect(result._unsafeUnwrap().issueToId).toEqual(targetIssueId);
+        expect(result._unsafeUnwrap().relationType).toEqual("relates");
       },
     );
 
@@ -101,17 +101,17 @@ Deno.test({
       "DELETE /relations/:id.json should delete a relation",
       async () => {
         const listResult = await fetchList(e2eContext, firstIssue.id);
-        assert(listResult.isOk());
-        const relation = listResult.value.find((r) =>
+        expect(listResult.isOk()).toBe(true);
+        const relation = listResult._unsafeUnwrap().find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
-        assert(relation !== undefined);
+        expect(relation !== undefined).toBe(true);
 
-        const result = await deleteRelation(e2eContext, relation.id);
-        assert(result.isOk());
+        const result = await deleteRelation(e2eContext, relation!.id);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, relation.id);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, relation!.id);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/issue-statuses.test.ts
+++ b/e2e/issue-statuses.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/issue-statuses/list.ts";
 
@@ -7,11 +7,11 @@ Deno.test("E2E: Issue Statuses API", async (t) => {
     "GET /issue_statuses.json should return default issue statuses",
     async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      assert(
-        result.value.length > 0,
+      expect(result.isOk()).toBe(true);
+      expect(
+        result._unsafeUnwrap().length > 0,
         "Redmine should have default issue statuses",
-      );
+      ).toBe(true);
     },
   );
 });

--- a/e2e/issue-statuses.test.ts
+++ b/e2e/issue-statuses.test.ts
@@ -9,9 +9,9 @@ Deno.test("E2E: Issue Statuses API", async (t) => {
       const result = await fetchList(e2eContext);
       expect(result.isOk()).toBe(true);
       expect(
-        result._unsafeUnwrap().length > 0,
+        result._unsafeUnwrap().length,
         "Redmine should have default issue statuses",
-      ).toBe(true);
+      ).toBeGreaterThan(0);
     },
   );
 });

--- a/e2e/issue-templates.test.ts
+++ b/e2e/issue-templates.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { list } from "../result/issue-templates/list.ts";
 
@@ -17,30 +17,31 @@ Deno.test({
         }
 
         const { issueTemplates, globalIssueTemplates, inheritTemplates } =
-          result.value;
+          result._unsafeUnwrap();
 
-        assertEquals(issueTemplates.length, 1);
-        assertEquals(issueTemplates[0].title, "E2E Bug Template");
-        assertEquals(issueTemplates[0].issueTitle, "Bug: ");
-        assertEquals(issueTemplates[0].description, "Template for bug reports");
-        assertEquals(issueTemplates[0].enabled, true);
-        assertEquals(issueTemplates[0].trackerName, "Bug");
-        assert(issueTemplates[0].createdOn instanceof Date);
-        assert(issueTemplates[0].updatedOn instanceof Date);
+        expect(issueTemplates.length).toEqual(1);
+        expect(issueTemplates[0].title).toEqual("E2E Bug Template");
+        expect(issueTemplates[0].issueTitle).toEqual("Bug: ");
+        expect(issueTemplates[0].description).toEqual(
+          "Template for bug reports",
+        );
+        expect(issueTemplates[0].enabled).toEqual(true);
+        expect(issueTemplates[0].trackerName).toEqual("Bug");
+        expect(issueTemplates[0].createdOn instanceof Date).toBe(true);
+        expect(issueTemplates[0].updatedOn instanceof Date).toBe(true);
 
-        assertEquals(globalIssueTemplates.length, 1);
-        assertEquals(globalIssueTemplates[0].title, "E2E Global Template");
-        assertEquals(globalIssueTemplates[0].issueTitle, "Global: ");
-        assertEquals(
-          globalIssueTemplates[0].description,
+        expect(globalIssueTemplates.length).toEqual(1);
+        expect(globalIssueTemplates[0].title).toEqual("E2E Global Template");
+        expect(globalIssueTemplates[0].issueTitle).toEqual("Global: ");
+        expect(globalIssueTemplates[0].description).toEqual(
           "Global template description",
         );
-        assertEquals(globalIssueTemplates[0].enabled, true);
-        assertEquals(globalIssueTemplates[0].trackerName, "Bug");
-        assert(globalIssueTemplates[0].createdOn instanceof Date);
-        assert(globalIssueTemplates[0].updatedOn instanceof Date);
+        expect(globalIssueTemplates[0].enabled).toEqual(true);
+        expect(globalIssueTemplates[0].trackerName).toEqual("Bug");
+        expect(globalIssueTemplates[0].createdOn instanceof Date).toBe(true);
+        expect(globalIssueTemplates[0].updatedOn instanceof Date).toBe(true);
 
-        assertEquals(inheritTemplates.length, 0);
+        expect(inheritTemplates.length).toEqual(0);
       },
     );
   },

--- a/e2e/issue-templates.test.ts
+++ b/e2e/issue-templates.test.ts
@@ -19,29 +19,31 @@ Deno.test({
         const { issueTemplates, globalIssueTemplates, inheritTemplates } =
           result._unsafeUnwrap();
 
-        expect(issueTemplates.length).toEqual(1);
-        expect(issueTemplates[0].title).toEqual("E2E Bug Template");
-        expect(issueTemplates[0].issueTitle).toEqual("Bug: ");
-        expect(issueTemplates[0].description).toEqual(
+        expect(issueTemplates.length).toStrictEqual(1);
+        expect(issueTemplates[0].title).toStrictEqual("E2E Bug Template");
+        expect(issueTemplates[0].issueTitle).toStrictEqual("Bug: ");
+        expect(issueTemplates[0].description).toStrictEqual(
           "Template for bug reports",
         );
-        expect(issueTemplates[0].enabled).toEqual(true);
-        expect(issueTemplates[0].trackerName).toEqual("Bug");
-        expect(issueTemplates[0].createdOn instanceof Date).toBe(true);
-        expect(issueTemplates[0].updatedOn instanceof Date).toBe(true);
+        expect(issueTemplates[0].enabled).toStrictEqual(true);
+        expect(issueTemplates[0].trackerName).toStrictEqual("Bug");
+        expect(issueTemplates[0].createdOn).toBeInstanceOf(Date);
+        expect(issueTemplates[0].updatedOn).toBeInstanceOf(Date);
 
-        expect(globalIssueTemplates.length).toEqual(1);
-        expect(globalIssueTemplates[0].title).toEqual("E2E Global Template");
-        expect(globalIssueTemplates[0].issueTitle).toEqual("Global: ");
-        expect(globalIssueTemplates[0].description).toEqual(
+        expect(globalIssueTemplates.length).toStrictEqual(1);
+        expect(globalIssueTemplates[0].title).toStrictEqual(
+          "E2E Global Template",
+        );
+        expect(globalIssueTemplates[0].issueTitle).toStrictEqual("Global: ");
+        expect(globalIssueTemplates[0].description).toStrictEqual(
           "Global template description",
         );
-        expect(globalIssueTemplates[0].enabled).toEqual(true);
-        expect(globalIssueTemplates[0].trackerName).toEqual("Bug");
-        expect(globalIssueTemplates[0].createdOn instanceof Date).toBe(true);
-        expect(globalIssueTemplates[0].updatedOn instanceof Date).toBe(true);
+        expect(globalIssueTemplates[0].enabled).toStrictEqual(true);
+        expect(globalIssueTemplates[0].trackerName).toStrictEqual("Bug");
+        expect(globalIssueTemplates[0].createdOn).toBeInstanceOf(Date);
+        expect(globalIssueTemplates[0].updatedOn).toBeInstanceOf(Date);
 
-        expect(inheritTemplates.length).toEqual(0);
+        expect(inheritTemplates.length).toStrictEqual(0);
       },
     );
   },

--- a/e2e/issue-watchers.test.ts
+++ b/e2e/issue-watchers.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { listIssues } from "../result/issues/list.ts";
 import { addWatcher } from "../result/issues/add-watcher.ts";
@@ -23,8 +23,8 @@ Deno.test({
   name: "E2E: Issue watchers API",
   fn: async (t) => {
     const issuesResult = await listIssues(e2eContext, { limit: 1 });
-    assert(issuesResult.isOk());
-    const issue = issuesResult.value[0];
+    expect(issuesResult.isOk()).toBe(true);
+    const issue = issuesResult._unsafeUnwrap()[0];
     if (issue === undefined) {
       // Nothing to watch when the seeded project holds no issues.
       return;
@@ -39,7 +39,7 @@ Deno.test({
       "POST /issues/:id/watchers.json should add a watcher",
       async () => {
         const result = await addWatcher(e2eContext, issue.id, userId);
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
@@ -47,7 +47,7 @@ Deno.test({
       "DELETE /issues/:id/watchers/:user_id.json should remove a watcher",
       async () => {
         const result = await removeWatcher(e2eContext, issue.id, userId);
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
   },

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { listIssues } from "../result/issues/list.ts";
 import { show } from "../result/issues/show.ts";
@@ -12,48 +12,48 @@ Deno.test({
   fn: async (t) => {
     await t.step("GET /issues.json should return issues", async () => {
       const result = await listIssues(e2eContext, {});
-      assert(result.isOk());
-      assert(result.value.length > 0);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().length > 0).toBe(true);
     });
 
     await t.step("GET /issues/:id.json should return an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
-      assert(listResult.isOk());
-      assert(listResult.value.length > 0);
-      const issueId = listResult.value[0].id;
+      expect(listResult.isOk()).toBe(true);
+      expect(listResult._unsafeUnwrap().length > 0).toBe(true);
+      const issueId = listResult._unsafeUnwrap()[0].id;
 
       const result = await show(e2eContext, issueId);
-      assert(result.isOk());
-      assertEquals(result.value.id, issueId);
-      assert(result.value.project !== undefined);
-      assert(result.value.tracker !== undefined);
-      assert(result.value.status !== undefined);
-      assert(result.value.priority !== undefined);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().id).toEqual(issueId);
+      expect(result._unsafeUnwrap().project !== undefined).toBe(true);
+      expect(result._unsafeUnwrap().tracker !== undefined).toBe(true);
+      expect(result._unsafeUnwrap().status !== undefined).toBe(true);
+      expect(result._unsafeUnwrap().priority !== undefined).toBe(true);
     });
 
     await t.step("POST /issues.json should create an issue", async () => {
       const projectsResult = await fetchProjects(e2eContext);
-      assert(projectsResult.isOk());
-      const project = projectsResult.value.find((p) =>
+      expect(projectsResult.isOk()).toBe(true);
+      const project = projectsResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-test-project"
       );
-      assert(project !== undefined);
+      expect(project !== undefined).toBe(true);
 
       const issuesBefore = await listIssues(e2eContext, {
-        projectId: project.id,
+        projectId: project!.id,
       });
-      assert(issuesBefore.isOk());
-      assert(issuesBefore.value.length > 0);
+      expect(issuesBefore.isOk()).toBe(true);
+      expect(issuesBefore._unsafeUnwrap().length > 0).toBe(true);
 
       const result = await createIssue(e2eContext, {
-        projectId: project.id,
-        trackerId: issuesBefore.value[0].tracker.id,
-        statusId: issuesBefore.value[0].status.id,
-        priorityId: issuesBefore.value[0].priority.id,
+        projectId: project!.id,
+        trackerId: issuesBefore._unsafeUnwrap()[0].tracker.id,
+        statusId: issuesBefore._unsafeUnwrap()[0].status.id,
+        priorityId: issuesBefore._unsafeUnwrap()[0].priority.id,
         subject: "E2E Created Issue",
         description: "Created by E2E test",
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
     });
 
     await t.step(
@@ -66,133 +66,136 @@ Deno.test({
           `${e2eContext.endpoint}/custom_fields.json`,
           { headers: { "X-Redmine-API-Key": e2eContext.apiKey } },
         );
-        assert(customFieldsResponse.ok);
+        expect(customFieldsResponse.ok).toBe(true);
         const customFieldsData = await customFieldsResponse.json() as {
           custom_fields: { id: number; name: string }[];
         };
         const customField = customFieldsData.custom_fields.find(
           (f) => f.name === "E2E CF",
         );
-        assert(customField !== undefined);
+        expect(customField !== undefined).toBe(true);
 
         const projectsResult = await fetchProjects(e2eContext);
-        assert(projectsResult.isOk());
-        const project = projectsResult.value.find((p) =>
+        expect(projectsResult.isOk()).toBe(true);
+        const project = projectsResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-test-project"
         );
-        assert(project !== undefined);
+        expect(project !== undefined).toBe(true);
 
         const issuesBefore = await listIssues(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(issuesBefore.isOk());
-        assert(issuesBefore.value.length > 0);
+        expect(issuesBefore.isOk()).toBe(true);
+        expect(issuesBefore._unsafeUnwrap().length > 0).toBe(true);
 
         const subject = "E2E Issue With Custom Field";
         const result = await createIssue(e2eContext, {
-          projectId: project.id,
-          trackerId: issuesBefore.value[0].tracker.id,
-          statusId: issuesBefore.value[0].status.id,
-          priorityId: issuesBefore.value[0].priority.id,
+          projectId: project!.id,
+          trackerId: issuesBefore._unsafeUnwrap()[0].tracker.id,
+          statusId: issuesBefore._unsafeUnwrap()[0].status.id,
+          priorityId: issuesBefore._unsafeUnwrap()[0].priority.id,
           subject,
-          customFields: [{ id: customField.id, value: "e2e custom value" }],
+          customFields: [{ id: customField!.id, value: "e2e custom value" }],
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const listAfter = await listIssues(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(listAfter.isOk());
-        const created = listAfter.value.find((i) => i.subject === subject);
-        assert(created !== undefined);
-
-        const showResult = await show(e2eContext, created.id);
-        assert(showResult.isOk());
-        const persisted = showResult.value.customFields?.find(
-          (f) => f.id === customField.id,
+        expect(listAfter.isOk()).toBe(true);
+        const created = listAfter._unsafeUnwrap().find((i) =>
+          i.subject === subject
         );
-        assert(persisted !== undefined);
-        assertEquals(persisted.value, "e2e custom value");
+        expect(created !== undefined).toBe(true);
+
+        const showResult = await show(e2eContext, created!.id);
+        expect(showResult.isOk()).toBe(true);
+        const persisted = showResult._unsafeUnwrap().customFields?.find(
+          (f) => f.id === customField!.id,
+        );
+        expect(persisted !== undefined).toBe(true);
+        expect(persisted!.value).toEqual("e2e custom value");
       },
     );
 
     await t.step("PUT /issues/:id.json should update an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
-      assert(listResult.isOk());
-      const issue = listResult.value.find((i) =>
+      expect(listResult.isOk()).toBe(true);
+      const issue = listResult._unsafeUnwrap().find((i) =>
         i.subject === "E2E Created Issue"
       );
-      assert(issue !== undefined);
+      expect(issue !== undefined).toBe(true);
 
-      const result = await update(e2eContext, issue.id, {
+      const result = await update(e2eContext, issue!.id, {
         subject: "E2E Updated Issue",
         doneRatio: 90,
         isPrivate: true,
         startDate: new Date("2026-07-01"),
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, issue.id);
-      assert(showResult.isOk());
-      assertEquals(showResult.value.subject, "E2E Updated Issue");
-      assertEquals(showResult.value.doneRatio, 90);
-      assertEquals(showResult.value.isPrivate, true);
-      assert(showResult.value.startDate !== undefined);
-      assertEquals(
-        showResult.value.startDate?.toISOString().slice(0, 10),
-        "2026-07-01",
-      );
+      const showResult = await show(e2eContext, issue!.id);
+      expect(showResult.isOk()).toBe(true);
+      expect(showResult._unsafeUnwrap().subject).toEqual("E2E Updated Issue");
+      expect(showResult._unsafeUnwrap().doneRatio).toEqual(90);
+      expect(showResult._unsafeUnwrap().isPrivate).toEqual(true);
+      expect(showResult._unsafeUnwrap().startDate !== undefined).toBe(true);
+      expect(showResult._unsafeUnwrap().startDate?.toISOString().slice(0, 10))
+        .toEqual(
+          "2026-07-01",
+        );
     });
 
     await t.step(
       "GET /issues.json with limit: 1 should return exactly one issue",
       async () => {
         const projectsResult = await fetchProjects(e2eContext);
-        assert(projectsResult.isOk());
-        const project = projectsResult.value.find((p) =>
+        expect(projectsResult.isOk()).toBe(true);
+        const project = projectsResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-test-project"
         );
-        assert(project !== undefined);
+        expect(project !== undefined).toBe(true);
 
         const issuesInProject = await listIssues(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(issuesInProject.isOk());
-        assert(issuesInProject.value.length > 0);
+        expect(issuesInProject.isOk()).toBe(true);
+        expect(issuesInProject._unsafeUnwrap().length > 0).toBe(true);
 
         // Ensure at least two issues exist on the server so that a
         // `limit: 1` result can only be explained by the limit being
         // honored, not by there happening to be a single issue.
         const subject = "E2E Limit Test Issue";
         const created = await createIssue(e2eContext, {
-          projectId: project.id,
-          trackerId: issuesInProject.value[0].tracker.id,
-          statusId: issuesInProject.value[0].status.id,
-          priorityId: issuesInProject.value[0].priority.id,
+          projectId: project!.id,
+          trackerId: issuesInProject._unsafeUnwrap()[0].tracker.id,
+          statusId: issuesInProject._unsafeUnwrap()[0].status.id,
+          priorityId: issuesInProject._unsafeUnwrap()[0].priority.id,
           subject,
           description: "Created by E2E test to exercise listIssues limit",
         });
-        assert(created.isOk());
+        expect(created.isOk()).toBe(true);
 
         // Cleanup looks the issue up by subject because createIssue does
         // not return the created id.
         try {
           const result = await listIssues(e2eContext, { limit: 1 });
-          assert(result.isOk());
-          assertEquals(result.value.length, 1);
+          expect(result.isOk()).toBe(true);
+          expect(result._unsafeUnwrap().length).toEqual(1);
         } finally {
           const cleanupList = await listIssues(e2eContext, {
-            projectId: project.id,
+            projectId: project!.id,
           });
-          assert(cleanupList.isOk(), "cleanup listing must succeed");
+          expect(cleanupList.isOk(), "cleanup listing must succeed").toBe(true);
           // Delete every match, not just one: runs that predate this
           // cleanup left issues with the same subject behind.
-          const leftovers = cleanupList.value.filter((i) =>
+          const leftovers = cleanupList._unsafeUnwrap().filter((i) =>
             i.subject === subject
           );
           for (const leftover of leftovers) {
             const deleted = await deleteIssue(e2eContext, leftover.id);
-            assert(deleted.isOk(), `cleanup must delete issue ${leftover.id}`);
+            expect(deleted.isOk(), `cleanup must delete issue ${leftover.id}`)
+              .toBe(true);
           }
         }
       },
@@ -200,17 +203,17 @@ Deno.test({
 
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
-      assert(listResult.isOk());
-      const issue = listResult.value.find((i) =>
+      expect(listResult.isOk()).toBe(true);
+      const issue = listResult._unsafeUnwrap().find((i) =>
         i.subject === "E2E Updated Issue"
       );
-      assert(issue !== undefined);
+      expect(issue !== undefined).toBe(true);
 
-      const result = await deleteIssue(e2eContext, issue.id);
-      assert(result.isOk());
+      const result = await deleteIssue(e2eContext, issue!.id);
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, issue.id);
-      assert(showResult.isErr());
+      const showResult = await show(e2eContext, issue!.id);
+      expect(showResult.isErr()).toBe(true);
     });
   },
 });

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -13,22 +13,23 @@ Deno.test({
     await t.step("GET /issues.json should return issues", async () => {
       const result = await listIssues(e2eContext, {});
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().length > 0).toBe(true);
+      expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
     });
 
     await t.step("GET /issues/:id.json should return an issue", async () => {
       const listResult = await listIssues(e2eContext, {});
       expect(listResult.isOk()).toBe(true);
-      expect(listResult._unsafeUnwrap().length > 0).toBe(true);
+      expect(listResult._unsafeUnwrap().length).toBeGreaterThan(0);
       const issueId = listResult._unsafeUnwrap()[0].id;
 
       const result = await show(e2eContext, issueId);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().id).toEqual(issueId);
-      expect(result._unsafeUnwrap().project !== undefined).toBe(true);
-      expect(result._unsafeUnwrap().tracker !== undefined).toBe(true);
-      expect(result._unsafeUnwrap().status !== undefined).toBe(true);
-      expect(result._unsafeUnwrap().priority !== undefined).toBe(true);
+      const issue = result._unsafeUnwrap();
+      expect(issue.id).toStrictEqual(issueId);
+      expect(issue.project).toBeDefined();
+      expect(issue.tracker).toBeDefined();
+      expect(issue.status).toBeDefined();
+      expect(issue.priority).toBeDefined();
     });
 
     await t.step("POST /issues.json should create an issue", async () => {
@@ -37,19 +38,20 @@ Deno.test({
       const project = projectsResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-test-project"
       );
-      expect(project !== undefined).toBe(true);
+      expect(project).toBeDefined();
 
       const issuesBefore = await listIssues(e2eContext, {
         projectId: project!.id,
       });
       expect(issuesBefore.isOk()).toBe(true);
-      expect(issuesBefore._unsafeUnwrap().length > 0).toBe(true);
+      const issues = issuesBefore._unsafeUnwrap();
+      expect(issues.length).toBeGreaterThan(0);
 
       const result = await createIssue(e2eContext, {
         projectId: project!.id,
-        trackerId: issuesBefore._unsafeUnwrap()[0].tracker.id,
-        statusId: issuesBefore._unsafeUnwrap()[0].status.id,
-        priorityId: issuesBefore._unsafeUnwrap()[0].priority.id,
+        trackerId: issues[0].tracker.id,
+        statusId: issues[0].status.id,
+        priorityId: issues[0].priority.id,
         subject: "E2E Created Issue",
         description: "Created by E2E test",
       });
@@ -73,27 +75,28 @@ Deno.test({
         const customField = customFieldsData.custom_fields.find(
           (f) => f.name === "E2E CF",
         );
-        expect(customField !== undefined).toBe(true);
+        expect(customField).toBeDefined();
 
         const projectsResult = await fetchProjects(e2eContext);
         expect(projectsResult.isOk()).toBe(true);
         const project = projectsResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-test-project"
         );
-        expect(project !== undefined).toBe(true);
+        expect(project).toBeDefined();
 
         const issuesBefore = await listIssues(e2eContext, {
           projectId: project!.id,
         });
         expect(issuesBefore.isOk()).toBe(true);
-        expect(issuesBefore._unsafeUnwrap().length > 0).toBe(true);
+        const issues = issuesBefore._unsafeUnwrap();
+        expect(issues.length).toBeGreaterThan(0);
 
         const subject = "E2E Issue With Custom Field";
         const result = await createIssue(e2eContext, {
           projectId: project!.id,
-          trackerId: issuesBefore._unsafeUnwrap()[0].tracker.id,
-          statusId: issuesBefore._unsafeUnwrap()[0].status.id,
-          priorityId: issuesBefore._unsafeUnwrap()[0].priority.id,
+          trackerId: issues[0].tracker.id,
+          statusId: issues[0].status.id,
+          priorityId: issues[0].priority.id,
           subject,
           customFields: [{ id: customField!.id, value: "e2e custom value" }],
         });
@@ -106,15 +109,15 @@ Deno.test({
         const created = listAfter._unsafeUnwrap().find((i) =>
           i.subject === subject
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
 
         const showResult = await show(e2eContext, created!.id);
         expect(showResult.isOk()).toBe(true);
         const persisted = showResult._unsafeUnwrap().customFields?.find(
           (f) => f.id === customField!.id,
         );
-        expect(persisted !== undefined).toBe(true);
-        expect(persisted!.value).toEqual("e2e custom value");
+        expect(persisted).toBeDefined();
+        expect(persisted!.value).toStrictEqual("e2e custom value");
       },
     );
 
@@ -124,7 +127,7 @@ Deno.test({
       const issue = listResult._unsafeUnwrap().find((i) =>
         i.subject === "E2E Created Issue"
       );
-      expect(issue !== undefined).toBe(true);
+      expect(issue).toBeDefined();
 
       const result = await update(e2eContext, issue!.id, {
         subject: "E2E Updated Issue",
@@ -136,12 +139,13 @@ Deno.test({
 
       const showResult = await show(e2eContext, issue!.id);
       expect(showResult.isOk()).toBe(true);
-      expect(showResult._unsafeUnwrap().subject).toEqual("E2E Updated Issue");
-      expect(showResult._unsafeUnwrap().doneRatio).toEqual(90);
-      expect(showResult._unsafeUnwrap().isPrivate).toEqual(true);
-      expect(showResult._unsafeUnwrap().startDate !== undefined).toBe(true);
-      expect(showResult._unsafeUnwrap().startDate?.toISOString().slice(0, 10))
-        .toEqual(
+      const showIssue = showResult._unsafeUnwrap();
+      expect(showIssue.subject).toStrictEqual("E2E Updated Issue");
+      expect(showIssue.doneRatio).toStrictEqual(90);
+      expect(showIssue.isPrivate).toStrictEqual(true);
+      expect(showIssue.startDate).toBeDefined();
+      expect(showIssue.startDate?.toISOString().slice(0, 10))
+        .toStrictEqual(
           "2026-07-01",
         );
     });
@@ -154,13 +158,14 @@ Deno.test({
         const project = projectsResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-test-project"
         );
-        expect(project !== undefined).toBe(true);
+        expect(project).toBeDefined();
 
         const issuesInProject = await listIssues(e2eContext, {
           projectId: project!.id,
         });
         expect(issuesInProject.isOk()).toBe(true);
-        expect(issuesInProject._unsafeUnwrap().length > 0).toBe(true);
+        const issues = issuesInProject._unsafeUnwrap();
+        expect(issues.length).toBeGreaterThan(0);
 
         // Ensure at least two issues exist on the server so that a
         // `limit: 1` result can only be explained by the limit being
@@ -168,9 +173,9 @@ Deno.test({
         const subject = "E2E Limit Test Issue";
         const created = await createIssue(e2eContext, {
           projectId: project!.id,
-          trackerId: issuesInProject._unsafeUnwrap()[0].tracker.id,
-          statusId: issuesInProject._unsafeUnwrap()[0].status.id,
-          priorityId: issuesInProject._unsafeUnwrap()[0].priority.id,
+          trackerId: issues[0].tracker.id,
+          statusId: issues[0].status.id,
+          priorityId: issues[0].priority.id,
           subject,
           description: "Created by E2E test to exercise listIssues limit",
         });
@@ -181,7 +186,7 @@ Deno.test({
         try {
           const result = await listIssues(e2eContext, { limit: 1 });
           expect(result.isOk()).toBe(true);
-          expect(result._unsafeUnwrap().length).toEqual(1);
+          expect(result._unsafeUnwrap().length).toStrictEqual(1);
         } finally {
           const cleanupList = await listIssues(e2eContext, {
             projectId: project!.id,
@@ -207,7 +212,7 @@ Deno.test({
       const issue = listResult._unsafeUnwrap().find((i) =>
         i.subject === "E2E Updated Issue"
       );
-      expect(issue !== undefined).toBe(true);
+      expect(issue).toBeDefined();
 
       const result = await deleteIssue(e2eContext, issue!.id);
       expect(result.isOk()).toBe(true);

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/memberships/list.ts";
 import { show } from "../result/memberships/show.ts";
@@ -44,11 +44,11 @@ Deno.test({
   name: "E2E: Memberships API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     const userId = await fetchCurrentUserId();
     const roleId = await fetchFirstRoleId();
@@ -64,23 +64,25 @@ Deno.test({
     await t.step(
       "POST /projects/:project_id/memberships.json should create a membership",
       async () => {
-        const result = await create(e2eContext, project.id, {
+        const result = await create(e2eContext, project!.id, {
           userId,
           roleIds: [roleId],
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "GET /projects/:project_id/memberships.json should return memberships",
       async () => {
-        const result = await fetchList(e2eContext, project.id);
-        assert(result.isOk());
-        assert(result.value.length > 0);
-        const created = result.value.find((m) => m.user?.id === userId);
-        assert(created !== undefined);
-        membershipId = created.id;
+        const result = await fetchList(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        const created = result._unsafeUnwrap().find((m) =>
+          m.user?.id === userId
+        );
+        expect(created !== undefined).toBe(true);
+        membershipId = created!.id;
       },
     );
 
@@ -88,10 +90,13 @@ Deno.test({
       "GET /memberships/:id.json should return a membership",
       async () => {
         const result = await show(e2eContext, membershipId);
-        assert(result.isOk());
-        assertEquals(result.value.id, membershipId);
-        assert(result.value.project !== undefined);
-        assert(result.value.roles.some((role) => role.id === roleId));
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id).toEqual(membershipId);
+        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
+        expect(result._unsafeUnwrap().roles.some((role) => role.id === roleId))
+          .toBe(
+            true,
+          );
       },
     );
 
@@ -101,11 +106,15 @@ Deno.test({
         const result = await update(e2eContext, membershipId, {
           roleIds: [roleId],
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const showResult = await show(e2eContext, membershipId);
-        assert(showResult.isOk());
-        assert(showResult.value.roles.some((role) => role.id === roleId));
+        expect(showResult.isOk()).toBe(true);
+        expect(
+          showResult._unsafeUnwrap().roles.some((role) => role.id === roleId),
+        ).toBe(
+          true,
+        );
       },
     );
 
@@ -113,10 +122,10 @@ Deno.test({
       "DELETE /memberships/:id.json should delete a membership",
       async () => {
         const result = await deleteMembership(e2eContext, membershipId);
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const showResult = await show(e2eContext, membershipId);
-        assert(showResult.isErr());
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -48,7 +48,7 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     const userId = await fetchCurrentUserId();
     const roleId = await fetchFirstRoleId();
@@ -77,11 +77,11 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext, project!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
         const created = result._unsafeUnwrap().find((m) =>
           m.user?.id === userId
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
         membershipId = created!.id;
       },
     );
@@ -91,9 +91,10 @@ Deno.test({
       async () => {
         const result = await show(e2eContext, membershipId);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id).toEqual(membershipId);
-        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
-        expect(result._unsafeUnwrap().roles.some((role) => role.id === roleId))
+        const membership = result._unsafeUnwrap();
+        expect(membership.id).toStrictEqual(membershipId);
+        expect(membership.project).toBeDefined();
+        expect(membership.roles.some((role) => role.id === roleId))
           .toBe(
             true,
           );

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { show } from "../result/my-account/show.ts";
 import { update } from "../result/my-account/update.ts";
@@ -7,18 +7,18 @@ Deno.test({
   name: "E2E: My Account API",
   fn: async (t) => {
     const initialResult = await show(e2eContext);
-    assert(initialResult.isOk());
-    const originalFirstname = initialResult.value.firstname;
+    expect(initialResult.isOk()).toBe(true);
+    const originalFirstname = initialResult._unsafeUnwrap().firstname;
 
     try {
       await t.step(
         "GET /my/account.json should return the authenticated user's account",
         async () => {
           const result = await show(e2eContext);
-          assert(result.isOk());
+          expect(result.isOk()).toBe(true);
           // e2e/setup.ts authenticates as the "admin" user, so the account
           // returned here is always that user.
-          assertEquals(result.value.login, "admin");
+          expect(result._unsafeUnwrap().login).toEqual("admin");
         },
       );
 
@@ -28,11 +28,13 @@ Deno.test({
           const result = await update(e2eContext, {
             firstname: "E2E Updated Firstname",
           });
-          assert(result.isOk());
+          expect(result.isOk()).toBe(true);
 
           const showResult = await show(e2eContext);
-          assert(showResult.isOk());
-          assertEquals(showResult.value.firstname, "E2E Updated Firstname");
+          expect(showResult.isOk()).toBe(true);
+          expect(showResult._unsafeUnwrap().firstname).toEqual(
+            "E2E Updated Firstname",
+          );
         },
       );
     } finally {
@@ -41,7 +43,7 @@ Deno.test({
       const restoreResult = await update(e2eContext, {
         firstname: originalFirstname,
       });
-      assert(restoreResult.isOk());
+      expect(restoreResult.isOk()).toBe(true);
     }
   },
 });

--- a/e2e/my-account.test.ts
+++ b/e2e/my-account.test.ts
@@ -18,7 +18,7 @@ Deno.test({
           expect(result.isOk()).toBe(true);
           // e2e/setup.ts authenticates as the "admin" user, so the account
           // returned here is always that user.
-          expect(result._unsafeUnwrap().login).toEqual("admin");
+          expect(result._unsafeUnwrap().login).toStrictEqual("admin");
         },
       );
 
@@ -32,7 +32,7 @@ Deno.test({
 
           const showResult = await show(e2eContext);
           expect(showResult.isOk()).toBe(true);
-          expect(showResult._unsafeUnwrap().firstname).toEqual(
+          expect(showResult._unsafeUnwrap().firstname).toStrictEqual(
             "E2E Updated Firstname",
           );
         },

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/news/list.ts";
 import { fetchListByProject } from "../result/news/list-by-project.ts";
@@ -8,38 +8,40 @@ Deno.test({
   name: "E2E: News API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     await t.step("GET /news.json should return the seeded news", async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      const seeded = result.value.find((n) => n.title === "E2E News");
-      assert(seeded !== undefined);
-      assertEquals(seeded.summary, "E2E news summary");
-      assertEquals(seeded.description, "E2E news description");
-      assert(seeded.project !== undefined);
-      assert(seeded.author !== undefined);
-      assert(seeded.createdOn instanceof Date);
+      expect(result.isOk()).toBe(true);
+      const seeded = result._unsafeUnwrap().find((n) => n.title === "E2E News");
+      expect(seeded !== undefined).toBe(true);
+      expect(seeded!.summary).toEqual("E2E news summary");
+      expect(seeded!.description).toEqual("E2E news description");
+      expect(seeded!.project !== undefined).toBe(true);
+      expect(seeded!.author !== undefined).toBe(true);
+      expect(seeded!.createdOn instanceof Date).toBe(true);
     });
 
     await t.step(
       "GET /projects/:project_id/news.json should return the project news",
       async () => {
-        const result = await fetchListByProject(e2eContext, project.id);
-        assert(result.isOk());
-        const seeded = result.value.find((n) => n.title === "E2E News");
-        assert(seeded !== undefined);
+        const result = await fetchListByProject(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
+        const seeded = result._unsafeUnwrap().find((n) =>
+          n.title === "E2E News"
+        );
+        expect(seeded !== undefined).toBe(true);
         // A news created without a summary is rendered as an empty string
         // (not null), which is why the schema keeps `summary` a required string.
-        const noSummary = result.value.find((n) =>
+        const noSummary = result._unsafeUnwrap().find((n) =>
           n.title === "E2E News Without Summary"
         );
-        assert(noSummary !== undefined);
-        assertEquals(noSummary.summary, "");
+        expect(noSummary !== undefined).toBe(true);
+        expect(noSummary!.summary).toEqual("");
       },
     );
   },

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -12,18 +12,18 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     await t.step("GET /news.json should return the seeded news", async () => {
       const result = await fetchList(e2eContext);
       expect(result.isOk()).toBe(true);
       const seeded = result._unsafeUnwrap().find((n) => n.title === "E2E News");
-      expect(seeded !== undefined).toBe(true);
-      expect(seeded!.summary).toEqual("E2E news summary");
-      expect(seeded!.description).toEqual("E2E news description");
-      expect(seeded!.project !== undefined).toBe(true);
-      expect(seeded!.author !== undefined).toBe(true);
-      expect(seeded!.createdOn instanceof Date).toBe(true);
+      expect(seeded).toBeDefined();
+      expect(seeded!.summary).toStrictEqual("E2E news summary");
+      expect(seeded!.description).toStrictEqual("E2E news description");
+      expect(seeded!.project).toBeDefined();
+      expect(seeded!.author).toBeDefined();
+      expect(seeded!.createdOn).toBeInstanceOf(Date);
     });
 
     await t.step(
@@ -34,14 +34,14 @@ Deno.test({
         const seeded = result._unsafeUnwrap().find((n) =>
           n.title === "E2E News"
         );
-        expect(seeded !== undefined).toBe(true);
+        expect(seeded).toBeDefined();
         // A news created without a summary is rendered as an empty string
         // (not null), which is why the schema keeps `summary` a required string.
         const noSummary = result._unsafeUnwrap().find((n) =>
           n.title === "E2E News Without Summary"
         );
-        expect(noSummary !== undefined).toBe(true);
-        expect(noSummary!.summary).toEqual("");
+        expect(noSummary).toBeDefined();
+        expect(noSummary!.summary).toStrictEqual("");
       },
     );
   },

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -13,18 +13,18 @@ Deno.test({
     await t.step("GET /projects.json should return projects", async () => {
       const result = await fetchList(e2eContext);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().length > 0).toBe(true);
+      expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
     });
 
     await t.step("GET /projects/:id.json should return a project", async () => {
       const listResult = await fetchList(e2eContext);
       expect(listResult.isOk()).toBe(true);
-      expect(listResult._unsafeUnwrap().length > 0).toBe(true);
+      expect(listResult._unsafeUnwrap().length).toBeGreaterThan(0);
       const projectId = listResult._unsafeUnwrap()[0].id;
 
       const result = await show(e2eContext, projectId);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().id).toEqual(projectId);
+      expect(result._unsafeUnwrap().id).toStrictEqual(projectId);
     });
 
     await t.step("POST /projects.json should create a project", async () => {
@@ -41,7 +41,7 @@ Deno.test({
       const project = listResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-created-project"
       );
-      expect(project !== undefined).toBe(true);
+      expect(project).toBeDefined();
 
       const result = await update(e2eContext, project!.id, {
         name: "E2E Updated Project",
@@ -50,7 +50,9 @@ Deno.test({
 
       const showResult = await show(e2eContext, project!.id);
       expect(showResult.isOk()).toBe(true);
-      expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Project");
+      expect(showResult._unsafeUnwrap().name).toStrictEqual(
+        "E2E Updated Project",
+      );
     });
 
     await t.step(
@@ -73,14 +75,14 @@ Deno.test({
           const created = listResult._unsafeUnwrap().find((p) =>
             p.identifier === identifier
           );
-          expect(created !== undefined).toBe(true);
+          expect(created).toBeDefined();
 
           const createdShow = await show(e2eContext, created!.id);
           expect(createdShow.isOk()).toBe(true);
           expect(
             createdShow._unsafeUnwrap().isPublic,
             "isPublic:false must be stored as private on the server",
-          ).toEqual(false);
+          ).toStrictEqual(false);
 
           const updateResult = await update(e2eContext, created!.id, {
             isPublic: true,
@@ -92,7 +94,7 @@ Deno.test({
           expect(
             updatedShow._unsafeUnwrap().isPublic,
             "update must flip is_public on the server",
-          ).toEqual(true);
+          ).toStrictEqual(true);
         } finally {
           const cleanupList = await fetchList(e2eContext);
           if (cleanupList.isOk()) {
@@ -115,7 +117,7 @@ Deno.test({
         const project = listResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-created-project"
         );
-        expect(project !== undefined).toBe(true);
+        expect(project).toBeDefined();
 
         const archiveResult = await archive(e2eContext, project!.id);
         expect(archiveResult.isOk(), "Expected archive to succeed").toBe(true);
@@ -135,7 +137,7 @@ Deno.test({
         const project = listResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-created-project"
         );
-        expect(project !== undefined).toBe(true);
+        expect(project).toBeDefined();
 
         const result = await deleteProject(e2eContext, project!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/projects/list.ts";
 import { show } from "../result/projects/show.ts";
@@ -12,19 +12,19 @@ Deno.test({
   fn: async (t) => {
     await t.step("GET /projects.json should return projects", async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      assert(result.value.length > 0);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().length > 0).toBe(true);
     });
 
     await t.step("GET /projects/:id.json should return a project", async () => {
       const listResult = await fetchList(e2eContext);
-      assert(listResult.isOk());
-      assert(listResult.value.length > 0);
-      const projectId = listResult.value[0].id;
+      expect(listResult.isOk()).toBe(true);
+      expect(listResult._unsafeUnwrap().length > 0).toBe(true);
+      const projectId = listResult._unsafeUnwrap()[0].id;
 
       const result = await show(e2eContext, projectId);
-      assert(result.isOk());
-      assertEquals(result.value.id, projectId);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().id).toEqual(projectId);
     });
 
     await t.step("POST /projects.json should create a project", async () => {
@@ -32,25 +32,25 @@ Deno.test({
         name: "E2E Created Project",
         identifier: "e2e-created-project",
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
     });
 
     await t.step("PUT /projects/:id.json should update a project", async () => {
       const listResult = await fetchList(e2eContext);
-      assert(listResult.isOk());
-      const project = listResult.value.find((p) =>
+      expect(listResult.isOk()).toBe(true);
+      const project = listResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-created-project"
       );
-      assert(project !== undefined);
+      expect(project !== undefined).toBe(true);
 
-      const result = await update(e2eContext, project.id, {
+      const result = await update(e2eContext, project!.id, {
         name: "E2E Updated Project",
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, project.id);
-      assert(showResult.isOk());
-      assertEquals(showResult.value.name, "E2E Updated Project");
+      const showResult = await show(e2eContext, project!.id);
+      expect(showResult.isOk()).toBe(true);
+      expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Project");
     });
 
     await t.step(
@@ -62,43 +62,41 @@ Deno.test({
           identifier,
           isPublic: false,
         });
-        assert(createResult.isOk());
+        expect(createResult.isOk()).toBe(true);
 
         // Cleanup re-resolves the project by identifier instead of reusing
         // an id from the try block: that id is unavailable exactly when the
         // lookup is the step that failed.
         try {
           const listResult = await fetchList(e2eContext);
-          assert(listResult.isOk());
-          const created = listResult.value.find((p) =>
+          expect(listResult.isOk()).toBe(true);
+          const created = listResult._unsafeUnwrap().find((p) =>
             p.identifier === identifier
           );
-          assert(created !== undefined);
+          expect(created !== undefined).toBe(true);
 
-          const createdShow = await show(e2eContext, created.id);
-          assert(createdShow.isOk());
-          assertEquals(
-            createdShow.value.isPublic,
-            false,
+          const createdShow = await show(e2eContext, created!.id);
+          expect(createdShow.isOk()).toBe(true);
+          expect(
+            createdShow._unsafeUnwrap().isPublic,
             "isPublic:false must be stored as private on the server",
-          );
+          ).toEqual(false);
 
-          const updateResult = await update(e2eContext, created.id, {
+          const updateResult = await update(e2eContext, created!.id, {
             isPublic: true,
           });
-          assert(updateResult.isOk());
+          expect(updateResult.isOk()).toBe(true);
 
-          const updatedShow = await show(e2eContext, created.id);
-          assert(updatedShow.isOk());
-          assertEquals(
-            updatedShow.value.isPublic,
-            true,
+          const updatedShow = await show(e2eContext, created!.id);
+          expect(updatedShow.isOk()).toBe(true);
+          expect(
+            updatedShow._unsafeUnwrap().isPublic,
             "update must flip is_public on the server",
-          );
+          ).toEqual(true);
         } finally {
           const cleanupList = await fetchList(e2eContext);
           if (cleanupList.isOk()) {
-            const leftover = cleanupList.value.find((p) =>
+            const leftover = cleanupList._unsafeUnwrap().find((p) =>
               p.identifier === identifier
             );
             if (leftover !== undefined) {
@@ -113,22 +111,18 @@ Deno.test({
       "PUT /projects/:id/archive.json should archive and unarchive",
       async () => {
         const listResult = await fetchList(e2eContext);
-        assert(listResult.isOk());
-        const project = listResult.value.find((p) =>
+        expect(listResult.isOk()).toBe(true);
+        const project = listResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-created-project"
         );
-        assert(project !== undefined);
+        expect(project !== undefined).toBe(true);
 
-        const archiveResult = await archive(e2eContext, project.id);
-        assert(
-          archiveResult.isOk(),
-          "Expected archive to succeed",
-        );
+        const archiveResult = await archive(e2eContext, project!.id);
+        expect(archiveResult.isOk(), "Expected archive to succeed").toBe(true);
 
-        const unarchiveResult = await unarchive(e2eContext, project.id);
-        assert(
-          unarchiveResult.isOk(),
-          "Expected unarchive to succeed",
+        const unarchiveResult = await unarchive(e2eContext, project!.id);
+        expect(unarchiveResult.isOk(), "Expected unarchive to succeed").toBe(
+          true,
         );
       },
     );
@@ -137,14 +131,14 @@ Deno.test({
       "DELETE /projects/:id.json should delete a project",
       async () => {
         const listResult = await fetchList(e2eContext);
-        assert(listResult.isOk());
-        const project = listResult.value.find((p) =>
+        expect(listResult.isOk()).toBe(true);
+        const project = listResult._unsafeUnwrap().find((p) =>
           p.identifier === "e2e-created-project"
         );
-        assert(project !== undefined);
+        expect(project !== undefined).toBe(true);
 
-        const result = await deleteProject(e2eContext, project.id);
-        assert(result.isOk());
+        const result = await deleteProject(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
       },
     );
   },

--- a/e2e/queries.test.ts
+++ b/e2e/queries.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/queries/list.ts";
 
@@ -7,11 +7,11 @@ Deno.test("E2E: Queries API", async (t) => {
     "GET /queries.json should return the list of queries",
     async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
       // Saved queries are user-created, so a freshly provisioned Redmine has
       // none; a successful parse already proves the response matches the
       // schema regardless of length.
-      assert(Array.isArray(result.value));
+      expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
     },
   );
 });

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/roles/list.ts";
 import { show } from "../result/roles/show.ts";
@@ -10,8 +10,8 @@ Deno.test({
       "GET /roles.json should return a list of roles",
       async () => {
         const result = await fetchList(e2eContext);
-        assert(result.isOk());
-        assert(Array.isArray(result.value));
+        expect(result.isOk()).toBe(true);
+        expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
       },
     );
 
@@ -19,8 +19,8 @@ Deno.test({
       "GET /roles/:id.json should return a role",
       async () => {
         const listResult = await fetchList(e2eContext);
-        assert(listResult.isOk());
-        const role = listResult.value[0];
+        expect(listResult.isOk()).toBe(true);
+        const role = listResult._unsafeUnwrap()[0];
         // e2e/setup.ts seeds a role so this normally runs. A freshly
         // provisioned Redmine loads no default roles, so guard the listing
         // being empty, but surface it rather than passing silently.
@@ -30,10 +30,10 @@ Deno.test({
         }
 
         const result = await show(e2eContext, role.id);
-        assert(result.isOk());
-        assert(result.value.id === role.id);
-        assert(result.value.name === role.name);
-        assert(Array.isArray(result.value.permissions));
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id === role.id).toBe(true);
+        expect(result._unsafeUnwrap().name === role.name).toBe(true);
+        expect(Array.isArray(result._unsafeUnwrap().permissions)).toBe(true);
       },
     );
   },

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -31,9 +31,10 @@ Deno.test({
 
         const result = await show(e2eContext, role.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id === role.id).toBe(true);
-        expect(result._unsafeUnwrap().name === role.name).toBe(true);
-        expect(Array.isArray(result._unsafeUnwrap().permissions)).toBe(true);
+        const shown = result._unsafeUnwrap();
+        expect(shown.id).toBe(role.id);
+        expect(shown.name).toBe(role.name);
+        expect(Array.isArray(shown.permissions)).toBe(true);
       },
     );
   },

--- a/e2e/search.test.ts
+++ b/e2e/search.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { search } from "../result/search/search.ts";
 
@@ -11,10 +11,10 @@ Deno.test({
         // The result set may be empty depending on how far Redmine's indexing
         // has progressed, so only the response shape is asserted.
         const result = await search(e2eContext, { q: "E2E" });
-        assert(result.isOk());
-        assert(Array.isArray(result.value));
-        for (const item of result.value) {
-          assert(item.datetime instanceof Date);
+        expect(result.isOk()).toBe(true);
+        expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
+        for (const item of result._unsafeUnwrap()) {
+          expect(item.datetime instanceof Date).toBe(true);
         }
       },
     );

--- a/e2e/search.test.ts
+++ b/e2e/search.test.ts
@@ -14,7 +14,7 @@ Deno.test({
         expect(result.isOk()).toBe(true);
         expect(Array.isArray(result._unsafeUnwrap())).toBe(true);
         for (const item of result._unsafeUnwrap()) {
-          expect(item.datetime instanceof Date).toBe(true);
+          expect(item.datetime).toBeInstanceOf(Date);
         }
       },
     );

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -16,13 +16,13 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     const issuesResult = await listIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issuesResult.isOk()).toBe(true);
-    expect(issuesResult._unsafeUnwrap().length > 0).toBe(true);
+    expect(issuesResult._unsafeUnwrap().length).toBeGreaterThan(0);
     const issue = issuesResult._unsafeUnwrap()[0];
 
     // Activities are a server-wide enumeration seeded by Redmine's default
@@ -63,11 +63,11 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext, { projectId: project!.id });
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
         const created = result._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
       },
     );
 
@@ -81,15 +81,16 @@ Deno.test({
         const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        expect(timeEntry !== undefined).toBe(true);
+        expect(timeEntry).toBeDefined();
 
         const result = await show(e2eContext, timeEntry!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().id).toEqual(timeEntry!.id);
-        expect(result._unsafeUnwrap().hours).toEqual(2.5);
-        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
-        expect(result._unsafeUnwrap().issue !== undefined).toBe(true);
-        expect(result._unsafeUnwrap().issue?.id).toEqual(issue.id);
+        const shown = result._unsafeUnwrap();
+        expect(shown.id).toStrictEqual(timeEntry!.id);
+        expect(shown.hours).toStrictEqual(2.5);
+        expect(shown.project).toBeDefined();
+        expect(shown.issue).toBeDefined();
+        expect(shown.issue?.id).toStrictEqual(issue.id);
       },
     );
 
@@ -103,7 +104,7 @@ Deno.test({
         const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        expect(timeEntry !== undefined).toBe(true);
+        expect(timeEntry).toBeDefined();
 
         const result = await update(e2eContext, timeEntry!.id, {
           hours: 4,
@@ -113,8 +114,8 @@ Deno.test({
 
         const showResult = await show(e2eContext, timeEntry!.id);
         expect(showResult.isOk()).toBe(true);
-        expect(showResult._unsafeUnwrap().hours).toEqual(4);
-        expect(showResult._unsafeUnwrap().comments).toEqual(
+        expect(showResult._unsafeUnwrap().hours).toStrictEqual(4);
+        expect(showResult._unsafeUnwrap().comments).toStrictEqual(
           "E2E Updated Time Entry",
         );
       },
@@ -130,7 +131,7 @@ Deno.test({
         const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Updated Time Entry"
         );
-        expect(timeEntry !== undefined).toBe(true);
+        expect(timeEntry).toBeDefined();
 
         const result = await deleteTimeEntry(e2eContext, timeEntry!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/time-entries/list.ts";
 import { show } from "../result/time-entries/show.ts";
@@ -12,18 +12,18 @@ Deno.test({
   name: "E2E: Time Entries API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     const issuesResult = await listIssues(e2eContext, {
-      projectId: project.id,
+      projectId: project!.id,
     });
-    assert(issuesResult.isOk());
-    assert(issuesResult.value.length > 0);
-    const issue = issuesResult.value[0];
+    expect(issuesResult.isOk()).toBe(true);
+    expect(issuesResult._unsafeUnwrap().length > 0).toBe(true);
+    const issue = issuesResult._unsafeUnwrap()[0];
 
     // Activities are a server-wide enumeration seeded by Redmine's default
     // data, which this test suite does not control, so an empty list is
@@ -32,7 +32,7 @@ Deno.test({
       `${e2eContext.endpoint}/enumerations/time_entry_activities.json`,
       { headers: { "X-Redmine-API-Key": e2eContext.apiKey } },
     );
-    assert(activitiesResponse.ok);
+    expect(activitiesResponse.ok).toBe(true);
     const activitiesData = await activitiesResponse.json() as {
       time_entry_activities: { id: number; name: string }[];
     };
@@ -54,20 +54,20 @@ Deno.test({
           comments: "E2E Created Time Entry",
           spentOn: new Date("2026-07-01"),
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "GET /time_entries.json?project_id=... should return time entries",
       async () => {
-        const result = await fetchList(e2eContext, { projectId: project.id });
-        assert(result.isOk());
-        assert(result.value.length > 0);
-        const created = result.value.find((e) =>
+        const result = await fetchList(e2eContext, { projectId: project!.id });
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        const created = result._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        assert(created !== undefined);
+        expect(created !== undefined).toBe(true);
       },
     );
 
@@ -75,21 +75,21 @@ Deno.test({
       "GET /time_entries/:id.json should return a time entry",
       async () => {
         const listResult = await fetchList(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(listResult.isOk());
-        const timeEntry = listResult.value.find((e) =>
+        expect(listResult.isOk()).toBe(true);
+        const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        assert(timeEntry !== undefined);
+        expect(timeEntry !== undefined).toBe(true);
 
-        const result = await show(e2eContext, timeEntry.id);
-        assert(result.isOk());
-        assertEquals(result.value.id, timeEntry.id);
-        assertEquals(result.value.hours, 2.5);
-        assert(result.value.project !== undefined);
-        assert(result.value.issue !== undefined);
-        assertEquals(result.value.issue?.id, issue.id);
+        const result = await show(e2eContext, timeEntry!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().id).toEqual(timeEntry!.id);
+        expect(result._unsafeUnwrap().hours).toEqual(2.5);
+        expect(result._unsafeUnwrap().project !== undefined).toBe(true);
+        expect(result._unsafeUnwrap().issue !== undefined).toBe(true);
+        expect(result._unsafeUnwrap().issue?.id).toEqual(issue.id);
       },
     );
 
@@ -97,24 +97,26 @@ Deno.test({
       "PUT /time_entries/:id.json should update a time entry",
       async () => {
         const listResult = await fetchList(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(listResult.isOk());
-        const timeEntry = listResult.value.find((e) =>
+        expect(listResult.isOk()).toBe(true);
+        const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Created Time Entry"
         );
-        assert(timeEntry !== undefined);
+        expect(timeEntry !== undefined).toBe(true);
 
-        const result = await update(e2eContext, timeEntry.id, {
+        const result = await update(e2eContext, timeEntry!.id, {
           hours: 4,
           comments: "E2E Updated Time Entry",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, timeEntry.id);
-        assert(showResult.isOk());
-        assertEquals(showResult.value.hours, 4);
-        assertEquals(showResult.value.comments, "E2E Updated Time Entry");
+        const showResult = await show(e2eContext, timeEntry!.id);
+        expect(showResult.isOk()).toBe(true);
+        expect(showResult._unsafeUnwrap().hours).toEqual(4);
+        expect(showResult._unsafeUnwrap().comments).toEqual(
+          "E2E Updated Time Entry",
+        );
       },
     );
 
@@ -122,19 +124,19 @@ Deno.test({
       "DELETE /time_entries/:id.json should delete a time entry",
       async () => {
         const listResult = await fetchList(e2eContext, {
-          projectId: project.id,
+          projectId: project!.id,
         });
-        assert(listResult.isOk());
-        const timeEntry = listResult.value.find((e) =>
+        expect(listResult.isOk()).toBe(true);
+        const timeEntry = listResult._unsafeUnwrap().find((e) =>
           e.comments === "E2E Updated Time Entry"
         );
-        assert(timeEntry !== undefined);
+        expect(timeEntry !== undefined).toBe(true);
 
-        const result = await deleteTimeEntry(e2eContext, timeEntry.id);
-        assert(result.isOk());
+        const result = await deleteTimeEntry(e2eContext, timeEntry!.id);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, timeEntry.id);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, timeEntry!.id);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/trackers.test.ts
+++ b/e2e/trackers.test.ts
@@ -1,4 +1,4 @@
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/trackers/list.ts";
 
@@ -7,8 +7,12 @@ Deno.test("E2E: Trackers API", async (t) => {
     "GET /trackers.json should return default trackers",
     async () => {
       const result = await fetchList(e2eContext);
-      assert(result.isOk());
-      assert(result.value.length > 0, "Redmine should have default trackers");
+      expect(result.isOk()).toBe(true);
+      expect(
+        result._unsafeUnwrap().length > 0,
+        "Redmine should have default trackers",
+      )
+        .toBe(true);
     },
   );
 });

--- a/e2e/trackers.test.ts
+++ b/e2e/trackers.test.ts
@@ -9,10 +9,9 @@ Deno.test("E2E: Trackers API", async (t) => {
       const result = await fetchList(e2eContext);
       expect(result.isOk()).toBe(true);
       expect(
-        result._unsafeUnwrap().length > 0,
+        result._unsafeUnwrap().length,
         "Redmine should have default trackers",
-      )
-        .toBe(true);
+      ).toBeGreaterThan(0);
     },
   );
 });

--- a/e2e/users.test.ts
+++ b/e2e/users.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/users/list.ts";
 import { show } from "../result/users/show.ts";
@@ -25,7 +25,7 @@ Deno.test({
           password: "SuperSecret123!",
           generatePassword: false,
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
@@ -33,58 +33,58 @@ Deno.test({
       "GET /users.json should return users",
       async () => {
         const result = await fetchList(e2eContext);
-        assert(result.isOk());
-        assert(result.value.length > 0);
-        const created = result.value.find((u) => u.login === login);
-        assert(created !== undefined);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        const created = result._unsafeUnwrap().find((u) => u.login === login);
+        expect(created !== undefined).toBe(true);
       },
     );
 
     await t.step("GET /users/:id.json should return a user", async () => {
       const listResult = await fetchList(e2eContext);
-      assert(listResult.isOk());
-      const user = listResult.value.find((u) => u.login === login);
-      assert(user !== undefined);
+      expect(listResult.isOk()).toBe(true);
+      const user = listResult._unsafeUnwrap().find((u) => u.login === login);
+      expect(user !== undefined).toBe(true);
 
-      const result = await show(e2eContext, user.id);
-      assert(result.isOk());
-      assertEquals(result.value.id, user.id);
-      assertEquals(result.value.login, login);
-      assertEquals(result.value.firstname, "E2E");
-      assertEquals(result.value.lastname, "Created");
-      assertEquals(result.value.mail, mail);
+      const result = await show(e2eContext, user!.id);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().id).toEqual(user!.id);
+      expect(result._unsafeUnwrap().login).toEqual(login);
+      expect(result._unsafeUnwrap().firstname).toEqual("E2E");
+      expect(result._unsafeUnwrap().lastname).toEqual("Created");
+      expect(result._unsafeUnwrap().mail).toEqual(mail);
     });
 
     await t.step("PUT /users/:id.json should update a user", async () => {
       const listResult = await fetchList(e2eContext);
-      assert(listResult.isOk());
-      const user = listResult.value.find((u) => u.login === login);
-      assert(user !== undefined);
+      expect(listResult.isOk()).toBe(true);
+      const user = listResult._unsafeUnwrap().find((u) => u.login === login);
+      expect(user !== undefined).toBe(true);
 
-      const result = await update(e2eContext, user.id, {
+      const result = await update(e2eContext, user!.id, {
         firstname: "E2E",
         lastname: "Updated",
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, user.id);
-      assert(showResult.isOk());
-      assertEquals(showResult.value.lastname, "Updated");
+      const showResult = await show(e2eContext, user!.id);
+      expect(showResult.isOk()).toBe(true);
+      expect(showResult._unsafeUnwrap().lastname).toEqual("Updated");
     });
 
     await t.step(
       "DELETE /users/:id.json should delete a user",
       async () => {
         const listResult = await fetchList(e2eContext);
-        assert(listResult.isOk());
-        const user = listResult.value.find((u) => u.login === login);
-        assert(user !== undefined);
+        expect(listResult.isOk()).toBe(true);
+        const user = listResult._unsafeUnwrap().find((u) => u.login === login);
+        expect(user !== undefined).toBe(true);
 
-        const result = await deleteUser(e2eContext, user.id);
-        assert(result.isOk());
+        const result = await deleteUser(e2eContext, user!.id);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, user.id);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, user!.id);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/users.test.ts
+++ b/e2e/users.test.ts
@@ -34,9 +34,9 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
         const created = result._unsafeUnwrap().find((u) => u.login === login);
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
       },
     );
 
@@ -44,22 +44,23 @@ Deno.test({
       const listResult = await fetchList(e2eContext);
       expect(listResult.isOk()).toBe(true);
       const user = listResult._unsafeUnwrap().find((u) => u.login === login);
-      expect(user !== undefined).toBe(true);
+      expect(user).toBeDefined();
 
       const result = await show(e2eContext, user!.id);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().id).toEqual(user!.id);
-      expect(result._unsafeUnwrap().login).toEqual(login);
-      expect(result._unsafeUnwrap().firstname).toEqual("E2E");
-      expect(result._unsafeUnwrap().lastname).toEqual("Created");
-      expect(result._unsafeUnwrap().mail).toEqual(mail);
+      const shown = result._unsafeUnwrap();
+      expect(shown.id).toStrictEqual(user!.id);
+      expect(shown.login).toStrictEqual(login);
+      expect(shown.firstname).toStrictEqual("E2E");
+      expect(shown.lastname).toStrictEqual("Created");
+      expect(shown.mail).toStrictEqual(mail);
     });
 
     await t.step("PUT /users/:id.json should update a user", async () => {
       const listResult = await fetchList(e2eContext);
       expect(listResult.isOk()).toBe(true);
       const user = listResult._unsafeUnwrap().find((u) => u.login === login);
-      expect(user !== undefined).toBe(true);
+      expect(user).toBeDefined();
 
       const result = await update(e2eContext, user!.id, {
         firstname: "E2E",
@@ -69,7 +70,7 @@ Deno.test({
 
       const showResult = await show(e2eContext, user!.id);
       expect(showResult.isOk()).toBe(true);
-      expect(showResult._unsafeUnwrap().lastname).toEqual("Updated");
+      expect(showResult._unsafeUnwrap().lastname).toStrictEqual("Updated");
     });
 
     await t.step(
@@ -78,7 +79,7 @@ Deno.test({
         const listResult = await fetchList(e2eContext);
         expect(listResult.isOk()).toBe(true);
         const user = listResult._unsafeUnwrap().find((u) => u.login === login);
-        expect(user !== undefined).toBe(true);
+        expect(user).toBeDefined();
 
         const result = await deleteUser(e2eContext, user!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/versions/list.ts";
 import { show } from "../result/versions/show.ts";
@@ -11,90 +11,90 @@ Deno.test({
   name: "E2E: Versions API",
   fn: async (t) => {
     const projectsResult = await fetchProjects(e2eContext);
-    assert(projectsResult.isOk());
-    const project = projectsResult.value.find((p) =>
+    expect(projectsResult.isOk()).toBe(true);
+    const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    assert(project !== undefined);
+    expect(project !== undefined).toBe(true);
 
     await t.step(
       "POST /projects/:project_id/versions.json should create a version",
       async () => {
-        const result = await create(e2eContext, project.id, {
+        const result = await create(e2eContext, project!.id, {
           name: "E2E Created Version",
           status: "open",
           sharing: "none",
           description: "Created by E2E test",
           dueDate: new Date("2026-08-01"),
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
     await t.step(
       "GET /projects/:project_id/versions.json should return versions",
       async () => {
-        const result = await fetchList(e2eContext, project.id);
-        assert(result.isOk());
-        assert(result.value.length > 0);
-        const created = result.value.find((v) =>
+        const result = await fetchList(e2eContext, project!.id);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        const created = result._unsafeUnwrap().find((v) =>
           v.name === "E2E Created Version"
         );
-        assert(created !== undefined);
+        expect(created !== undefined).toBe(true);
       },
     );
 
     await t.step("GET /versions/:id.json should return a version", async () => {
-      const listResult = await fetchList(e2eContext, project.id);
-      assert(listResult.isOk());
-      const version = listResult.value.find((v) =>
+      const listResult = await fetchList(e2eContext, project!.id);
+      expect(listResult.isOk()).toBe(true);
+      const version = listResult._unsafeUnwrap().find((v) =>
         v.name === "E2E Created Version"
       );
-      assert(version !== undefined);
+      expect(version !== undefined).toBe(true);
 
-      const result = await show(e2eContext, version.id);
-      assert(result.isOk());
-      assertEquals(result.value.id, version.id);
-      assertEquals(result.value.name, "E2E Created Version");
-      assert(result.value.project !== undefined);
-      assertEquals(result.value.status, "open");
+      const result = await show(e2eContext, version!.id);
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap().id).toEqual(version!.id);
+      expect(result._unsafeUnwrap().name).toEqual("E2E Created Version");
+      expect(result._unsafeUnwrap().project !== undefined).toBe(true);
+      expect(result._unsafeUnwrap().status).toEqual("open");
     });
 
     await t.step("PUT /versions/:id.json should update a version", async () => {
-      const listResult = await fetchList(e2eContext, project.id);
-      assert(listResult.isOk());
-      const version = listResult.value.find((v) =>
+      const listResult = await fetchList(e2eContext, project!.id);
+      expect(listResult.isOk()).toBe(true);
+      const version = listResult._unsafeUnwrap().find((v) =>
         v.name === "E2E Created Version"
       );
-      assert(version !== undefined);
+      expect(version !== undefined).toBe(true);
 
-      const result = await update(e2eContext, version.id, {
+      const result = await update(e2eContext, version!.id, {
         name: "E2E Updated Version",
         status: "locked",
       });
-      assert(result.isOk());
+      expect(result.isOk()).toBe(true);
 
-      const showResult = await show(e2eContext, version.id);
-      assert(showResult.isOk());
-      assertEquals(showResult.value.name, "E2E Updated Version");
-      assertEquals(showResult.value.status, "locked");
+      const showResult = await show(e2eContext, version!.id);
+      expect(showResult.isOk()).toBe(true);
+      expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Version");
+      expect(showResult._unsafeUnwrap().status).toEqual("locked");
     });
 
     await t.step(
       "DELETE /versions/:id.json should delete a version",
       async () => {
-        const listResult = await fetchList(e2eContext, project.id);
-        assert(listResult.isOk());
-        const version = listResult.value.find((v) =>
+        const listResult = await fetchList(e2eContext, project!.id);
+        expect(listResult.isOk()).toBe(true);
+        const version = listResult._unsafeUnwrap().find((v) =>
           v.name === "E2E Updated Version"
         );
-        assert(version !== undefined);
+        expect(version !== undefined).toBe(true);
 
-        const result = await deleteVersion(e2eContext, version.id);
-        assert(result.isOk());
+        const result = await deleteVersion(e2eContext, version!.id);
+        expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, version.id);
-        assert(showResult.isErr());
+        const showResult = await show(e2eContext, version!.id);
+        expect(showResult.isErr()).toBe(true);
       },
     );
   },

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -15,7 +15,7 @@ Deno.test({
     const project = projectsResult._unsafeUnwrap().find((p) =>
       p.identifier === "e2e-test-project"
     );
-    expect(project !== undefined).toBe(true);
+    expect(project).toBeDefined();
 
     await t.step(
       "POST /projects/:project_id/versions.json should create a version",
@@ -36,11 +36,11 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext, project!.id);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
         const created = result._unsafeUnwrap().find((v) =>
           v.name === "E2E Created Version"
         );
-        expect(created !== undefined).toBe(true);
+        expect(created).toBeDefined();
       },
     );
 
@@ -50,14 +50,15 @@ Deno.test({
       const version = listResult._unsafeUnwrap().find((v) =>
         v.name === "E2E Created Version"
       );
-      expect(version !== undefined).toBe(true);
+      expect(version).toBeDefined();
 
       const result = await show(e2eContext, version!.id);
       expect(result.isOk()).toBe(true);
-      expect(result._unsafeUnwrap().id).toEqual(version!.id);
-      expect(result._unsafeUnwrap().name).toEqual("E2E Created Version");
-      expect(result._unsafeUnwrap().project !== undefined).toBe(true);
-      expect(result._unsafeUnwrap().status).toEqual("open");
+      const shown = result._unsafeUnwrap();
+      expect(shown.id).toStrictEqual(version!.id);
+      expect(shown.name).toStrictEqual("E2E Created Version");
+      expect(shown.project).toBeDefined();
+      expect(shown.status).toStrictEqual("open");
     });
 
     await t.step("PUT /versions/:id.json should update a version", async () => {
@@ -66,7 +67,7 @@ Deno.test({
       const version = listResult._unsafeUnwrap().find((v) =>
         v.name === "E2E Created Version"
       );
-      expect(version !== undefined).toBe(true);
+      expect(version).toBeDefined();
 
       const result = await update(e2eContext, version!.id, {
         name: "E2E Updated Version",
@@ -76,8 +77,10 @@ Deno.test({
 
       const showResult = await show(e2eContext, version!.id);
       expect(showResult.isOk()).toBe(true);
-      expect(showResult._unsafeUnwrap().name).toEqual("E2E Updated Version");
-      expect(showResult._unsafeUnwrap().status).toEqual("locked");
+      expect(showResult._unsafeUnwrap().name).toStrictEqual(
+        "E2E Updated Version",
+      );
+      expect(showResult._unsafeUnwrap().status).toStrictEqual("locked");
     });
 
     await t.step(
@@ -88,7 +91,7 @@ Deno.test({
         const version = listResult._unsafeUnwrap().find((v) =>
           v.name === "E2E Updated Version"
         );
-        expect(version !== undefined).toBe(true);
+        expect(version).toBeDefined();
 
         const result = await deleteVersion(e2eContext, version!.id);
         expect(result.isOk()).toBe(true);

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -17,7 +17,7 @@ Deno.test({
       const project = projectsResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-test-project"
       );
-      expect(project !== undefined).toBe(true);
+      expect(project).toBeDefined();
       projectId = project!.id;
     });
 
@@ -26,7 +26,7 @@ Deno.test({
       async () => {
         const result = await fetchList(e2eContext, projectId);
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().length > 0).toBe(true);
+        expect(result._unsafeUnwrap().length).toBeGreaterThan(0);
       },
     );
 
@@ -35,8 +35,8 @@ Deno.test({
       async () => {
         const result = await show(e2eContext, projectId, "E2ETestPage");
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().title).toEqual("E2ETestPage");
-        expect(result._unsafeUnwrap().version >= 1).toBe(true);
+        expect(result._unsafeUnwrap().title).toStrictEqual("E2ETestPage");
+        expect(result._unsafeUnwrap().version).toBeGreaterThanOrEqual(1);
       },
     );
 
@@ -57,9 +57,12 @@ Deno.test({
       async () => {
         const result = await show(e2eContext, projectId, "E2ECreatedPage");
         expect(result.isOk()).toBe(true);
-        expect(result._unsafeUnwrap().title).toEqual("E2ECreatedPage");
-        expect(result._unsafeUnwrap().text).toEqual("Created by E2E test");
-        expect(result._unsafeUnwrap().version >= 1).toBe(true);
+        const page = result._unsafeUnwrap();
+        expect(page.title).toStrictEqual("E2ECreatedPage");
+        expect(page.text).toStrictEqual(
+          "Created by E2E test",
+        );
+        expect(page.version).toBeGreaterThanOrEqual(1);
       },
     );
 

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
 import { fetchList } from "../result/wiki-pages/list.ts";
 import { show } from "../result/wiki-pages/show.ts";
@@ -13,20 +13,20 @@ Deno.test({
 
     await t.step("resolve test project", async () => {
       const projectsResult = await fetchProjects(e2eContext);
-      assert(projectsResult.isOk());
-      const project = projectsResult.value.find((p) =>
+      expect(projectsResult.isOk()).toBe(true);
+      const project = projectsResult._unsafeUnwrap().find((p) =>
         p.identifier === "e2e-test-project"
       );
-      assert(project !== undefined);
-      projectId = project.id;
+      expect(project !== undefined).toBe(true);
+      projectId = project!.id;
     });
 
     await t.step(
       "GET /projects/:id/wiki/index.json should return wiki pages",
       async () => {
         const result = await fetchList(e2eContext, projectId);
-        assert(result.isOk());
-        assert(result.value.length > 0);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().length > 0).toBe(true);
       },
     );
 
@@ -34,9 +34,9 @@ Deno.test({
       "GET /projects/:id/wiki/:page.json should return a wiki page",
       async () => {
         const result = await show(e2eContext, projectId, "E2ETestPage");
-        assert(result.isOk());
-        assertEquals(result.value.title, "E2ETestPage");
-        assert(result.value.version >= 1);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().title).toEqual("E2ETestPage");
+        expect(result._unsafeUnwrap().version >= 1).toBe(true);
       },
     );
 
@@ -48,7 +48,7 @@ Deno.test({
           text: "Created by E2E test",
           comments: "E2E test creation",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
 
@@ -56,10 +56,10 @@ Deno.test({
       "GET /projects/:id/wiki/:page.json should return a wiki page with comments",
       async () => {
         const result = await show(e2eContext, projectId, "E2ECreatedPage");
-        assert(result.isOk());
-        assertEquals(result.value.title, "E2ECreatedPage");
-        assertEquals(result.value.text, "Created by E2E test");
-        assert(result.value.version >= 1);
+        expect(result.isOk()).toBe(true);
+        expect(result._unsafeUnwrap().title).toEqual("E2ECreatedPage");
+        expect(result._unsafeUnwrap().text).toEqual("Created by E2E test");
+        expect(result._unsafeUnwrap().version >= 1).toBe(true);
       },
     );
 
@@ -71,11 +71,14 @@ Deno.test({
           text: "Updated by E2E test",
           comments: "E2E test update",
         });
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
 
         const showResult = await show(e2eContext, projectId, "E2ECreatedPage");
-        assert(showResult.isOk());
-        assert(showResult.value.text.includes("Updated by E2E test"));
+        expect(showResult.isOk()).toBe(true);
+        expect(showResult._unsafeUnwrap().text.includes("Updated by E2E test"))
+          .toBe(
+            true,
+          );
       },
     );
 
@@ -87,7 +90,7 @@ Deno.test({
           projectId,
           "E2ECreatedPage",
         );
-        assert(result.isOk());
+        expect(result.isOk()).toBe(true);
       },
     );
   },

--- a/error.test.ts
+++ b/error.test.ts
@@ -9,18 +9,18 @@ Deno.test("RedmineResponseError.fromResponse captures status, statusText and bod
   const error = await RedmineResponseError.fromResponse(response);
 
   expect(error).toBeInstanceOf(RedmineResponseError);
-  expect(error.name).toEqual("RedmineResponseError");
-  expect(error.status).toEqual(422);
-  expect(error.statusText).toEqual("Unprocessable Entity");
-  expect(error.body).toEqual("id is required");
-  expect(error.message).toEqual("Unprocessable Entity");
+  expect(error.name).toStrictEqual("RedmineResponseError");
+  expect(error.status).toStrictEqual(422);
+  expect(error.statusText).toStrictEqual("Unprocessable Entity");
+  expect(error.body).toStrictEqual("id is required");
+  expect(error.message).toStrictEqual("Unprocessable Entity");
 });
 
 Deno.test("RedmineResponseError falls back to the status code when statusText is empty", async () => {
   const response = new Response("boom", { status: 500, statusText: "" });
   const error = await RedmineResponseError.fromResponse(response);
 
-  expect(error.message).toEqual("HTTP 500");
+  expect(error.message).toStrictEqual("HTTP 500");
 });
 
 Deno.test("RedmineResponseError does not populate cause", async () => {
@@ -42,7 +42,7 @@ Deno.test("RedmineResponseError.fromResponse falls back to empty body when the b
 
   const error = await RedmineResponseError.fromResponse(response);
 
-  expect(error.body).toEqual("");
+  expect(error.body).toStrictEqual("");
 });
 
 Deno.test("assertResponse resolves without throwing for an ok response", async () => {
@@ -63,6 +63,6 @@ Deno.test("assertResponse throws RedmineResponseError carrying the response deta
     error = e;
   }
   expect(error).toBeInstanceOf(RedmineResponseError);
-  expect((error as RedmineResponseError).status).toEqual(404);
-  expect((error as RedmineResponseError).body).toEqual("not found");
+  expect((error as RedmineResponseError).status).toStrictEqual(404);
+  expect((error as RedmineResponseError).body).toStrictEqual("not found");
 });

--- a/error.test.ts
+++ b/error.test.ts
@@ -1,9 +1,4 @@
-import {
-  assertEquals,
-  assertInstanceOf,
-  assertRejects,
-  assertStrictEquals,
-} from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { assertResponse, RedmineResponseError } from "./error.ts";
 
 Deno.test("RedmineResponseError.fromResponse captures status, statusText and body", async () => {
@@ -13,19 +8,19 @@ Deno.test("RedmineResponseError.fromResponse captures status, statusText and bod
   });
   const error = await RedmineResponseError.fromResponse(response);
 
-  assertInstanceOf(error, RedmineResponseError);
-  assertEquals(error.name, "RedmineResponseError");
-  assertEquals(error.status, 422);
-  assertEquals(error.statusText, "Unprocessable Entity");
-  assertEquals(error.body, "id is required");
-  assertEquals(error.message, "Unprocessable Entity");
+  expect(error).toBeInstanceOf(RedmineResponseError);
+  expect(error.name).toEqual("RedmineResponseError");
+  expect(error.status).toEqual(422);
+  expect(error.statusText).toEqual("Unprocessable Entity");
+  expect(error.body).toEqual("id is required");
+  expect(error.message).toEqual("Unprocessable Entity");
 });
 
 Deno.test("RedmineResponseError falls back to the status code when statusText is empty", async () => {
   const response = new Response("boom", { status: 500, statusText: "" });
   const error = await RedmineResponseError.fromResponse(response);
 
-  assertEquals(error.message, "HTTP 500");
+  expect(error.message).toEqual("HTTP 500");
 });
 
 Deno.test("RedmineResponseError does not populate cause", async () => {
@@ -35,7 +30,7 @@ Deno.test("RedmineResponseError does not populate cause", async () => {
   });
   const error = await RedmineResponseError.fromResponse(response);
 
-  assertStrictEquals(error.cause, undefined);
+  expect(error.cause).toBe(undefined);
 });
 
 Deno.test("RedmineResponseError.fromResponse falls back to empty body when the body is unreadable", async () => {
@@ -47,7 +42,7 @@ Deno.test("RedmineResponseError.fromResponse falls back to empty body when the b
 
   const error = await RedmineResponseError.fromResponse(response);
 
-  assertEquals(error.body, "");
+  expect(error.body).toEqual("");
 });
 
 Deno.test("assertResponse resolves without throwing for an ok response", async () => {
@@ -61,8 +56,13 @@ Deno.test("assertResponse throws RedmineResponseError carrying the response deta
     statusText: "Not Found",
   });
 
-  const error = await assertRejects(() => assertResponse(response));
-  assertInstanceOf(error, RedmineResponseError);
-  assertEquals(error.status, 404);
-  assertEquals(error.body, "not found");
+  let error: unknown;
+  try {
+    await assertResponse(response);
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBeInstanceOf(RedmineResponseError);
+  expect((error as RedmineResponseError).status).toEqual(404);
+  expect((error as RedmineResponseError).body).toEqual("not found");
 });

--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { fetchAllPages, type Page } from "./paging.ts";
 
 const nextTick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -25,7 +25,7 @@ function finiteSource(
 
 Deno.test("aggregates every page in ascending offset order", async () => {
   const result = await fetchAllPages(finiteSource(23), { pageSize: 10 });
-  assertEquals(result, range(0, 23));
+  expect(result).toEqual(range(0, 23));
 });
 
 Deno.test("returns an empty result without fetching data pages when the total is zero", async () => {
@@ -37,8 +37,8 @@ Deno.test("returns an empty result without fetching data pages when the total is
     },
     { pageSize: 10 },
   );
-  assertEquals(result, []);
-  assertEquals(offsets, [0]);
+  expect(result).toEqual([]);
+  expect(offsets).toEqual([0]);
 });
 
 Deno.test("keeps offset order even when later pages settle first", async () => {
@@ -52,7 +52,7 @@ Deno.test("keeps offset order even when later pages settle first", async () => {
     },
     { pageSize: 10, concurrency: 6 },
   );
-  assertEquals(result, range(0, 30));
+  expect(result).toEqual(range(0, 30));
 });
 
 Deno.test("never exceeds the concurrency bound for data pages", async () => {
@@ -71,8 +71,8 @@ Deno.test("never exceeds the concurrency bound for data pages", async () => {
     },
     { pageSize: 10, concurrency: 3 },
   );
-  assertEquals(result, range(0, 100));
-  assertEquals(maxInFlight, 3);
+  expect(result).toEqual(range(0, 100));
+  expect(maxInFlight).toEqual(3);
 });
 
 Deno.test("fetches a single page when the total fits within one page", async () => {
@@ -87,8 +87,8 @@ Deno.test("fetches a single page when the total fits within one page", async () 
     },
     { pageSize: 10 },
   );
-  assertEquals(result, range(0, 5));
-  assertEquals(calls, [{ limit: 10, offset: 0 }]);
+  expect(result).toEqual(range(0, 5));
+  expect(calls).toEqual([{ limit: 10, offset: 0 }]);
 });
 
 Deno.test("rejects a pageSize outside Redmine's 1-to-100 range", async () => {
@@ -96,10 +96,8 @@ Deno.test("rejects a pageSize outside Redmine's 1-to-100 range", async () => {
   // full pageSize, which would silently skip records; at or below zero the walk
   // cannot advance.
   for (const pageSize of [0, -1, 101, 10.5]) {
-    await assertRejects(
-      () => fetchAllPages(finiteSource(50), { pageSize }),
-      RangeError,
-    );
+    await expect(fetchAllPages(finiteSource(50), { pageSize })).rejects
+      .toThrow(RangeError);
   }
 });
 
@@ -110,7 +108,7 @@ Deno.test("clamps a non-positive concurrency to at least one", async () => {
     pageSize: 10,
     concurrency: 0,
   });
-  assertEquals(result, range(0, 30));
+  expect(result).toEqual(range(0, 30));
 });
 
 Deno.test("stops at the requested limit and slices off the over-fetch", async () => {
@@ -125,9 +123,9 @@ Deno.test("stops at the requested limit and slices off the over-fetch", async ()
     },
     { pageSize: 100, limit: 250 },
   );
-  assertEquals(result, range(0, 250));
+  expect(result).toEqual(range(0, 250));
   // No count probe; the last page requests only the remaining 50 items.
-  assertEquals(calls, [
+  expect(calls).toEqual([
     { limit: 100, offset: 0 },
     { limit: 100, offset: 100 },
     { limit: 50, offset: 200 },
@@ -146,6 +144,6 @@ Deno.test("stops early when the source is exhausted before the limit", async () 
     },
     { pageSize: 100, limit: 250 },
   );
-  assertEquals(result, range(0, 30));
-  assertEquals(calls, [{ limit: 100, offset: 0 }]);
+  expect(result).toEqual(range(0, 30));
+  expect(calls).toEqual([{ limit: 100, offset: 0 }]);
 });

--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -25,7 +25,7 @@ function finiteSource(
 
 Deno.test("aggregates every page in ascending offset order", async () => {
   const result = await fetchAllPages(finiteSource(23), { pageSize: 10 });
-  expect(result).toEqual(range(0, 23));
+  expect(result).toStrictEqual(range(0, 23));
 });
 
 Deno.test("returns an empty result without fetching data pages when the total is zero", async () => {
@@ -37,8 +37,8 @@ Deno.test("returns an empty result without fetching data pages when the total is
     },
     { pageSize: 10 },
   );
-  expect(result).toEqual([]);
-  expect(offsets).toEqual([0]);
+  expect(result).toStrictEqual([]);
+  expect(offsets).toStrictEqual([0]);
 });
 
 Deno.test("keeps offset order even when later pages settle first", async () => {
@@ -52,7 +52,7 @@ Deno.test("keeps offset order even when later pages settle first", async () => {
     },
     { pageSize: 10, concurrency: 6 },
   );
-  expect(result).toEqual(range(0, 30));
+  expect(result).toStrictEqual(range(0, 30));
 });
 
 Deno.test("never exceeds the concurrency bound for data pages", async () => {
@@ -71,8 +71,8 @@ Deno.test("never exceeds the concurrency bound for data pages", async () => {
     },
     { pageSize: 10, concurrency: 3 },
   );
-  expect(result).toEqual(range(0, 100));
-  expect(maxInFlight).toEqual(3);
+  expect(result).toStrictEqual(range(0, 100));
+  expect(maxInFlight).toStrictEqual(3);
 });
 
 Deno.test("fetches a single page when the total fits within one page", async () => {
@@ -87,8 +87,8 @@ Deno.test("fetches a single page when the total fits within one page", async () 
     },
     { pageSize: 10 },
   );
-  expect(result).toEqual(range(0, 5));
-  expect(calls).toEqual([{ limit: 10, offset: 0 }]);
+  expect(result).toStrictEqual(range(0, 5));
+  expect(calls).toStrictEqual([{ limit: 10, offset: 0 }]);
 });
 
 Deno.test("rejects a pageSize outside Redmine's 1-to-100 range", async () => {
@@ -108,7 +108,7 @@ Deno.test("clamps a non-positive concurrency to at least one", async () => {
     pageSize: 10,
     concurrency: 0,
   });
-  expect(result).toEqual(range(0, 30));
+  expect(result).toStrictEqual(range(0, 30));
 });
 
 Deno.test("stops at the requested limit and slices off the over-fetch", async () => {
@@ -123,9 +123,9 @@ Deno.test("stops at the requested limit and slices off the over-fetch", async ()
     },
     { pageSize: 100, limit: 250 },
   );
-  expect(result).toEqual(range(0, 250));
+  expect(result).toStrictEqual(range(0, 250));
   // No count probe; the last page requests only the remaining 50 items.
-  expect(calls).toEqual([
+  expect(calls).toStrictEqual([
     { limit: 100, offset: 0 },
     { limit: 100, offset: 100 },
     { limit: 50, offset: 200 },
@@ -144,6 +144,6 @@ Deno.test("stops early when the source is exhausted before the limit", async () 
     },
     { pageSize: 100, limit: 250 },
   );
-  expect(result).toEqual(range(0, 30));
-  expect(calls).toEqual([{ limit: 100, offset: 0 }]);
+  expect(result).toStrictEqual(range(0, 30));
+  expect(calls).toStrictEqual([{ limit: 100, offset: 0 }]);
 });

--- a/internal/url.test.ts
+++ b/internal/url.test.ts
@@ -2,23 +2,24 @@ import { expect } from "jsr:@std/expect@1.0.20";
 import { buildUrl } from "./url.ts";
 
 Deno.test("buildUrl appends segments to a bare endpoint", () => {
-  expect(buildUrl("https://example.com", "projects", "1.json").href).toEqual(
-    "https://example.com/projects/1.json",
-  );
+  expect(buildUrl("https://example.com", "projects", "1.json").href)
+    .toStrictEqual(
+      "https://example.com/projects/1.json",
+    );
 });
 
 Deno.test("buildUrl keeps the scheme intact (no `https:/` collapse)", () => {
   const url = buildUrl("https://example.com", "projects.json");
-  expect(url.protocol).toEqual("https:");
-  expect(url.host).toEqual("example.com");
+  expect(url.protocol).toStrictEqual("https:");
+  expect(url.host).toStrictEqual("example.com");
 });
 
 Deno.test("buildUrl preserves a base path for subpath installations", () => {
   expect(buildUrl("https://example.com/redmine", "projects", "1.json").href)
-    .toEqual("https://example.com/redmine/projects/1.json");
+    .toStrictEqual("https://example.com/redmine/projects/1.json");
 });
 
 Deno.test("buildUrl preserves a base path regardless of a trailing slash", () => {
   expect(buildUrl("https://example.com/redmine/", "projects", "1.json").href)
-    .toEqual("https://example.com/redmine/projects/1.json");
+    .toStrictEqual("https://example.com/redmine/projects/1.json");
 });

--- a/internal/url.test.ts
+++ b/internal/url.test.ts
@@ -1,29 +1,24 @@
-import { assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { buildUrl } from "./url.ts";
 
 Deno.test("buildUrl appends segments to a bare endpoint", () => {
-  assertEquals(
-    buildUrl("https://example.com", "projects", "1.json").href,
+  expect(buildUrl("https://example.com", "projects", "1.json").href).toEqual(
     "https://example.com/projects/1.json",
   );
 });
 
 Deno.test("buildUrl keeps the scheme intact (no `https:/` collapse)", () => {
   const url = buildUrl("https://example.com", "projects.json");
-  assertEquals(url.protocol, "https:");
-  assertEquals(url.host, "example.com");
+  expect(url.protocol).toEqual("https:");
+  expect(url.host).toEqual("example.com");
 });
 
 Deno.test("buildUrl preserves a base path for subpath installations", () => {
-  assertEquals(
-    buildUrl("https://example.com/redmine", "projects", "1.json").href,
-    "https://example.com/redmine/projects/1.json",
-  );
+  expect(buildUrl("https://example.com/redmine", "projects", "1.json").href)
+    .toEqual("https://example.com/redmine/projects/1.json");
 });
 
 Deno.test("buildUrl preserves a base path regardless of a trailing slash", () => {
-  assertEquals(
-    buildUrl("https://example.com/redmine/", "projects", "1.json").href,
-    "https://example.com/redmine/projects/1.json",
-  );
+  expect(buildUrl("https://example.com/redmine/", "projects", "1.json").href)
+    .toEqual("https://example.com/redmine/projects/1.json");
 });

--- a/result/attachments/delete.test.ts
+++ b/result/attachments/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteAttachment } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /attachments/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteAttachment(context, 6243);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /attachments/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteAttachment(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteAttachment(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/attachments/show.test.ts
+++ b/result/attachments/show.test.ts
@@ -19,16 +19,17 @@ Deno.test("GET /attachments/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 6243);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().id).toEqual(6243);
-      expect(e._unsafeUnwrap().filename).toEqual("example.txt");
-      expect(e._unsafeUnwrap().contentType).toEqual("text/plain");
-      expect(e._unsafeUnwrap().contentUrl).toEqual(
+      const attachment = e._unsafeUnwrap();
+      expect(attachment.id).toStrictEqual(6243);
+      expect(attachment.filename).toStrictEqual("example.txt");
+      expect(attachment.contentType).toStrictEqual("text/plain");
+      expect(attachment.contentUrl).toStrictEqual(
         "http://redmine.example.com/attachments/download/6243/example.txt",
       );
-      expect(e._unsafeUnwrap().thumbnailUrl).toEqual(
+      expect(attachment.thumbnailUrl).toStrictEqual(
         "http://redmine.example.com/attachments/thumbnail/6243",
       );
-      expect(e._unsafeUnwrap().author).toEqual({
+      expect(attachment.author).toStrictEqual({
         id: 1,
         name: "Redmine Admin",
       });

--- a/result/attachments/show.test.ts
+++ b/result/attachments/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /attachments/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 6243);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,19 +18,20 @@ Deno.test("GET /attachments/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 6243);
-      assert(e.isOk());
-      assertEquals(e.value.id, 6243);
-      assertEquals(e.value.filename, "example.txt");
-      assertEquals(e.value.contentType, "text/plain");
-      assertEquals(
-        e.value.contentUrl,
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().id).toEqual(6243);
+      expect(e._unsafeUnwrap().filename).toEqual("example.txt");
+      expect(e._unsafeUnwrap().contentType).toEqual("text/plain");
+      expect(e._unsafeUnwrap().contentUrl).toEqual(
         "http://redmine.example.com/attachments/download/6243/example.txt",
       );
-      assertEquals(
-        e.value.thumbnailUrl,
+      expect(e._unsafeUnwrap().thumbnailUrl).toEqual(
         "http://redmine.example.com/attachments/thumbnail/6243",
       );
-      assertEquals(e.value.author, { id: 1, name: "Redmine Admin" });
+      expect(e._unsafeUnwrap().author).toEqual({
+        id: 1,
+        name: "Redmine Admin",
+      });
     },
   );
 
@@ -39,13 +40,13 @@ Deno.test("GET /attachments/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/attachments/update.test.ts
+++ b/result/attachments/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PATCH /attachments/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 6243, { filename: "renamed.txt" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PATCH /attachments/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { filename: "renamed.txt" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { filename: "renamed.txt" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -49,9 +49,9 @@ Deno.test("PATCH /attachments/:id.json", async (t) => {
         filename: "renamed.txt",
         description: "Updated description",
       });
-      assert(e.isOk());
-      assertEquals(captured?.filename, "renamed.txt");
-      assertEquals(captured?.description, "Updated description");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.filename).toEqual("renamed.txt");
+      expect(captured?.description).toEqual("Updated description");
     },
   );
 });

--- a/result/attachments/update.test.ts
+++ b/result/attachments/update.test.ts
@@ -50,8 +50,8 @@ Deno.test("PATCH /attachments/:id.json", async (t) => {
         description: "Updated description",
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.filename).toEqual("renamed.txt");
-      expect(captured?.description).toEqual("Updated description");
+      expect(captured?.filename).toStrictEqual("renamed.txt");
+      expect(captured?.description).toStrictEqual("Updated description");
     },
   );
 });

--- a/result/custom-fields/list.test.ts
+++ b/result/custom-fields/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,9 +19,9 @@ Deno.test("GET /custom_fields.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 3);
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(3);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         name: "Affected version",
         customizedType: "issue",
@@ -39,7 +39,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
         trackers: [{ id: 1, name: "Bug" }],
         roles: [{ id: 3, name: "Manager" }],
       });
-      assertEquals(e.value[1], {
+      expect(e._unsafeUnwrap()[1]).toEqual({
         id: 2,
         name: "Database",
         customizedType: "project",
@@ -57,7 +57,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
         multiple: false,
         visible: true,
       });
-      assertEquals(e.value[2].possibleValues, [
+      expect(e._unsafeUnwrap()[2].possibleValues).toEqual([
         { value: "a" },
         { value: "b" },
       ]);
@@ -69,7 +69,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/custom-fields/list.test.ts
+++ b/result/custom-fields/list.test.ts
@@ -20,8 +20,9 @@ Deno.test("GET /custom_fields.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(3);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      const customFields = e._unsafeUnwrap();
+      expect(customFields.length).toStrictEqual(3);
+      expect(customFields[0]).toStrictEqual({
         id: 1,
         name: "Affected version",
         customizedType: "issue",
@@ -39,7 +40,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
         trackers: [{ id: 1, name: "Bug" }],
         roles: [{ id: 3, name: "Manager" }],
       });
-      expect(e._unsafeUnwrap()[1]).toEqual({
+      expect(customFields[1]).toStrictEqual({
         id: 2,
         name: "Database",
         customizedType: "project",
@@ -57,7 +58,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
         multiple: false,
         visible: true,
       });
-      expect(e._unsafeUnwrap()[2].possibleValues).toEqual([
+      expect(customFields[2].possibleValues).toStrictEqual([
         { value: "a" },
         { value: "b" },
       ]);

--- a/result/enumerations/list-document-categories.test.ts
+++ b/result/enumerations/list-document-categories.test.ts
@@ -24,8 +24,8 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await listDocumentCategories(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      expect(e._unsafeUnwrap().length).toStrictEqual(2);
+      expect(e._unsafeUnwrap()[0]).toStrictEqual({
         id: 1,
         name: "User documentation",
         isDefault: false,

--- a/result/enumerations/list-document-categories.test.ts
+++ b/result/enumerations/list-document-categories.test.ts
@@ -6,7 +6,7 @@ import {
   validHandlers,
 } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -15,7 +15,7 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await listDocumentCategories(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -23,9 +23,9 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await listDocumentCategories(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         name: "User documentation",
         isDefault: false,
@@ -39,13 +39,13 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await listDocumentCategories(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
     const e = await listDocumentCategories(context);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/enumerations/list-issue-priorities.test.ts
+++ b/result/enumerations/list-issue-priorities.test.ts
@@ -24,8 +24,8 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await listIssuePriorities(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(3);
-      expect(e._unsafeUnwrap()[1]).toEqual({
+      expect(e._unsafeUnwrap().length).toStrictEqual(3);
+      expect(e._unsafeUnwrap()[1]).toStrictEqual({
         id: 4,
         name: "Normal",
         isDefault: true,

--- a/result/enumerations/list-issue-priorities.test.ts
+++ b/result/enumerations/list-issue-priorities.test.ts
@@ -6,7 +6,7 @@ import {
   validHandlers,
 } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -15,7 +15,7 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await listIssuePriorities(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -23,9 +23,9 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await listIssuePriorities(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 3);
-      assertEquals(e.value[1], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(3);
+      expect(e._unsafeUnwrap()[1]).toEqual({
         id: 4,
         name: "Normal",
         isDefault: true,
@@ -39,13 +39,13 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await listIssuePriorities(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
     const e = await listIssuePriorities(context);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/enumerations/list-time-entry-activities.test.ts
+++ b/result/enumerations/list-time-entry-activities.test.ts
@@ -24,8 +24,8 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await listTimeEntryActivities(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[1]).toEqual({
+      expect(e._unsafeUnwrap().length).toStrictEqual(2);
+      expect(e._unsafeUnwrap()[1]).toStrictEqual({
         id: 9,
         name: "Development",
         isDefault: true,

--- a/result/enumerations/list-time-entry-activities.test.ts
+++ b/result/enumerations/list-time-entry-activities.test.ts
@@ -6,7 +6,7 @@ import {
   validHandlers,
 } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -15,7 +15,7 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await listTimeEntryActivities(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -23,9 +23,9 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await listTimeEntryActivities(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[1], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[1]).toEqual({
         id: 9,
         name: "Development",
         isDefault: true,
@@ -39,13 +39,13 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await listTimeEntryActivities(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
     const e = await listTimeEntryActivities(context);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/files/create.test.ts
+++ b/result/files/create.test.ts
@@ -53,10 +53,10 @@ Deno.test("POST /projects/:project_id/files.json", async (t) => {
         description: "A dummy attachment",
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.token).toEqual("abc");
-      expect(captured?.version_id).toEqual(3);
-      expect(captured?.filename).toEqual("foo.zip");
-      expect(captured?.description).toEqual("A dummy attachment");
+      expect(captured?.token).toStrictEqual("abc");
+      expect(captured?.version_id).toStrictEqual(3);
+      expect(captured?.filename).toStrictEqual("foo.zip");
+      expect(captured?.description).toStrictEqual("A dummy attachment");
     },
   );
 });

--- a/result/files/create.test.ts
+++ b/result/files/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /projects/:project_id/files.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await create(context, 1, { token: "abc" });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,14 +22,14 @@ Deno.test("POST /projects/:project_id/files.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await create(context, 422, { token: "abc" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await create(context, 404, { token: "abc" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -52,11 +52,11 @@ Deno.test("POST /projects/:project_id/files.json", async (t) => {
         filename: "foo.zip",
         description: "A dummy attachment",
       });
-      assert(e.isOk());
-      assertEquals(captured?.token, "abc");
-      assertEquals(captured?.version_id, 3);
-      assertEquals(captured?.filename, "foo.zip");
-      assertEquals(captured?.description, "A dummy attachment");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.token).toEqual("abc");
+      expect(captured?.version_id).toEqual(3);
+      expect(captured?.filename).toEqual("foo.zip");
+      expect(captured?.description).toEqual("A dummy attachment");
     },
   );
 });

--- a/result/files/list.test.ts
+++ b/result/files/list.test.ts
@@ -19,17 +19,18 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0].contentType).toEqual("application/zip");
-      expect(e._unsafeUnwrap()[0].contentUrl).toEqual(
+      const files = e._unsafeUnwrap();
+      expect(files.length).toStrictEqual(2);
+      expect(files[0].contentType).toStrictEqual("application/zip");
+      expect(files[0].contentUrl).toStrictEqual(
         "http://redmine.example.com/attachments/download/12/foo.zip",
       );
-      expect(e._unsafeUnwrap()[0].version).toEqual({ id: 3, name: "v1.0" });
-      expect(e._unsafeUnwrap()[0].createdOn).toEqual(
+      expect(files[0].version).toStrictEqual({ id: 3, name: "v1.0" });
+      expect(files[0].createdOn).toStrictEqual(
         new Date("2026-07-13T00:00:00.000Z"),
       );
-      expect(e._unsafeUnwrap()[1].description).toEqual(undefined);
-      expect(e._unsafeUnwrap()[1].version).toEqual(undefined);
+      expect(files[1].description).toBeUndefined();
+      expect(files[1].version).toBeUndefined();
     },
   );
 

--- a/result/files/list.test.ts
+++ b/result/files/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,17 +18,18 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0].contentType, "application/zip");
-      assertEquals(
-        e.value[0].contentUrl,
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0].contentType).toEqual("application/zip");
+      expect(e._unsafeUnwrap()[0].contentUrl).toEqual(
         "http://redmine.example.com/attachments/download/12/foo.zip",
       );
-      assertEquals(e.value[0].version, { id: 3, name: "v1.0" });
-      assertEquals(e.value[0].createdOn, new Date("2026-07-13T00:00:00.000Z"));
-      assertEquals(e.value[1].description, undefined);
-      assertEquals(e.value[1].version, undefined);
+      expect(e._unsafeUnwrap()[0].version).toEqual({ id: 3, name: "v1.0" });
+      expect(e._unsafeUnwrap()[0].createdOn).toEqual(
+        new Date("2026-07-13T00:00:00.000Z"),
+      );
+      expect(e._unsafeUnwrap()[1].description).toEqual(undefined);
+      expect(e._unsafeUnwrap()[1].version).toEqual(undefined);
     },
   );
 
@@ -37,13 +38,13 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await fetchList(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/files/upload.test.ts
+++ b/result/files/upload.test.ts
@@ -13,7 +13,9 @@ Deno.test("POST /uploads.json", async (t) => {
     server.resetHandlers(...validHandlers);
     const e = await upload(context, new TextEncoder().encode("content"));
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap()).toEqual("7167.ed1ccdb093229ca1bd0b043618d88743");
+    expect(e._unsafeUnwrap()).toStrictEqual(
+      "7167.ed1ccdb093229ca1bd0b043618d88743",
+    );
   });
 
   await t.step(
@@ -37,10 +39,10 @@ Deno.test("POST /uploads.json", async (t) => {
         "foo.zip",
       );
       expect(e.isOk()).toBe(true);
-      expect(new URL(capturedUrl!).searchParams.get("filename")).toEqual(
+      expect(new URL(capturedUrl!).searchParams.get("filename")).toStrictEqual(
         "foo.zip",
       );
-      expect(capturedContentType).toEqual("application/octet-stream");
+      expect(capturedContentType).toStrictEqual("application/octet-stream");
     },
   );
 

--- a/result/files/upload.test.ts
+++ b/result/files/upload.test.ts
@@ -1,5 +1,5 @@
 import { upload } from "./upload.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -12,8 +12,8 @@ Deno.test("POST /uploads.json", async (t) => {
   await t.step("if got 201, should return the upload token", async () => {
     server.resetHandlers(...validHandlers);
     const e = await upload(context, new TextEncoder().encode("content"));
-    assert(e.isOk());
-    assertEquals(e.value, "7167.ed1ccdb093229ca1bd0b043618d88743");
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap()).toEqual("7167.ed1ccdb093229ca1bd0b043618d88743");
   });
 
   await t.step(
@@ -36,12 +36,11 @@ Deno.test("POST /uploads.json", async (t) => {
         new TextEncoder().encode("content"),
         "foo.zip",
       );
-      assert(e.isOk());
-      assertEquals(
-        new URL(capturedUrl!).searchParams.get("filename"),
+      expect(e.isOk()).toBe(true);
+      expect(new URL(capturedUrl!).searchParams.get("filename")).toEqual(
         "foo.zip",
       );
-      assertEquals(capturedContentType, "application/octet-stream");
+      expect(capturedContentType).toEqual("application/octet-stream");
     },
   );
 
@@ -60,7 +59,7 @@ Deno.test("POST /uploads.json", async (t) => {
         }),
       );
       const e = await upload(context, new TextEncoder().encode("content"));
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -72,6 +71,6 @@ Deno.test("POST /uploads.json", async (t) => {
       }),
     );
     const e = await upload(context, new TextEncoder().encode("content"));
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/groups/add-user.test.ts
+++ b/result/groups/add-user.test.ts
@@ -1,5 +1,5 @@
 import { addUser } from "./add-user.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("POST /groups/:id/users.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await addUser(context, 20, 5);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("POST /groups/:id/users.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await addUser(context, 422, 5);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await addUser(context, 404, 5);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step("should send the user id as user_id", async () => {
@@ -42,7 +42,7 @@ Deno.test("POST /groups/:id/users.json", async (t) => {
       ),
     );
     const e = await addUser(context, 20, 5);
-    assert(e.isOk());
-    assertEquals(captured?.user_id, 5);
+    expect(e.isOk()).toBe(true);
+    expect(captured?.user_id).toEqual(5);
   });
 });

--- a/result/groups/add-user.test.ts
+++ b/result/groups/add-user.test.ts
@@ -43,6 +43,6 @@ Deno.test("POST /groups/:id/users.json", async (t) => {
     );
     const e = await addUser(context, 20, 5);
     expect(e.isOk()).toBe(true);
-    expect(captured?.user_id).toEqual(5);
+    expect(captured?.user_id).toStrictEqual(5);
   });
 });

--- a/result/groups/create.test.ts
+++ b/result/groups/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /groups.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await create(context, { name: "Developers" });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,7 +22,7 @@ Deno.test("POST /groups.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await create(context, { name: "Developers" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -44,9 +44,9 @@ Deno.test("POST /groups.json", async (t) => {
         name: "Developers",
         userIds: [3, 5],
       });
-      assert(e.isOk());
-      assertEquals(captured?.name, "Developers");
-      assertEquals(captured?.user_ids, [3, 5]);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.name).toEqual("Developers");
+      expect(captured?.user_ids).toEqual([3, 5]);
     },
   );
 });

--- a/result/groups/create.test.ts
+++ b/result/groups/create.test.ts
@@ -45,8 +45,8 @@ Deno.test("POST /groups.json", async (t) => {
         userIds: [3, 5],
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.name).toEqual("Developers");
-      expect(captured?.user_ids).toEqual([3, 5]);
+      expect(captured?.name).toStrictEqual("Developers");
+      expect(captured?.user_ids).toStrictEqual([3, 5]);
     },
   );
 });

--- a/result/groups/delete.test.ts
+++ b/result/groups/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteGroup } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /groups/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await deleteGroup(context, 20);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /groups/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await deleteGroup(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await deleteGroup(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/groups/list.test.ts
+++ b/result/groups/list.test.ts
@@ -19,9 +19,13 @@ Deno.test("GET /groups.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0]).toEqual({ id: 53, name: "Managers" });
-      expect(e._unsafeUnwrap()[1]).toEqual({ id: 55, name: "Developers" });
+      const groups = e._unsafeUnwrap();
+      expect(groups.length).toStrictEqual(2);
+      expect(groups[0]).toStrictEqual({ id: 53, name: "Managers" });
+      expect(groups[1]).toStrictEqual({
+        id: 55,
+        name: "Developers",
+      });
     },
   );
 

--- a/result/groups/list.test.ts
+++ b/result/groups/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("GET /groups.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,10 +18,10 @@ Deno.test("GET /groups.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0], { id: 53, name: "Managers" });
-      assertEquals(e.value[1], { id: 55, name: "Developers" });
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0]).toEqual({ id: 53, name: "Managers" });
+      expect(e._unsafeUnwrap()[1]).toEqual({ id: 55, name: "Developers" });
     },
   );
 
@@ -30,7 +30,7 @@ Deno.test("GET /groups.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/groups/remove-user.test.ts
+++ b/result/groups/remove-user.test.ts
@@ -1,5 +1,5 @@
 import { removeUser } from "./remove-user.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /groups/:id/users/:user_id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await removeUser(context, 20, 5);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /groups/:id/users/:user_id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await removeUser(context, 422, 5);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await removeUser(context, 404, 5);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/groups/show.test.ts
+++ b/result/groups/show.test.ts
@@ -1,5 +1,5 @@
 import { show } from "./show.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,12 +10,15 @@ Deno.test("GET /groups/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.resetHandlers(...validHandlers);
     const e = await show(context, 20);
-    assert(e.isOk());
-    assertEquals(e.value.id, 20);
-    assertEquals(e.value.name, "Developers");
-    assert(e.value.users !== undefined);
-    assertEquals(e.value.users?.[0], { id: 5, name: "John Smith" });
-    assertEquals(e.value.memberships?.[0].project, { id: 1, name: "Demo" });
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().id).toEqual(20);
+    expect(e._unsafeUnwrap().name).toEqual("Developers");
+    expect(e._unsafeUnwrap().users !== undefined).toBe(true);
+    expect(e._unsafeUnwrap().users?.[0]).toEqual({ id: 5, name: "John Smith" });
+    expect(e._unsafeUnwrap().memberships?.[0].project).toEqual({
+      id: 1,
+      name: "Demo",
+    });
   });
 
   await t.step(
@@ -23,13 +26,13 @@ Deno.test("GET /groups/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/groups/show.test.ts
+++ b/result/groups/show.test.ts
@@ -11,11 +11,12 @@ Deno.test("GET /groups/:id.json", async (t) => {
     server.resetHandlers(...validHandlers);
     const e = await show(context, 20);
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().id).toEqual(20);
-    expect(e._unsafeUnwrap().name).toEqual("Developers");
-    expect(e._unsafeUnwrap().users !== undefined).toBe(true);
-    expect(e._unsafeUnwrap().users?.[0]).toEqual({ id: 5, name: "John Smith" });
-    expect(e._unsafeUnwrap().memberships?.[0].project).toEqual({
+    const group = e._unsafeUnwrap();
+    expect(group.id).toStrictEqual(20);
+    expect(group.name).toStrictEqual("Developers");
+    expect(group.users).toBeDefined();
+    expect(group.users?.[0]).toStrictEqual({ id: 5, name: "John Smith" });
+    expect(group.memberships?.[0].project).toStrictEqual({
       id: 1,
       name: "Demo",
     });

--- a/result/groups/update.test.ts
+++ b/result/groups/update.test.ts
@@ -49,7 +49,7 @@ Deno.test("PUT /groups/:id.json", async (t) => {
       );
       const e = await update(context, 20, { userIds: [3, 5] });
       expect(e.isOk()).toBe(true);
-      expect(captured?.user_ids).toEqual([3, 5]);
+      expect(captured?.user_ids).toStrictEqual([3, 5]);
     },
   );
 });

--- a/result/groups/update.test.ts
+++ b/result/groups/update.test.ts
@@ -1,5 +1,5 @@
 import { update } from "./update.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("PUT /groups/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await update(context, 20, { name: "Developers" });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,14 +22,14 @@ Deno.test("PUT /groups/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await update(context, 422, { name: "Developers" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await update(context, 404, { name: "Developers" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -48,8 +48,8 @@ Deno.test("PUT /groups/:id.json", async (t) => {
         ),
       );
       const e = await update(context, 20, { userIds: [3, 5] });
-      assert(e.isOk());
-      assertEquals(captured?.user_ids, [3, 5]);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.user_ids).toEqual([3, 5]);
     },
   );
 });

--- a/result/issue-categories/create.test.ts
+++ b/result/issue-categories/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /projects/:project_id/issue_categories.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await create(context, 1, { name: "Bug" });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,14 +22,14 @@ Deno.test("POST /projects/:project_id/issue_categories.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await create(context, 422, { name: "Bug" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await create(context, 404, { name: "Bug" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -52,9 +52,9 @@ Deno.test("POST /projects/:project_id/issue_categories.json", async (t) => {
         name: "Bug",
         assignedToId: 5,
       });
-      assert(e.isOk());
-      assertEquals(captured?.name, "Bug");
-      assertEquals(captured?.assigned_to_id, 5);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.name).toEqual("Bug");
+      expect(captured?.assigned_to_id).toEqual(5);
     },
   );
 });

--- a/result/issue-categories/create.test.ts
+++ b/result/issue-categories/create.test.ts
@@ -53,8 +53,8 @@ Deno.test("POST /projects/:project_id/issue_categories.json", async (t) => {
         assignedToId: 5,
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.name).toEqual("Bug");
-      expect(captured?.assigned_to_id).toEqual(5);
+      expect(captured?.name).toStrictEqual("Bug");
+      expect(captured?.assigned_to_id).toStrictEqual(5);
     },
   );
 });

--- a/result/issue-categories/delete.test.ts
+++ b/result/issue-categories/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteIssueCategory } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /issue_categories/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteIssueCategory(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /issue_categories/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteIssueCategory(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteIssueCategory(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-categories/list.test.ts
+++ b/result/issue-categories/list.test.ts
@@ -1,7 +1,7 @@
 import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,9 +18,9 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value[0].assignedTo, { id: 5, name: "Alice" });
-      assertEquals(e.value[1].assignedTo, undefined);
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap()[0].assignedTo).toEqual({ id: 5, name: "Alice" });
+      expect(e._unsafeUnwrap()[1].assignedTo).toEqual(undefined);
     },
   );
 
@@ -29,13 +29,13 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await fetchList(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await fetchList(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-categories/list.test.ts
+++ b/result/issue-categories/list.test.ts
@@ -19,8 +19,11 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap()[0].assignedTo).toEqual({ id: 5, name: "Alice" });
-      expect(e._unsafeUnwrap()[1].assignedTo).toEqual(undefined);
+      expect(e._unsafeUnwrap()[0].assignedTo).toStrictEqual({
+        id: 5,
+        name: "Alice",
+      });
+      expect(e._unsafeUnwrap()[1].assignedTo).toBeUndefined();
     },
   );
 

--- a/result/issue-categories/show.test.ts
+++ b/result/issue-categories/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /issue_categories/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,8 +18,8 @@ Deno.test("GET /issue_categories/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 3);
-      assert(e.isOk());
-      assertEquals(e.value.assignedTo, { id: 5, name: "Alice" });
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().assignedTo).toEqual({ id: 5, name: "Alice" });
     },
   );
 
@@ -28,13 +28,13 @@ Deno.test("GET /issue_categories/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-categories/show.test.ts
+++ b/result/issue-categories/show.test.ts
@@ -19,7 +19,10 @@ Deno.test("GET /issue_categories/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 3);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().assignedTo).toEqual({ id: 5, name: "Alice" });
+      expect(e._unsafeUnwrap().assignedTo).toStrictEqual({
+        id: 5,
+        name: "Alice",
+      });
     },
   );
 

--- a/result/issue-categories/update.test.ts
+++ b/result/issue-categories/update.test.ts
@@ -49,7 +49,7 @@ Deno.test("PUT /issue_categories/:id.json", async (t) => {
         assignedToId: 7,
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.assigned_to_id).toEqual(7);
+      expect(captured?.assigned_to_id).toStrictEqual(7);
     },
   );
 });

--- a/result/issue-categories/update.test.ts
+++ b/result/issue-categories/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /issue_categories/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 3, { name: "Bugfix" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /issue_categories/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { name: "Bugfix" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { name: "Bugfix" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -48,8 +48,8 @@ Deno.test("PUT /issue_categories/:id.json", async (t) => {
       const e = await update(context, 3, {
         assignedToId: 7,
       });
-      assert(e.isOk());
-      assertEquals(captured?.assigned_to_id, 7);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.assigned_to_id).toEqual(7);
     },
   );
 });

--- a/result/issue-relations/create.test.ts
+++ b/result/issue-relations/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -16,7 +16,7 @@ Deno.test("POST /issues/:issue_id/relations.json", async (t) => {
         issueToId: 2,
         relationType: "relates",
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -28,7 +28,7 @@ Deno.test("POST /issues/:issue_id/relations.json", async (t) => {
         issueToId: 2,
         relationType: "relates",
       });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -38,7 +38,7 @@ Deno.test("POST /issues/:issue_id/relations.json", async (t) => {
       issueToId: 2,
       relationType: "relates",
     });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -60,10 +60,10 @@ Deno.test("POST /issues/:issue_id/relations.json", async (t) => {
         relationType: "precedes",
         delay: 3,
       });
-      assert(e.isOk());
-      assertEquals(captured?.issue_to_id, 2);
-      assertEquals(captured?.relation_type, "precedes");
-      assertEquals(captured?.delay, 3);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.issue_to_id).toEqual(2);
+      expect(captured?.relation_type).toEqual("precedes");
+      expect(captured?.delay).toEqual(3);
     },
   );
 });

--- a/result/issue-relations/create.test.ts
+++ b/result/issue-relations/create.test.ts
@@ -61,9 +61,9 @@ Deno.test("POST /issues/:issue_id/relations.json", async (t) => {
         delay: 3,
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.issue_to_id).toEqual(2);
-      expect(captured?.relation_type).toEqual("precedes");
-      expect(captured?.delay).toEqual(3);
+      expect(captured?.issue_to_id).toStrictEqual(2);
+      expect(captured?.relation_type).toStrictEqual("precedes");
+      expect(captured?.delay).toStrictEqual(3);
     },
   );
 });

--- a/result/issue-relations/delete.test.ts
+++ b/result/issue-relations/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteRelation } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /relations/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteRelation(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /relations/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteRelation(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteRelation(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-relations/list.test.ts
+++ b/result/issue-relations/list.test.ts
@@ -19,15 +19,16 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      const relations = e._unsafeUnwrap();
+      expect(relations[0]).toStrictEqual({
         id: 1,
         issueId: 1,
         issueToId: 2,
         relationType: "relates",
         delay: undefined,
       });
-      expect(e._unsafeUnwrap()[1].relationType).toEqual("precedes");
-      expect(e._unsafeUnwrap()[1].delay).toEqual(2);
+      expect(relations[1].relationType).toStrictEqual("precedes");
+      expect(relations[1].delay).toStrictEqual(2);
     },
   );
 

--- a/result/issue-relations/list.test.ts
+++ b/result/issue-relations/list.test.ts
@@ -1,7 +1,7 @@
 import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,16 +18,16 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         issueId: 1,
         issueToId: 2,
         relationType: "relates",
         delay: undefined,
       });
-      assertEquals(e.value[1].relationType, "precedes");
-      assertEquals(e.value[1].delay, 2);
+      expect(e._unsafeUnwrap()[1].relationType).toEqual("precedes");
+      expect(e._unsafeUnwrap()[1].delay).toEqual(2);
     },
   );
 
@@ -36,13 +36,13 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await fetchList(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await fetchList(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-relations/show.test.ts
+++ b/result/issue-relations/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /relations/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,9 +18,9 @@ Deno.test("GET /relations/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value.issueToId, 2);
-      assertEquals(e.value.relationType, "relates");
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().issueToId).toEqual(2);
+      expect(e._unsafeUnwrap().relationType).toEqual("relates");
     },
   );
 
@@ -29,13 +29,13 @@ Deno.test("GET /relations/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issue-relations/show.test.ts
+++ b/result/issue-relations/show.test.ts
@@ -19,8 +19,8 @@ Deno.test("GET /relations/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().issueToId).toEqual(2);
-      expect(e._unsafeUnwrap().relationType).toEqual("relates");
+      expect(e._unsafeUnwrap().issueToId).toStrictEqual(2);
+      expect(e._unsafeUnwrap().relationType).toStrictEqual("relates");
     },
   );
 

--- a/result/issue-statuses/list.test.ts
+++ b/result/issue-statuses/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,10 +19,18 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 3);
-      assertEquals(e.value[0], { id: 1, name: "New", isClosed: false });
-      assertEquals(e.value[2], { id: 5, name: "Closed", isClosed: true });
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(3);
+      expect(e._unsafeUnwrap()[0]).toEqual({
+        id: 1,
+        name: "New",
+        isClosed: false,
+      });
+      expect(e._unsafeUnwrap()[2]).toEqual({
+        id: 5,
+        name: "Closed",
+        isClosed: true,
+      });
     },
   );
 
@@ -31,7 +39,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/issue-statuses/list.test.ts
+++ b/result/issue-statuses/list.test.ts
@@ -20,13 +20,14 @@ Deno.test("GET /issue_statuses.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(3);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      const issueStatuses = e._unsafeUnwrap();
+      expect(issueStatuses.length).toStrictEqual(3);
+      expect(issueStatuses[0]).toStrictEqual({
         id: 1,
         name: "New",
         isClosed: false,
       });
-      expect(e._unsafeUnwrap()[2]).toEqual({
+      expect(issueStatuses[2]).toStrictEqual({
         id: 5,
         name: "Closed",
         isClosed: true,

--- a/result/issues/add-watcher.test.ts
+++ b/result/issues/add-watcher.test.ts
@@ -1,5 +1,5 @@
 import { addWatcher } from "./add-watcher.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { http, HttpResponse } from "npm:msw@2.15.0";
@@ -11,7 +11,7 @@ Deno.test("POST /issues/:id/watchers.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await addWatcher(context, 1, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -29,10 +29,10 @@ Deno.test("POST /issues/:id/watchers.json", async (t) => {
       );
 
       const e = await addWatcher(context, 1, 5);
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
 
-      assert(capturedBody !== undefined);
-      assertEquals(capturedBody.user_id, 5);
+      expect(capturedBody !== undefined).toBe(true);
+      expect(capturedBody!.user_id).toEqual(5);
     },
   );
 
@@ -41,13 +41,13 @@ Deno.test("POST /issues/:id/watchers.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await addWatcher(context, 422, 1);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await addWatcher(context, 404, 1);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issues/add-watcher.test.ts
+++ b/result/issues/add-watcher.test.ts
@@ -31,8 +31,8 @@ Deno.test("POST /issues/:id/watchers.json", async (t) => {
       const e = await addWatcher(context, 1, 5);
       expect(e.isOk()).toBe(true);
 
-      expect(capturedBody !== undefined).toBe(true);
-      expect(capturedBody!.user_id).toEqual(5);
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.user_id).toStrictEqual(5);
     },
   );
 

--- a/result/issues/create.test.ts
+++ b/result/issues/create.test.ts
@@ -31,8 +31,8 @@ Deno.test("POST /issues.json", async (t) => {
       });
       expect(e.isOk()).toBe(true);
 
-      expect(capturedBody !== undefined).toBe(true);
-      expect(capturedBody!.issue.custom_fields).toEqual([
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.issue.custom_fields).toStrictEqual([
         { id: 1, value: "hello" },
       ]);
     },
@@ -61,8 +61,8 @@ Deno.test("POST /issues.json", async (t) => {
       });
       expect(e.isOk()).toBe(true);
 
-      expect(capturedBody !== undefined).toBe(true);
-      expect(capturedBody!.issue.custom_fields).toEqual([
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.issue.custom_fields).toStrictEqual([
         { id: 2, value: ["a", "b"] },
       ]);
     },

--- a/result/issues/create.test.ts
+++ b/result/issues/create.test.ts
@@ -1,5 +1,5 @@
 import { createIssue } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { http, HttpResponse } from "npm:msw@2.15.0";
@@ -29,10 +29,10 @@ Deno.test("POST /issues.json", async (t) => {
         subject: "sample",
         customFields: [{ id: 1, value: "hello" }],
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
 
-      assert(capturedBody !== undefined);
-      assertEquals(capturedBody.issue.custom_fields, [
+      expect(capturedBody !== undefined).toBe(true);
+      expect(capturedBody!.issue.custom_fields).toEqual([
         { id: 1, value: "hello" },
       ]);
     },
@@ -59,10 +59,10 @@ Deno.test("POST /issues.json", async (t) => {
         subject: "sample",
         customFields: [{ id: 2, value: ["a", "b"] }],
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
 
-      assert(capturedBody !== undefined);
-      assertEquals(capturedBody.issue.custom_fields, [
+      expect(capturedBody !== undefined).toBe(true);
+      expect(capturedBody!.issue.custom_fields).toEqual([
         { id: 2, value: ["a", "b"] },
       ]);
     },

--- a/result/issues/delete.test.ts
+++ b/result/issues/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteIssue } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /issues/:id.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteIssue(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /issues/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteIssue(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteIssue(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -1,5 +1,5 @@
 import { listIssues } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
@@ -12,7 +12,7 @@ Deno.test("GET /projects/issues.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await listIssues(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -20,7 +20,7 @@ Deno.test("GET /projects/issues.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await listIssues(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });
@@ -88,10 +88,10 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, { limit: 1 });
 
-      assert(e.isOk());
-      assertEquals(e.value.length, 1);
-      assertEquals(requests.length, 1);
-      assertEquals(requests[0], { limit: "1", offset: "0" });
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(1);
+      expect(requests.length).toEqual(1);
+      expect(requests[0]).toEqual({ limit: "1", offset: "0" });
     },
   );
 
@@ -103,9 +103,9 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, { limit: 150 });
 
-      assert(e.isOk());
-      assertEquals(e.value.length, 150);
-      assertEquals(requests, [
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(150);
+      expect(requests).toEqual([
         { limit: "100", offset: "0" },
         { limit: "50", offset: "100" },
       ]);
@@ -120,9 +120,9 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, {});
 
-      assert(e.isOk());
-      assertEquals(e.value.length, 150);
-      assertEquals(requests, [
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(150);
+      expect(requests).toEqual([
         { limit: "100", offset: "0" },
         { limit: "100", offset: "100" },
       ]);
@@ -137,8 +137,8 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, { limit: 1.5 });
 
-      assert(e.isErr());
-      assertEquals(requests.length, 0);
+      expect(e.isErr()).toBe(true);
+      expect(requests.length).toEqual(0);
     },
   );
 
@@ -150,8 +150,8 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, { limit: -1 });
 
-      assert(e.isErr());
-      assertEquals(requests.length, 0);
+      expect(e.isErr()).toBe(true);
+      expect(requests.length).toEqual(0);
     },
   );
 
@@ -163,8 +163,8 @@ Deno.test("listIssues limit option", async (t) => {
 
       const e = await listIssues(context, { limit: 0 });
 
-      assert(e.isErr());
-      assertEquals(requests.length, 0);
+      expect(e.isErr()).toBe(true);
+      expect(requests.length).toEqual(0);
     },
   );
 });

--- a/result/issues/list.test.ts
+++ b/result/issues/list.test.ts
@@ -89,9 +89,9 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, { limit: 1 });
 
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(1);
-      expect(requests.length).toEqual(1);
-      expect(requests[0]).toEqual({ limit: "1", offset: "0" });
+      expect(e._unsafeUnwrap().length).toStrictEqual(1);
+      expect(requests.length).toStrictEqual(1);
+      expect(requests[0]).toStrictEqual({ limit: "1", offset: "0" });
     },
   );
 
@@ -104,8 +104,8 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, { limit: 150 });
 
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(150);
-      expect(requests).toEqual([
+      expect(e._unsafeUnwrap().length).toStrictEqual(150);
+      expect(requests).toStrictEqual([
         { limit: "100", offset: "0" },
         { limit: "50", offset: "100" },
       ]);
@@ -121,8 +121,8 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, {});
 
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(150);
-      expect(requests).toEqual([
+      expect(e._unsafeUnwrap().length).toStrictEqual(150);
+      expect(requests).toStrictEqual([
         { limit: "100", offset: "0" },
         { limit: "100", offset: "100" },
       ]);
@@ -138,7 +138,7 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, { limit: 1.5 });
 
       expect(e.isErr()).toBe(true);
-      expect(requests.length).toEqual(0);
+      expect(requests.length).toStrictEqual(0);
     },
   );
 
@@ -151,7 +151,7 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, { limit: -1 });
 
       expect(e.isErr()).toBe(true);
-      expect(requests.length).toEqual(0);
+      expect(requests.length).toStrictEqual(0);
     },
   );
 
@@ -164,7 +164,7 @@ Deno.test("listIssues limit option", async (t) => {
       const e = await listIssues(context, { limit: 0 });
 
       expect(e.isErr()).toBe(true);
-      expect(requests.length).toEqual(0);
+      expect(requests.length).toStrictEqual(0);
     },
   );
 });

--- a/result/issues/remove-watcher.test.ts
+++ b/result/issues/remove-watcher.test.ts
@@ -1,5 +1,5 @@
 import { removeWatcher } from "./remove-watcher.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /issues/:id/watchers/:userId.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await removeWatcher(context, 1, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /issues/:id/watchers/:userId.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await removeWatcher(context, 422, 1);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await removeWatcher(context, 404, 1);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/issues/show.test.ts
+++ b/result/issues/show.test.ts
@@ -1,5 +1,5 @@
 import { show } from "./show.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("GET /projects/issues/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.resetHandlers(...validHandlers);
     const e = await show(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,7 +19,7 @@ Deno.test("GET /projects/issues/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await show(context, 1);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/issues/update.test.ts
+++ b/result/issues/update.test.ts
@@ -1,5 +1,5 @@
 import { update } from "./update.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { http, HttpResponse } from "npm:msw@2.15.0";
@@ -11,7 +11,7 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await update(context, 1, { notes: "sample" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await update(context, 411, { notes: "sample" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await update(context, 404, { notes: "sample" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -55,18 +55,18 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
         startDate: new Date("2026-07-01"),
         dueDate: new Date("2026-07-31"),
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
 
-      assert(capturedBody !== undefined);
-      const { issue } = capturedBody;
-      assertEquals(issue.subject, "updated subject");
-      assertEquals(issue.notes, "a note");
-      assertEquals(issue.private_notes, true);
-      assertEquals(issue.done_ratio, 90);
-      assertEquals(issue.is_private, true);
-      assertEquals(issue.estimated_hours, 8);
-      assertEquals(issue.start_date, "2026-07-01");
-      assertEquals(issue.due_date, "2026-07-31");
+      expect(capturedBody !== undefined).toBe(true);
+      const { issue } = capturedBody!;
+      expect(issue.subject).toEqual("updated subject");
+      expect(issue.notes).toEqual("a note");
+      expect(issue.private_notes).toEqual(true);
+      expect(issue.done_ratio).toEqual(90);
+      expect(issue.is_private).toEqual(true);
+      expect(issue.estimated_hours).toEqual(8);
+      expect(issue.start_date).toEqual("2026-07-01");
+      expect(issue.due_date).toEqual("2026-07-31");
     },
   );
 
@@ -92,10 +92,10 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
           { id: 2, name: "list field", multiple: true, value: ["a", "b"] },
         ],
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
 
-      assert(capturedBody !== undefined);
-      assertEquals(capturedBody.issue.custom_fields, [
+      expect(capturedBody !== undefined).toBe(true);
+      expect(capturedBody!.issue.custom_fields).toEqual([
         { id: 1, value: "hello" },
         { id: 2, value: ["a", "b"] },
       ]);

--- a/result/issues/update.test.ts
+++ b/result/issues/update.test.ts
@@ -57,16 +57,16 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
       });
       expect(e.isOk()).toBe(true);
 
-      expect(capturedBody !== undefined).toBe(true);
+      expect(capturedBody).toBeDefined();
       const { issue } = capturedBody!;
-      expect(issue.subject).toEqual("updated subject");
-      expect(issue.notes).toEqual("a note");
-      expect(issue.private_notes).toEqual(true);
-      expect(issue.done_ratio).toEqual(90);
-      expect(issue.is_private).toEqual(true);
-      expect(issue.estimated_hours).toEqual(8);
-      expect(issue.start_date).toEqual("2026-07-01");
-      expect(issue.due_date).toEqual("2026-07-31");
+      expect(issue.subject).toStrictEqual("updated subject");
+      expect(issue.notes).toStrictEqual("a note");
+      expect(issue.private_notes).toStrictEqual(true);
+      expect(issue.done_ratio).toStrictEqual(90);
+      expect(issue.is_private).toStrictEqual(true);
+      expect(issue.estimated_hours).toStrictEqual(8);
+      expect(issue.start_date).toStrictEqual("2026-07-01");
+      expect(issue.due_date).toStrictEqual("2026-07-31");
     },
   );
 
@@ -94,8 +94,8 @@ Deno.test("PUT /projects/issues/:id.json", async (t) => {
       });
       expect(e.isOk()).toBe(true);
 
-      expect(capturedBody !== undefined).toBe(true);
-      expect(capturedBody!.issue.custom_fields).toEqual([
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.issue.custom_fields).toStrictEqual([
         { id: 1, value: "hello" },
         { id: 2, value: ["a", "b"] },
       ]);

--- a/result/memberships/create.test.ts
+++ b/result/memberships/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /projects/:project_id/memberships.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await create(context, 1, { userId: 17, roleIds: [1] });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,14 +22,14 @@ Deno.test("POST /projects/:project_id/memberships.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await create(context, 422, { userId: 17, roleIds: [1] });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await create(context, 404, { userId: 17, roleIds: [1] });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -52,9 +52,9 @@ Deno.test("POST /projects/:project_id/memberships.json", async (t) => {
         userId: 17,
         roleIds: [1, 2],
       });
-      assert(e.isOk());
-      assertEquals(captured?.user_id, 17);
-      assertEquals(captured?.role_ids, [1, 2]);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.user_id).toEqual(17);
+      expect(captured?.role_ids).toEqual([1, 2]);
     },
   );
 });

--- a/result/memberships/create.test.ts
+++ b/result/memberships/create.test.ts
@@ -53,8 +53,8 @@ Deno.test("POST /projects/:project_id/memberships.json", async (t) => {
         roleIds: [1, 2],
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.user_id).toEqual(17);
-      expect(captured?.role_ids).toEqual([1, 2]);
+      expect(captured?.user_id).toStrictEqual(17);
+      expect(captured?.role_ids).toStrictEqual([1, 2]);
     },
   );
 });

--- a/result/memberships/delete.test.ts
+++ b/result/memberships/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteMembership } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /memberships/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteMembership(context, 5);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /memberships/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteMembership(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteMembership(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/memberships/list.test.ts
+++ b/result/memberships/list.test.ts
@@ -2,7 +2,7 @@ import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,13 +19,16 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value[0].user, { id: 17, name: "David Robert" });
-      assertEquals(e.value[0].roles, [
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap()[0].user).toEqual({
+        id: 17,
+        name: "David Robert",
+      });
+      expect(e._unsafeUnwrap()[0].roles).toEqual([
         { id: 1, name: "Manager", inherited: true },
         { id: 2, name: "Developer" },
       ]);
-      assertEquals(e.value[1].group, { id: 8, name: "Developers" });
+      expect(e._unsafeUnwrap()[1].group).toEqual({ id: 8, name: "Developers" });
     },
   );
 
@@ -34,14 +37,14 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await fetchList(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await fetchList(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -69,10 +72,10 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
         ),
       );
       const e = await fetchList(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value.length, total);
-      assertEquals(e.value[0].id, 1);
-      assertEquals(e.value[total - 1].id, total);
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(total);
+      expect(e._unsafeUnwrap()[0].id).toEqual(1);
+      expect(e._unsafeUnwrap()[total - 1].id).toEqual(total);
     },
   );
 });

--- a/result/memberships/list.test.ts
+++ b/result/memberships/list.test.ts
@@ -20,15 +20,16 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
       server.use(...validHandlers);
       const e = await fetchList(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap()[0].user).toEqual({
+      const memberships = e._unsafeUnwrap();
+      expect(memberships[0].user).toStrictEqual({
         id: 17,
         name: "David Robert",
       });
-      expect(e._unsafeUnwrap()[0].roles).toEqual([
+      expect(memberships[0].roles).toStrictEqual([
         { id: 1, name: "Manager", inherited: true },
         { id: 2, name: "Developer" },
       ]);
-      expect(e._unsafeUnwrap()[1].group).toEqual({ id: 8, name: "Developers" });
+      expect(memberships[1].group).toStrictEqual({ id: 8, name: "Developers" });
     },
   );
 
@@ -73,9 +74,10 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
       );
       const e = await fetchList(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(total);
-      expect(e._unsafeUnwrap()[0].id).toEqual(1);
-      expect(e._unsafeUnwrap()[total - 1].id).toEqual(total);
+      const memberships = e._unsafeUnwrap();
+      expect(memberships.length).toStrictEqual(total);
+      expect(memberships[0].id).toStrictEqual(1);
+      expect(memberships[total - 1].id).toStrictEqual(total);
     },
   );
 });

--- a/result/memberships/show.test.ts
+++ b/result/memberships/show.test.ts
@@ -19,8 +19,11 @@ Deno.test("GET /memberships/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 5);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().user).toEqual({ id: 17, name: "David Robert" });
-      expect(e._unsafeUnwrap().roles).toEqual([
+      expect(e._unsafeUnwrap().user).toStrictEqual({
+        id: 17,
+        name: "David Robert",
+      });
+      expect(e._unsafeUnwrap().roles).toStrictEqual([
         { id: 1, name: "Manager", inherited: true },
         { id: 2, name: "Developer" },
       ]);

--- a/result/memberships/show.test.ts
+++ b/result/memberships/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /memberships/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 5);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,9 +18,9 @@ Deno.test("GET /memberships/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 5);
-      assert(e.isOk());
-      assertEquals(e.value.user, { id: 17, name: "David Robert" });
-      assertEquals(e.value.roles, [
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().user).toEqual({ id: 17, name: "David Robert" });
+      expect(e._unsafeUnwrap().roles).toEqual([
         { id: 1, name: "Manager", inherited: true },
         { id: 2, name: "Developer" },
       ]);
@@ -32,13 +32,13 @@ Deno.test("GET /memberships/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/memberships/update.test.ts
+++ b/result/memberships/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /memberships/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 5, { roleIds: [2] });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /memberships/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { roleIds: [2] });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { roleIds: [2] });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -48,8 +48,8 @@ Deno.test("PUT /memberships/:id.json", async (t) => {
       const e = await update(context, 5, {
         roleIds: [3, 4],
       });
-      assert(e.isOk());
-      assertEquals(captured?.role_ids, [3, 4]);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.role_ids).toEqual([3, 4]);
     },
   );
 });

--- a/result/memberships/update.test.ts
+++ b/result/memberships/update.test.ts
@@ -49,7 +49,7 @@ Deno.test("PUT /memberships/:id.json", async (t) => {
         roleIds: [3, 4],
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.role_ids).toEqual([3, 4]);
+      expect(captured?.role_ids).toStrictEqual([3, 4]);
     },
   );
 });

--- a/result/my-account/show.test.ts
+++ b/result/my-account/show.test.ts
@@ -1,5 +1,5 @@
 import { show } from "./show.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidHandlers,
@@ -15,7 +15,7 @@ Deno.test("GET /my/account.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await show(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -23,11 +23,11 @@ Deno.test("GET /my/account.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await show(context);
-      assert(e.isOk());
-      assertEquals(e.value.login, "jsmith");
-      assertEquals(e.value.mailNotification, "only_my_events");
-      assertEquals(e.value.apiKey, "sample-api-key");
-      assertEquals(e.value.customFields?.[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().login).toEqual("jsmith");
+      expect(e._unsafeUnwrap().mailNotification).toEqual("only_my_events");
+      expect(e._unsafeUnwrap().apiKey).toEqual("sample-api-key");
+      expect(e._unsafeUnwrap().customFields?.[0]).toEqual({
         id: 1,
         name: "Phone",
         value: "090-0000-0000",
@@ -40,13 +40,13 @@ Deno.test("GET /my/account.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await show(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
     const e = await show(context);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/my-account/show.test.ts
+++ b/result/my-account/show.test.ts
@@ -24,10 +24,13 @@ Deno.test("GET /my/account.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await show(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().login).toEqual("jsmith");
-      expect(e._unsafeUnwrap().mailNotification).toEqual("only_my_events");
-      expect(e._unsafeUnwrap().apiKey).toEqual("sample-api-key");
-      expect(e._unsafeUnwrap().customFields?.[0]).toEqual({
+      const account = e._unsafeUnwrap();
+      expect(account.login).toStrictEqual("jsmith");
+      expect(account.mailNotification).toStrictEqual(
+        "only_my_events",
+      );
+      expect(account.apiKey).toStrictEqual("sample-api-key");
+      expect(account.customFields?.[0]).toStrictEqual({
         id: 1,
         name: "Phone",
         value: "090-0000-0000",

--- a/result/my-account/update.test.ts
+++ b/result/my-account/update.test.ts
@@ -55,10 +55,12 @@ Deno.test("PUT /my/account.json", async (t) => {
         customFieldValues: { "1": "090-1111-2222" },
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.firstname).toEqual("Jane");
-      expect(captured?.lastname).toEqual("Doe");
-      expect(captured?.mail).toEqual("jane@example.com");
-      expect(captured?.custom_field_values).toEqual({ "1": "090-1111-2222" });
+      expect(captured?.firstname).toStrictEqual("Jane");
+      expect(captured?.lastname).toStrictEqual("Doe");
+      expect(captured?.mail).toStrictEqual("jane@example.com");
+      expect(captured?.custom_field_values).toStrictEqual({
+        "1": "090-1111-2222",
+      });
     },
   );
 });

--- a/result/my-account/update.test.ts
+++ b/result/my-account/update.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -16,7 +16,7 @@ Deno.test("PUT /my/account.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await update(context, { firstname: "Jane" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -24,14 +24,14 @@ Deno.test("PUT /my/account.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await update(context, { firstname: "Jane" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
     const e = await update(context, { firstname: "Jane" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -54,11 +54,11 @@ Deno.test("PUT /my/account.json", async (t) => {
         mail: "jane@example.com",
         customFieldValues: { "1": "090-1111-2222" },
       });
-      assert(e.isOk());
-      assertEquals(captured?.firstname, "Jane");
-      assertEquals(captured?.lastname, "Doe");
-      assertEquals(captured?.mail, "jane@example.com");
-      assertEquals(captured?.custom_field_values, { "1": "090-1111-2222" });
+      expect(e.isOk()).toBe(true);
+      expect(captured?.firstname).toEqual("Jane");
+      expect(captured?.lastname).toEqual("Doe");
+      expect(captured?.mail).toEqual("jane@example.com");
+      expect(captured?.custom_field_values).toEqual({ "1": "090-1111-2222" });
     },
   );
 });

--- a/result/news/list-by-project.test.ts
+++ b/result/news/list-by-project.test.ts
@@ -19,8 +19,8 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
       server.use(...validHandlers);
       const e = await fetchListByProject(context, 1);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      expect(e._unsafeUnwrap().length).toStrictEqual(2);
+      expect(e._unsafeUnwrap()[0]).toStrictEqual({
         id: 1,
         project: { id: 1, name: "Demo" },
         author: { id: 2, name: "John Smith" },

--- a/result/news/list-by-project.test.ts
+++ b/result/news/list-by-project.test.ts
@@ -1,7 +1,7 @@
 import { fetchListByProject } from "./list-by-project.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchListByProject(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,9 +18,9 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await fetchListByProject(context, 1);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         project: { id: 1, name: "Demo" },
         author: { id: 2, name: "John Smith" },
@@ -37,13 +37,13 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await fetchListByProject(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await fetchListByProject(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/news/list.test.ts
+++ b/result/news/list.test.ts
@@ -20,8 +20,8 @@ Deno.test("GET /news.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      expect(e._unsafeUnwrap().length).toStrictEqual(2);
+      expect(e._unsafeUnwrap()[0]).toStrictEqual({
         id: 1,
         project: { id: 1, name: "Demo" },
         author: { id: 2, name: "John Smith" },

--- a/result/news/list.test.ts
+++ b/result/news/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("GET /news.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,9 +19,9 @@ Deno.test("GET /news.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         project: { id: 1, name: "Demo" },
         author: { id: 2, name: "John Smith" },
@@ -38,7 +38,7 @@ Deno.test("GET /news.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/projects/archive.test.ts
+++ b/result/projects/archive.test.ts
@@ -1,5 +1,5 @@
 import { archive, unarchive } from "./archive.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("PUT /projects/:id/archive.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await archive(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /projects/:id/archive.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await archive(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await archive(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });
 
@@ -34,7 +34,7 @@ Deno.test("PUT /projects/:id/unarchive.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await unarchive(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -42,13 +42,13 @@ Deno.test("PUT /projects/:id/unarchive.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await unarchive(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await unarchive(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/projects/create.test.ts
+++ b/result/projects/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -16,7 +16,7 @@ Deno.test("POST /projects.json", async (t) => {
         context,
         { name: "sample", identifier: "sample" },
       );
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -26,7 +26,7 @@ Deno.test("POST /projects.json", async (t) => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
       const e = await create(c, { name: "sample", identifier: "sample" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -34,7 +34,7 @@ Deno.test("POST /projects.json", async (t) => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/422` };
     const e = await create(c, { name: "sample", identifier: "sample" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -56,11 +56,11 @@ Deno.test("POST /projects.json", async (t) => {
         inheritMembers: true,
         trackerIds: [1, 2],
       });
-      assert(e.isOk());
-      assertEquals(captured?.is_public, false);
-      assertEquals(captured?.parent_id, 42);
-      assertEquals(captured?.inherit_members, true);
-      assertEquals(captured?.tracker_ids, [1, 2]);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.is_public).toEqual(false);
+      expect(captured?.parent_id).toEqual(42);
+      expect(captured?.inherit_members).toEqual(true);
+      expect(captured?.tracker_ids).toEqual([1, 2]);
     },
   );
 
@@ -79,8 +79,8 @@ Deno.test("POST /projects.json", async (t) => {
         name: "My Project",
         identifier: "my-project",
       });
-      assert(e.isOk());
-      assertEquals(captured?.name, "My Project");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.name).toEqual("My Project");
     },
   );
 });

--- a/result/projects/create.test.ts
+++ b/result/projects/create.test.ts
@@ -57,10 +57,10 @@ Deno.test("POST /projects.json", async (t) => {
         trackerIds: [1, 2],
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.is_public).toEqual(false);
-      expect(captured?.parent_id).toEqual(42);
-      expect(captured?.inherit_members).toEqual(true);
-      expect(captured?.tracker_ids).toEqual([1, 2]);
+      expect(captured?.is_public).toStrictEqual(false);
+      expect(captured?.parent_id).toStrictEqual(42);
+      expect(captured?.inherit_members).toStrictEqual(true);
+      expect(captured?.tracker_ids).toStrictEqual([1, 2]);
     },
   );
 
@@ -80,7 +80,7 @@ Deno.test("POST /projects.json", async (t) => {
         identifier: "my-project",
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.name).toEqual("My Project");
+      expect(captured?.name).toStrictEqual("My Project");
     },
   );
 });

--- a/result/projects/delete.test.ts
+++ b/result/projects/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteProject } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /projects/:id.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteProject(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /projects/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteProject(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteProject(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/projects/list.test.ts
+++ b/result/projects/list.test.ts
@@ -1,7 +1,7 @@
 import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /projects.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -20,7 +20,7 @@ Deno.test("GET /projects.json", async (t) => {
       // Simulate an endpoint that returns an error
       context.endpoint += "/422";
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/projects/show.test.ts
+++ b/result/projects/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /projects/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,7 +18,7 @@ Deno.test("GET /projects/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/projects/update.test.ts
+++ b/result/projects/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /projects/:id.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 1, { name: "sample" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /projects/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { name: "sample" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { name: "sample" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -44,8 +44,8 @@ Deno.test("PUT /projects/:id.json", async (t) => {
         ),
       );
       const e = await update(context, 1, { isPublic: false });
-      assert(e.isOk());
-      assertEquals(captured?.is_public, false);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.is_public).toEqual(false);
     },
   );
 });

--- a/result/projects/update.test.ts
+++ b/result/projects/update.test.ts
@@ -45,7 +45,7 @@ Deno.test("PUT /projects/:id.json", async (t) => {
       );
       const e = await update(context, 1, { isPublic: false });
       expect(e.isOk()).toBe(true);
-      expect(captured?.is_public).toEqual(false);
+      expect(captured?.is_public).toStrictEqual(false);
     },
   );
 });

--- a/result/queries/list.test.ts
+++ b/result/queries/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -11,7 +11,7 @@ Deno.test("GET /queries.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,15 +19,15 @@ Deno.test("GET /queries.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 3);
-      assertEquals(e.value[0], {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(3);
+      expect(e._unsafeUnwrap()[0]).toEqual({
         id: 1,
         name: "All issues",
         isPublic: true,
         projectId: 1,
       });
-      assertEquals(e.value[1], {
+      expect(e._unsafeUnwrap()[1]).toEqual({
         id: 2,
         name: "Open issues",
         isPublic: true,
@@ -41,7 +41,7 @@ Deno.test("GET /queries.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/queries/list.test.ts
+++ b/result/queries/list.test.ts
@@ -20,14 +20,15 @@ Deno.test("GET /queries.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(3);
-      expect(e._unsafeUnwrap()[0]).toEqual({
+      const queries = e._unsafeUnwrap();
+      expect(queries.length).toStrictEqual(3);
+      expect(queries[0]).toStrictEqual({
         id: 1,
         name: "All issues",
         isPublic: true,
         projectId: 1,
       });
-      expect(e._unsafeUnwrap()[1]).toEqual({
+      expect(queries[1]).toStrictEqual({
         id: 2,
         name: "Open issues",
         isPublic: true,

--- a/result/roles/list.test.ts
+++ b/result/roles/list.test.ts
@@ -19,9 +19,10 @@ Deno.test("GET /roles.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[0]).toEqual({ id: 1, name: "Manager" });
-      expect(e._unsafeUnwrap()[1]).toEqual({ id: 2, name: "Developer" });
+      const roles = e._unsafeUnwrap();
+      expect(roles.length).toStrictEqual(2);
+      expect(roles[0]).toStrictEqual({ id: 1, name: "Manager" });
+      expect(roles[1]).toStrictEqual({ id: 2, name: "Developer" });
     },
   );
 

--- a/result/roles/list.test.ts
+++ b/result/roles/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("GET /roles.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,10 +18,10 @@ Deno.test("GET /roles.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[0], { id: 1, name: "Manager" });
-      assertEquals(e.value[1], { id: 2, name: "Developer" });
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[0]).toEqual({ id: 1, name: "Manager" });
+      expect(e._unsafeUnwrap()[1]).toEqual({ id: 2, name: "Developer" });
     },
   );
 
@@ -30,7 +30,7 @@ Deno.test("GET /roles.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await fetchList(context);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 });

--- a/result/roles/show.test.ts
+++ b/result/roles/show.test.ts
@@ -19,7 +19,7 @@ Deno.test("GET /roles/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 5);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap()).toEqual({
+      expect(e._unsafeUnwrap()).toStrictEqual({
         id: 5,
         name: "Manager",
         assignable: true,

--- a/result/roles/show.test.ts
+++ b/result/roles/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /roles/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 5);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,8 +18,8 @@ Deno.test("GET /roles/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 5);
-      assert(e.isOk());
-      assertEquals(e.value, {
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap()).toEqual({
         id: 5,
         name: "Manager",
         assignable: true,
@@ -36,13 +36,13 @@ Deno.test("GET /roles/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/search/search.test.ts
+++ b/result/search/search.test.ts
@@ -20,13 +20,14 @@ Deno.test("GET /search.json", async (t) => {
       server.resetHandlers(...validHandlers);
       const e = await search(context, { q: "E2E" });
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(3);
-      expect(e._unsafeUnwrap()[0].id).toEqual(1);
-      expect(e._unsafeUnwrap()[0].type).toEqual("issue");
-      expect(e._unsafeUnwrap()[0].datetime instanceof Date).toBe(true);
+      const items = e._unsafeUnwrap();
+      expect(items.length).toStrictEqual(3);
+      expect(items[0].id).toStrictEqual(1);
+      expect(items[0].type).toStrictEqual("issue");
+      expect(items[0].datetime).toBeInstanceOf(Date);
       // A null description from Redmine normalizes to undefined.
-      expect(e._unsafeUnwrap()[2].type).toEqual("project");
-      expect(e._unsafeUnwrap()[2].description).toEqual(undefined);
+      expect(items[2].type).toStrictEqual("project");
+      expect(items[2].description).toBeUndefined();
     },
   );
 
@@ -54,13 +55,13 @@ Deno.test("GET /search.json", async (t) => {
         attachments: true,
       });
       expect(e.isOk()).toBe(true);
-      expect(capturedUrl !== undefined).toBe(true);
-      expect(capturedUrl!.searchParams.get("q")).toEqual("E2E");
-      expect(capturedUrl!.searchParams.get("all_words")).toEqual("1");
-      expect(capturedUrl!.searchParams.get("wiki_pages")).toEqual("1");
-      expect(capturedUrl!.searchParams.get("scope")).toEqual("all");
-      expect(capturedUrl!.searchParams.get("attachments")).toEqual("1");
-      expect(capturedUrl!.searchParams.get("open_issues")).toEqual(null);
+      expect(capturedUrl).toBeDefined();
+      expect(capturedUrl!.searchParams.get("q")).toStrictEqual("E2E");
+      expect(capturedUrl!.searchParams.get("all_words")).toStrictEqual("1");
+      expect(capturedUrl!.searchParams.get("wiki_pages")).toStrictEqual("1");
+      expect(capturedUrl!.searchParams.get("scope")).toStrictEqual("all");
+      expect(capturedUrl!.searchParams.get("attachments")).toStrictEqual("1");
+      expect(capturedUrl!.searchParams.get("open_issues")).toStrictEqual(null);
     },
   );
 
@@ -106,9 +107,10 @@ Deno.test("GET /search.json", async (t) => {
       );
       const e = await search(context, { q: "E2E" });
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(total);
-      expect(e._unsafeUnwrap()[0].id).toEqual(1);
-      expect(e._unsafeUnwrap()[total - 1].id).toEqual(total);
+      const items = e._unsafeUnwrap();
+      expect(items.length).toStrictEqual(total);
+      expect(items[0].id).toStrictEqual(1);
+      expect(items[total - 1].id).toStrictEqual(total);
     },
   );
 });

--- a/result/search/search.test.ts
+++ b/result/search/search.test.ts
@@ -2,7 +2,7 @@ import { search } from "./search.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("GET /search.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
     const e = await search(context, { q: "E2E" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("GET /search.json", async (t) => {
     async () => {
       server.resetHandlers(...validHandlers);
       const e = await search(context, { q: "E2E" });
-      assert(e.isOk());
-      assertEquals(e.value.length, 3);
-      assertEquals(e.value[0].id, 1);
-      assertEquals(e.value[0].type, "issue");
-      assert(e.value[0].datetime instanceof Date);
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(3);
+      expect(e._unsafeUnwrap()[0].id).toEqual(1);
+      expect(e._unsafeUnwrap()[0].type).toEqual("issue");
+      expect(e._unsafeUnwrap()[0].datetime instanceof Date).toBe(true);
       // A null description from Redmine normalizes to undefined.
-      assertEquals(e.value[2].type, "project");
-      assertEquals(e.value[2].description, undefined);
+      expect(e._unsafeUnwrap()[2].type).toEqual("project");
+      expect(e._unsafeUnwrap()[2].description).toEqual(undefined);
     },
   );
 
@@ -53,14 +53,14 @@ Deno.test("GET /search.json", async (t) => {
         scope: "all",
         attachments: true,
       });
-      assert(e.isOk());
-      assert(capturedUrl !== undefined);
-      assertEquals(capturedUrl.searchParams.get("q"), "E2E");
-      assertEquals(capturedUrl.searchParams.get("all_words"), "1");
-      assertEquals(capturedUrl.searchParams.get("wiki_pages"), "1");
-      assertEquals(capturedUrl.searchParams.get("scope"), "all");
-      assertEquals(capturedUrl.searchParams.get("attachments"), "1");
-      assertEquals(capturedUrl.searchParams.get("open_issues"), null);
+      expect(e.isOk()).toBe(true);
+      expect(capturedUrl !== undefined).toBe(true);
+      expect(capturedUrl!.searchParams.get("q")).toEqual("E2E");
+      expect(capturedUrl!.searchParams.get("all_words")).toEqual("1");
+      expect(capturedUrl!.searchParams.get("wiki_pages")).toEqual("1");
+      expect(capturedUrl!.searchParams.get("scope")).toEqual("all");
+      expect(capturedUrl!.searchParams.get("attachments")).toEqual("1");
+      expect(capturedUrl!.searchParams.get("open_issues")).toEqual(null);
     },
   );
 
@@ -69,14 +69,14 @@ Deno.test("GET /search.json", async (t) => {
     async () => {
       server.resetHandlers(...invalidHandlers);
       const e = await search(context, { q: "422" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
     const e = await search(context, { q: "404" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -105,10 +105,10 @@ Deno.test("GET /search.json", async (t) => {
         }),
       );
       const e = await search(context, { q: "E2E" });
-      assert(e.isOk());
-      assertEquals(e.value.length, total);
-      assertEquals(e.value[0].id, 1);
-      assertEquals(e.value[total - 1].id, total);
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(total);
+      expect(e._unsafeUnwrap()[0].id).toEqual(1);
+      expect(e._unsafeUnwrap()[total - 1].id).toEqual(total);
     },
   );
 });

--- a/result/time-entries/create.test.ts
+++ b/result/time-entries/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /time_entries.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await create(context, { projectId: 1, hours: 2 });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -23,7 +23,7 @@ Deno.test("POST /time_entries.json", async (t) => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
       const e = await create(c, { projectId: 1, hours: 2 });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -31,7 +31,7 @@ Deno.test("POST /time_entries.json", async (t) => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
     const e = await create(c, { projectId: 1, hours: 2 });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -57,12 +57,12 @@ Deno.test("POST /time_entries.json", async (t) => {
         comments: "Worked on it",
         spentOn: new Date("2026-07-01"),
       });
-      assert(e.isOk());
-      assertEquals(captured?.issue_id, 5);
-      assertEquals(captured?.hours, 2.5);
-      assertEquals(captured?.activity_id, 9);
-      assertEquals(captured?.comments, "Worked on it");
-      assertEquals(captured?.spent_on, "2026-07-01");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.issue_id).toEqual(5);
+      expect(captured?.hours).toEqual(2.5);
+      expect(captured?.activity_id).toEqual(9);
+      expect(captured?.comments).toEqual("Worked on it");
+      expect(captured?.spent_on).toEqual("2026-07-01");
     },
   );
 });

--- a/result/time-entries/create.test.ts
+++ b/result/time-entries/create.test.ts
@@ -58,11 +58,11 @@ Deno.test("POST /time_entries.json", async (t) => {
         spentOn: new Date("2026-07-01"),
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.issue_id).toEqual(5);
-      expect(captured?.hours).toEqual(2.5);
-      expect(captured?.activity_id).toEqual(9);
-      expect(captured?.comments).toEqual("Worked on it");
-      expect(captured?.spent_on).toEqual("2026-07-01");
+      expect(captured?.issue_id).toStrictEqual(5);
+      expect(captured?.hours).toStrictEqual(2.5);
+      expect(captured?.activity_id).toStrictEqual(9);
+      expect(captured?.comments).toStrictEqual("Worked on it");
+      expect(captured?.spent_on).toStrictEqual("2026-07-01");
     },
   );
 });

--- a/result/time-entries/delete.test.ts
+++ b/result/time-entries/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteTimeEntry } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /time_entries/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteTimeEntry(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /time_entries/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteTimeEntry(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteTimeEntry(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/time-entries/list.test.ts
+++ b/result/time-entries/list.test.ts
@@ -2,7 +2,7 @@ import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("GET /time_entries.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -20,7 +20,7 @@ Deno.test("GET /time_entries.json", async (t) => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
       const e = await fetchList(c);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -28,24 +28,26 @@ Deno.test("GET /time_entries.json", async (t) => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
     const e = await fetchList(c);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step("should map camelCase fields from the response", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
-    const entry = e.value.find((timeEntry) => timeEntry.id === 3);
-    assert(entry !== undefined);
-    assertEquals(entry.project, { id: 1, name: "Demo" });
-    assertEquals(entry.issue, { id: 5 });
-    assertEquals(entry.activity, { id: 9, name: "Development" });
-    assertEquals(entry.hours, 2.5);
+    expect(e.isOk()).toBe(true);
+    const entry = e._unsafeUnwrap().find((timeEntry) => timeEntry.id === 3);
+    expect(entry !== undefined).toBe(true);
+    expect(entry!.project).toEqual({ id: 1, name: "Demo" });
+    expect(entry!.issue).toEqual({ id: 5 });
+    expect(entry!.activity).toEqual({ id: 9, name: "Development" });
+    expect(entry!.hours).toEqual(2.5);
 
-    const entryWithoutIssue = e.value.find((timeEntry) => timeEntry.id === 2);
-    assert(entryWithoutIssue !== undefined);
-    assertEquals(entryWithoutIssue.issue, undefined);
-    assertEquals(entryWithoutIssue.comments, undefined);
+    const entryWithoutIssue = e._unsafeUnwrap().find((timeEntry) =>
+      timeEntry.id === 2
+    );
+    expect(entryWithoutIssue !== undefined).toBe(true);
+    expect(entryWithoutIssue!.issue).toEqual(undefined);
+    expect(entryWithoutIssue!.comments).toEqual(undefined);
   });
 
   await t.step(
@@ -70,12 +72,12 @@ Deno.test("GET /time_entries.json", async (t) => {
         from: new Date("2026-07-01"),
         to: new Date("2026-07-31"),
       });
-      assert(e.isOk());
-      assertEquals(captured?.get("project_id"), "1");
-      assertEquals(captured?.get("user_id"), "2");
-      assertEquals(captured?.get("spent_on"), "2026-07-01");
-      assertEquals(captured?.get("from"), "2026-07-01");
-      assertEquals(captured?.get("to"), "2026-07-31");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.get("project_id")).toEqual("1");
+      expect(captured?.get("user_id")).toEqual("2");
+      expect(captured?.get("spent_on")).toEqual("2026-07-01");
+      expect(captured?.get("from")).toEqual("2026-07-01");
+      expect(captured?.get("to")).toEqual("2026-07-31");
     },
   );
 
@@ -95,9 +97,9 @@ Deno.test("GET /time_entries.json", async (t) => {
         }),
       );
       const e = await fetchList(context, { projectId: undefined });
-      assert(e.isOk());
-      assertEquals(captured?.has("project_id"), false);
-      assert(!captured?.toString().includes("undefined"));
+      expect(e.isOk()).toBe(true);
+      expect(captured?.has("project_id")).toEqual(false);
+      expect(!captured?.toString().includes("undefined")).toBe(true);
     },
   );
 });

--- a/result/time-entries/list.test.ts
+++ b/result/time-entries/list.test.ts
@@ -36,18 +36,18 @@ Deno.test("GET /time_entries.json", async (t) => {
     const e = await fetchList(context);
     expect(e.isOk()).toBe(true);
     const entry = e._unsafeUnwrap().find((timeEntry) => timeEntry.id === 3);
-    expect(entry !== undefined).toBe(true);
-    expect(entry!.project).toEqual({ id: 1, name: "Demo" });
-    expect(entry!.issue).toEqual({ id: 5 });
-    expect(entry!.activity).toEqual({ id: 9, name: "Development" });
-    expect(entry!.hours).toEqual(2.5);
+    expect(entry).toBeDefined();
+    expect(entry!.project).toStrictEqual({ id: 1, name: "Demo" });
+    expect(entry!.issue).toStrictEqual({ id: 5 });
+    expect(entry!.activity).toStrictEqual({ id: 9, name: "Development" });
+    expect(entry!.hours).toStrictEqual(2.5);
 
     const entryWithoutIssue = e._unsafeUnwrap().find((timeEntry) =>
       timeEntry.id === 2
     );
-    expect(entryWithoutIssue !== undefined).toBe(true);
-    expect(entryWithoutIssue!.issue).toEqual(undefined);
-    expect(entryWithoutIssue!.comments).toEqual(undefined);
+    expect(entryWithoutIssue).toBeDefined();
+    expect(entryWithoutIssue!.issue).toBeUndefined();
+    expect(entryWithoutIssue!.comments).toBeUndefined();
   });
 
   await t.step(
@@ -73,11 +73,11 @@ Deno.test("GET /time_entries.json", async (t) => {
         to: new Date("2026-07-31"),
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.get("project_id")).toEqual("1");
-      expect(captured?.get("user_id")).toEqual("2");
-      expect(captured?.get("spent_on")).toEqual("2026-07-01");
-      expect(captured?.get("from")).toEqual("2026-07-01");
-      expect(captured?.get("to")).toEqual("2026-07-31");
+      expect(captured?.get("project_id")).toStrictEqual("1");
+      expect(captured?.get("user_id")).toStrictEqual("2");
+      expect(captured?.get("spent_on")).toStrictEqual("2026-07-01");
+      expect(captured?.get("from")).toStrictEqual("2026-07-01");
+      expect(captured?.get("to")).toStrictEqual("2026-07-31");
     },
   );
 
@@ -98,7 +98,7 @@ Deno.test("GET /time_entries.json", async (t) => {
       );
       const e = await fetchList(context, { projectId: undefined });
       expect(e.isOk()).toBe(true);
-      expect(captured?.has("project_id")).toEqual(false);
+      expect(captured?.has("project_id")).toStrictEqual(false);
       expect(!captured?.toString().includes("undefined")).toBe(true);
     },
   );

--- a/result/time-entries/show.test.ts
+++ b/result/time-entries/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /time_entries/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,24 +18,26 @@ Deno.test("GET /time_entries/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step("should map camelCase fields from the response", async () => {
     server.use(...validHandlers);
     const e = await show(context, 3);
-    assert(e.isOk());
-    assertEquals(e.value.project, { id: 1, name: "Demo" });
-    assertEquals(e.value.issue, { id: 5 });
-    assertEquals(e.value.activity, { id: 9, name: "Development" });
-    assertEquals(e.value.hours, 2.5);
-    assertEquals(e.value.spentOn.toISOString().slice(0, 10), "2026-07-01");
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().project).toEqual({ id: 1, name: "Demo" });
+    expect(e._unsafeUnwrap().issue).toEqual({ id: 5 });
+    expect(e._unsafeUnwrap().activity).toEqual({ id: 9, name: "Development" });
+    expect(e._unsafeUnwrap().hours).toEqual(2.5);
+    expect(e._unsafeUnwrap().spentOn.toISOString().slice(0, 10)).toEqual(
+      "2026-07-01",
+    );
   });
 });

--- a/result/time-entries/show.test.ts
+++ b/result/time-entries/show.test.ts
@@ -32,11 +32,12 @@ Deno.test("GET /time_entries/:id.json", async (t) => {
     server.use(...validHandlers);
     const e = await show(context, 3);
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().project).toEqual({ id: 1, name: "Demo" });
-    expect(e._unsafeUnwrap().issue).toEqual({ id: 5 });
-    expect(e._unsafeUnwrap().activity).toEqual({ id: 9, name: "Development" });
-    expect(e._unsafeUnwrap().hours).toEqual(2.5);
-    expect(e._unsafeUnwrap().spentOn.toISOString().slice(0, 10)).toEqual(
+    const entry = e._unsafeUnwrap();
+    expect(entry.project).toStrictEqual({ id: 1, name: "Demo" });
+    expect(entry.issue).toStrictEqual({ id: 5 });
+    expect(entry.activity).toStrictEqual({ id: 9, name: "Development" });
+    expect(entry.hours).toStrictEqual(2.5);
+    expect(entry.spentOn.toISOString().slice(0, 10)).toStrictEqual(
       "2026-07-01",
     );
   });

--- a/result/time-entries/update.test.ts
+++ b/result/time-entries/update.test.ts
@@ -50,8 +50,8 @@ Deno.test("PUT /time_entries/:id.json", async (t) => {
         spentOn: new Date("2026-07-02"),
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.activity_id).toEqual(8);
-      expect(captured?.spent_on).toEqual("2026-07-02");
+      expect(captured?.activity_id).toStrictEqual(8);
+      expect(captured?.spent_on).toStrictEqual("2026-07-02");
     },
   );
 });

--- a/result/time-entries/update.test.ts
+++ b/result/time-entries/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /time_entries/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 3, { hours: 3 });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /time_entries/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { hours: 3 });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { hours: 3 });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -49,9 +49,9 @@ Deno.test("PUT /time_entries/:id.json", async (t) => {
         activityId: 8,
         spentOn: new Date("2026-07-02"),
       });
-      assert(e.isOk());
-      assertEquals(captured?.activity_id, 8);
-      assertEquals(captured?.spent_on, "2026-07-02");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.activity_id).toEqual(8);
+      expect(captured?.spent_on).toEqual("2026-07-02");
     },
   );
 });

--- a/result/users/create.test.ts
+++ b/result/users/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -18,7 +18,7 @@ Deno.test("POST /users.json", async (t) => {
         lastname: "Smith",
         mail: "jsmith@example.com",
       });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -33,7 +33,7 @@ Deno.test("POST /users.json", async (t) => {
         lastname: "Smith",
         mail: "jsmith@example.com",
       });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -46,7 +46,7 @@ Deno.test("POST /users.json", async (t) => {
       lastname: "Smith",
       mail: "jsmith@example.com",
     });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -73,12 +73,12 @@ Deno.test("POST /users.json", async (t) => {
         mustChangePasswd: true,
         generatePassword: false,
       });
-      assert(e.isOk());
-      assertEquals(captured?.login, "jsmith");
-      assertEquals(captured?.auth_source_id, 1);
-      assertEquals(captured?.mail_notification, "only_my_events");
-      assertEquals(captured?.must_change_passwd, true);
-      assertEquals(captured?.generate_password, false);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.login).toEqual("jsmith");
+      expect(captured?.auth_source_id).toEqual(1);
+      expect(captured?.mail_notification).toEqual("only_my_events");
+      expect(captured?.must_change_passwd).toEqual(true);
+      expect(captured?.generate_password).toEqual(false);
     },
   );
 });

--- a/result/users/create.test.ts
+++ b/result/users/create.test.ts
@@ -74,11 +74,11 @@ Deno.test("POST /users.json", async (t) => {
         generatePassword: false,
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.login).toEqual("jsmith");
-      expect(captured?.auth_source_id).toEqual(1);
-      expect(captured?.mail_notification).toEqual("only_my_events");
-      expect(captured?.must_change_passwd).toEqual(true);
-      expect(captured?.generate_password).toEqual(false);
+      expect(captured?.login).toStrictEqual("jsmith");
+      expect(captured?.auth_source_id).toStrictEqual(1);
+      expect(captured?.mail_notification).toStrictEqual("only_my_events");
+      expect(captured?.must_change_passwd).toStrictEqual(true);
+      expect(captured?.generate_password).toStrictEqual(false);
     },
   );
 });

--- a/result/users/delete.test.ts
+++ b/result/users/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteUser } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /users/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteUser(context, 2);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /users/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteUser(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteUser(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/users/list.test.ts
+++ b/result/users/list.test.ts
@@ -19,11 +19,12 @@ Deno.test("GET /users.json", async (t) => {
       server.use(...validHandlers);
       const e = await fetchList(context);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().length).toEqual(2);
-      expect(e._unsafeUnwrap()[1].login).toEqual("admin");
-      expect(e._unsafeUnwrap()[1].admin).toEqual(true);
-      expect(e._unsafeUnwrap()[1].apiKey).toEqual("abcdef1234567890");
-      expect(e._unsafeUnwrap()[0].lastLoginOn).toEqual(
+      const users = e._unsafeUnwrap();
+      expect(users.length).toStrictEqual(2);
+      expect(users[1].login).toStrictEqual("admin");
+      expect(users[1].admin).toStrictEqual(true);
+      expect(users[1].apiKey).toStrictEqual("abcdef1234567890");
+      expect(users[0].lastLoginOn).toStrictEqual(
         new Date("2026-07-13T00:00:00.000Z"),
       );
     },

--- a/result/users/list.test.ts
+++ b/result/users/list.test.ts
@@ -1,7 +1,7 @@
 import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /users.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,12 @@ Deno.test("GET /users.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await fetchList(context);
-      assert(e.isOk());
-      assertEquals(e.value.length, 2);
-      assertEquals(e.value[1].login, "admin");
-      assertEquals(e.value[1].admin, true);
-      assertEquals(e.value[1].apiKey, "abcdef1234567890");
-      assertEquals(
-        e.value[0].lastLoginOn,
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().length).toEqual(2);
+      expect(e._unsafeUnwrap()[1].login).toEqual("admin");
+      expect(e._unsafeUnwrap()[1].admin).toEqual(true);
+      expect(e._unsafeUnwrap()[1].apiKey).toEqual("abcdef1234567890");
+      expect(e._unsafeUnwrap()[0].lastLoginOn).toEqual(
         new Date("2026-07-13T00:00:00.000Z"),
       );
     },
@@ -36,7 +35,7 @@ Deno.test("GET /users.json", async (t) => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
       const e = await fetchList(c);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
@@ -44,6 +43,6 @@ Deno.test("GET /users.json", async (t) => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
     const e = await fetchList(c);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/users/show.test.ts
+++ b/result/users/show.test.ts
@@ -19,9 +19,10 @@ Deno.test("GET /users/:id.json", async (t) => {
       server.use(...validHandlers);
       const e = await show(context, 2);
       expect(e.isOk()).toBe(true);
-      expect(e._unsafeUnwrap().id).toEqual(2);
-      expect(e._unsafeUnwrap().login).toEqual("jsmith");
-      expect(e._unsafeUnwrap().lastLoginOn).toEqual(
+      const user = e._unsafeUnwrap();
+      expect(user.id).toStrictEqual(2);
+      expect(user.login).toStrictEqual("jsmith");
+      expect(user.lastLoginOn).toStrictEqual(
         new Date("2026-07-13T00:00:00.000Z"),
       );
     },

--- a/result/users/show.test.ts
+++ b/result/users/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /users/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 2);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,11 +18,10 @@ Deno.test("GET /users/:id.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await show(context, 2);
-      assert(e.isOk());
-      assertEquals(e.value.id, 2);
-      assertEquals(e.value.login, "jsmith");
-      assertEquals(
-        e.value.lastLoginOn,
+      expect(e.isOk()).toBe(true);
+      expect(e._unsafeUnwrap().id).toEqual(2);
+      expect(e._unsafeUnwrap().login).toEqual("jsmith");
+      expect(e._unsafeUnwrap().lastLoginOn).toEqual(
         new Date("2026-07-13T00:00:00.000Z"),
       );
     },
@@ -33,13 +32,13 @@ Deno.test("GET /users/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/users/update.test.ts
+++ b/result/users/update.test.ts
@@ -48,8 +48,8 @@ Deno.test("PUT /users/:id.json", async (t) => {
         admin: true,
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.mail_notification).toEqual("none");
-      expect(captured?.admin).toEqual(true);
+      expect(captured?.mail_notification).toStrictEqual("none");
+      expect(captured?.admin).toStrictEqual(true);
     },
   );
 });

--- a/result/users/update.test.ts
+++ b/result/users/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /users/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 2, { firstname: "Jonathan" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /users/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { firstname: "Jonathan" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { firstname: "Jonathan" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -47,9 +47,9 @@ Deno.test("PUT /users/:id.json", async (t) => {
         mailNotification: "none",
         admin: true,
       });
-      assert(e.isOk());
-      assertEquals(captured?.mail_notification, "none");
-      assertEquals(captured?.admin, true);
+      expect(e.isOk()).toBe(true);
+      expect(captured?.mail_notification).toEqual("none");
+      expect(captured?.admin).toEqual(true);
     },
   );
 });

--- a/result/versions/create.test.ts
+++ b/result/versions/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ Deno.test("POST /projects/:project_id/versions.json", async (t) => {
     async () => {
       server.use(...validHandlers);
       const e = await create(context, 1, { name: "v1.0" });
-      assert(e.isOk());
+      expect(e.isOk()).toBe(true);
     },
   );
 
@@ -22,14 +22,14 @@ Deno.test("POST /projects/:project_id/versions.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await create(context, 422, { name: "v1.0" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await create(context, 404, { name: "v1.0" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -53,10 +53,10 @@ Deno.test("POST /projects/:project_id/versions.json", async (t) => {
         dueDate: new Date("2026-08-01"),
         wikiPageTitle: "Roadmap",
       });
-      assert(e.isOk());
-      assertEquals(captured?.name, "v1.0");
-      assertEquals(captured?.due_date, "2026-08-01");
-      assertEquals(captured?.wiki_page_title, "Roadmap");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.name).toEqual("v1.0");
+      expect(captured?.due_date).toEqual("2026-08-01");
+      expect(captured?.wiki_page_title).toEqual("Roadmap");
     },
   );
 });

--- a/result/versions/create.test.ts
+++ b/result/versions/create.test.ts
@@ -54,9 +54,9 @@ Deno.test("POST /projects/:project_id/versions.json", async (t) => {
         wikiPageTitle: "Roadmap",
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.name).toEqual("v1.0");
-      expect(captured?.due_date).toEqual("2026-08-01");
-      expect(captured?.wiki_page_title).toEqual("Roadmap");
+      expect(captured?.name).toStrictEqual("v1.0");
+      expect(captured?.due_date).toStrictEqual("2026-08-01");
+      expect(captured?.wiki_page_title).toStrictEqual("Roadmap");
     },
   );
 });

--- a/result/versions/delete.test.ts
+++ b/result/versions/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteVersion } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -10,7 +10,7 @@ Deno.test("DELETE /versions/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await deleteVersion(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("DELETE /versions/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await deleteVersion(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await deleteVersion(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/versions/list.test.ts
+++ b/result/versions/list.test.ts
@@ -1,7 +1,7 @@
 import { fetchList } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /projects/:project_id/versions.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.use(...validHandlers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("GET /projects/:project_id/versions.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await fetchList(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await fetchList(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/versions/show.test.ts
+++ b/result/versions/show.test.ts
@@ -1,7 +1,7 @@
 import { show } from "./show.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -10,7 +10,7 @@ Deno.test("GET /versions/:id.json", async (t) => {
   await t.step("if got 200, should return ok", async () => {
     server.use(...validHandlers);
     const e = await show(context, 3);
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -18,13 +18,13 @@ Deno.test("GET /versions/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await show(context, 422);
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await show(context, 404);
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 });

--- a/result/versions/update.test.ts
+++ b/result/versions/update.test.ts
@@ -48,8 +48,8 @@ Deno.test("PUT /versions/:id.json", async (t) => {
         wikiPageTitle: "Plan",
       });
       expect(e.isOk()).toBe(true);
-      expect(captured?.due_date).toEqual("2026-09-01");
-      expect(captured?.wiki_page_title).toEqual("Plan");
+      expect(captured?.due_date).toStrictEqual("2026-09-01");
+      expect(captured?.wiki_page_title).toStrictEqual("Plan");
     },
   );
 });

--- a/result/versions/update.test.ts
+++ b/result/versions/update.test.ts
@@ -2,7 +2,7 @@ import { update } from "./update.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 const server = setupServer();
 server.listen();
@@ -11,7 +11,7 @@ Deno.test("PUT /versions/:id.json", async (t) => {
   await t.step("if got 204, should be success", async () => {
     server.use(...validHandlers);
     const e = await update(context, 3, { name: "v1.1" });
-    assert(e.isOk());
+    expect(e.isOk()).toBe(true);
   });
 
   await t.step(
@@ -19,14 +19,14 @@ Deno.test("PUT /versions/:id.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const e = await update(context, 422, { name: "v1.1" });
-      assert(e.isErr());
+      expect(e.isErr()).toBe(true);
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const e = await update(context, 404, { name: "v1.1" });
-    assert(e.isErr());
+    expect(e.isErr()).toBe(true);
   });
 
   await t.step(
@@ -47,9 +47,9 @@ Deno.test("PUT /versions/:id.json", async (t) => {
         dueDate: new Date("2026-09-01"),
         wikiPageTitle: "Plan",
       });
-      assert(e.isOk());
-      assertEquals(captured?.due_date, "2026-09-01");
-      assertEquals(captured?.wiki_page_title, "Plan");
+      expect(e.isOk()).toBe(true);
+      expect(captured?.due_date).toEqual("2026-09-01");
+      expect(captured?.wiki_page_title).toEqual("Plan");
     },
   );
 });

--- a/result/wiki-pages/create.test.ts
+++ b/result/wiki-pages/create.test.ts
@@ -1,5 +1,5 @@
 import { create } from "./create.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
@@ -17,7 +17,7 @@ Deno.test("POST /project/:id/wiki/:page.json", async (t) => {
       title: "create",
       text: "sample text",
     });
-    assert(r.isOk());
+    expect(r.isOk()).toBe(true);
   });
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
@@ -25,6 +25,6 @@ Deno.test("POST /project/:id/wiki/:page.json", async (t) => {
       title: "create",
       text: "sample text",
     });
-    assert(r.isErr());
+    expect(r.isErr()).toBe(true);
   });
 });

--- a/result/wiki-pages/delete.test.ts
+++ b/result/wiki-pages/delete.test.ts
@@ -1,5 +1,5 @@
 import { deleteWiki } from "./delete.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
@@ -14,16 +14,16 @@ Deno.test("DELETE /projects/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
     const r = await deleteWiki(context, 1, "sample-title");
-    assert(r.isOk());
+    expect(r.isOk()).toBe(true);
   });
   await t.step("If got 403, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const r = await deleteWiki(context, 1, "forbidden");
-    assert(r.isErr());
+    expect(r.isErr()).toBe(true);
   });
   await t.step("If got 404, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const r = await deleteWiki(context, 1, "notfound");
-    assert(r.isErr());
+    expect(r.isErr()).toBe(true);
   });
 });

--- a/result/wiki-pages/list.test.ts
+++ b/result/wiki-pages/list.test.ts
@@ -1,5 +1,5 @@
 import { fetchList } from "./list.ts";
-import { assert } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 
 import {
   context,
@@ -15,13 +15,13 @@ Deno.test("GET /projects/:id/wiki/index.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
     const e = await fetchList(context, 1);
-    assert(e.isOk());
-    assert(e.value.length === 2);
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().length === 2).toBe(true);
   });
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const e = await fetchList(context, 2);
-    assert(e.isErr());
-    assert(e.error.message === "Unprocessable Entity");
+    expect(e.isErr()).toBe(true);
+    expect(e._unsafeUnwrapErr().message === "Unprocessable Entity").toBe(true);
   });
 });

--- a/result/wiki-pages/list.test.ts
+++ b/result/wiki-pages/list.test.ts
@@ -16,12 +16,12 @@ Deno.test("GET /projects/:id/wiki/index.json", async (t) => {
     server.resetHandlers(...validResponseHandelers);
     const e = await fetchList(context, 1);
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().length === 2).toBe(true);
+    expect(e._unsafeUnwrap().length).toBe(2);
   });
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const e = await fetchList(context, 2);
     expect(e.isErr()).toBe(true);
-    expect(e._unsafeUnwrapErr().message === "Unprocessable Entity").toBe(true);
+    expect(e._unsafeUnwrapErr().message).toBe("Unprocessable Entity");
   });
 });

--- a/result/wiki-pages/show.test.ts
+++ b/result/wiki-pages/show.test.ts
@@ -1,5 +1,5 @@
 import { show } from "./show.ts";
-import { assert, assertEquals } from "jsr:@std/assert@1.0.19";
+import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
@@ -15,8 +15,8 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
     const e = await show(context, 1, "sample-title");
-    assert(e.isOk());
-    assert(e.value.title === "sample-title");
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().title === "sample-title").toBe(true);
   });
   await t.step("if got 200 with null comments, should be success", async () => {
     server.resetHandlers(
@@ -38,15 +38,15 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
       ),
     );
     const e = await show(context, 1, "sample-title");
-    assert(e.isOk());
-    assertEquals(e.value.title, "sample-title");
-    assertEquals(e.value.comments, undefined);
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().title).toEqual("sample-title");
+    expect(e._unsafeUnwrap().comments).toEqual(undefined);
   });
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const e = await show(context, 2, "sample-title");
-    assert(e.isErr());
-    assert(e.error.message === "Unprocessable Entity");
+    expect(e.isErr()).toBe(true);
+    expect(e._unsafeUnwrapErr().message === "Unprocessable Entity").toBe(true);
   });
 });
 
@@ -54,8 +54,8 @@ Deno.test("GET /projects/:id/wiki/:page/:version.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
     const e = await show(context, 1, "sample-title", 3);
-    assert(e.isOk());
-    assert(e.value.title === "sample-title");
-    assert(e.value.version === 3);
+    expect(e.isOk()).toBe(true);
+    expect(e._unsafeUnwrap().title === "sample-title").toBe(true);
+    expect(e._unsafeUnwrap().version === 3).toBe(true);
   });
 });

--- a/result/wiki-pages/show.test.ts
+++ b/result/wiki-pages/show.test.ts
@@ -16,7 +16,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
     server.resetHandlers(...validResponseHandelers);
     const e = await show(context, 1, "sample-title");
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().title === "sample-title").toBe(true);
+    expect(e._unsafeUnwrap().title).toBe("sample-title");
   });
   await t.step("if got 200 with null comments, should be success", async () => {
     server.resetHandlers(
@@ -39,14 +39,14 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
     );
     const e = await show(context, 1, "sample-title");
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().title).toEqual("sample-title");
-    expect(e._unsafeUnwrap().comments).toEqual(undefined);
+    expect(e._unsafeUnwrap().title).toStrictEqual("sample-title");
+    expect(e._unsafeUnwrap().comments).toBeUndefined();
   });
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
     const e = await show(context, 2, "sample-title");
     expect(e.isErr()).toBe(true);
-    expect(e._unsafeUnwrapErr().message === "Unprocessable Entity").toBe(true);
+    expect(e._unsafeUnwrapErr().message).toBe("Unprocessable Entity");
   });
 });
 
@@ -55,7 +55,7 @@ Deno.test("GET /projects/:id/wiki/:page/:version.json", async (t) => {
     server.resetHandlers(...validResponseHandelers);
     const e = await show(context, 1, "sample-title", 3);
     expect(e.isOk()).toBe(true);
-    expect(e._unsafeUnwrap().title === "sample-title").toBe(true);
-    expect(e._unsafeUnwrap().version === 3).toBe(true);
+    expect(e._unsafeUnwrap().title).toBe("sample-title");
+    expect(e._unsafeUnwrap().version).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Migrate all unit and e2e test assertions from `@std/assert` to `@std/expect` for a consistent, Jest-like assertion style across the test suite.

## Details

The suite mixed several `@std/assert` helpers, so standardizing on `expect` gives one assertion style throughout.

Because `expect()` does not narrow types the way `assert()`'s `asserts` predicate did, neverthrow `Result` values are read via `_unsafeUnwrap()` / `_unsafeUnwrapErr()`, and possibly-`undefined` values use non-null assertions guarded by the preceding `expect` definedness check.

## Confirmation

Ran `nix run .#check-deno` (check + lint + test) and confirmed `94 passed (266 steps) | 0 failed`.

## Limitation

The e2e tests type-check but were not executed locally because they require a live Redmine instance.

Generated with: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized automated test assertions across API, end-to-end, error-handling, pagination, and URL-building coverage.
  * Expanded validation of successful and failed operations, returned fields, request payload mappings, pagination behavior, and cleanup flows.
  * Improved checks for response data, error states, date values, optional fields, and serialized query parameters.
  * No end-user functionality or API behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->