### PR TITLE
feat: implement Projects close/reopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Redmine rest api wrapper for deno.
   - [x] [Updating a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects#Updating-a-project)
   - [x] [Archiving a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects#Archiving-a-project)
   - [x] [Unarchiving a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects#Unarchiving-a-project)
+  - [x] [Closing a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects)
+  - [x] [Reopening a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects)
   - [x] [Deleting a project](https://www.redmine.org/projects/redmine/wiki/Rest_Projects#Deleting-a-project)
 - [x] [Project Memberships](https://www.redmine.org/projects/redmine/wiki/Rest_Memberships)
   - [x] [`/projects/:project_id/memberships.:format`](https://www.redmine.org/projects/redmine/wiki/Rest_Memberships#projectsproject_idmembershipsformat)

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -6,6 +6,7 @@ import { create } from "../result/projects/create.ts";
 import { update } from "../result/projects/update.ts";
 import { deleteProject } from "../result/projects/delete.ts";
 import { archive, unarchive } from "../result/projects/archive.ts";
+import { close, reopen } from "../result/projects/close.ts";
 
 Deno.test({
   name: "E2E: Projects API",
@@ -124,6 +125,26 @@ Deno.test({
 
         const unarchiveResult = await unarchive(e2eContext, project!.id);
         expect(unarchiveResult.isOk(), "Expected unarchive to succeed").toBe(
+          true,
+        );
+      },
+    );
+
+    await t.step(
+      "PUT /projects/:id/close.json should close and reopen",
+      async () => {
+        const listResult = await fetchList(e2eContext);
+        expect(listResult.isOk()).toBe(true);
+        const project = listResult._unsafeUnwrap().find((p) =>
+          p.identifier === "e2e-created-project"
+        );
+        expect(project).toBeDefined();
+
+        const closeResult = await close(e2eContext, project!.id);
+        expect(closeResult.isOk(), "Expected close to succeed").toBe(true);
+
+        const reopenResult = await reopen(e2eContext, project!.id);
+        expect(reopenResult.isOk(), "Expected reopen to succeed").toBe(
           true,
         );
       },

--- a/result/projects/_mock.ts
+++ b/result/projects/_mock.ts
@@ -13,6 +13,12 @@ export const validHandlers = [
   http.put(`${context.endpoint}/projects/:id/unarchive.json`, () => {
     return HttpResponse.json({});
   }),
+  http.put(`${context.endpoint}/projects/:id/close.json`, () => {
+    return HttpResponse.json({});
+  }),
+  http.put(`${context.endpoint}/projects/:id/reopen.json`, () => {
+    return HttpResponse.json({});
+  }),
   http.post(`${context.endpoint}/projects.json`, () => {
     return HttpResponse.json({});
   }),
@@ -128,6 +134,32 @@ export const invalidHandlers = [
     });
   }),
   http.put(`${context.endpoint}/projects/404/unarchive.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.put(`${context.endpoint}/projects/422/close.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.put(`${context.endpoint}/projects/404/close.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+  http.put(`${context.endpoint}/projects/422/reopen.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.put(`${context.endpoint}/projects/404/reopen.json`, () => {
     // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
     return new HttpResponse(null, { status: STATUS_CODE.NotFound });
   }),

--- a/result/projects/close.test.ts
+++ b/result/projects/close.test.ts
@@ -1,0 +1,54 @@
+import { close, reopen } from "./close.ts";
+import { expect } from "jsr:@std/expect@1.0.20";
+
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { setupServer } from "npm:msw@2.15.0/node";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("PUT /projects/:id/close.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await close(context, 1);
+    expect(e.isOk()).toBe(true);
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.resetHandlers(...invalidHandlers);
+      const e = await close(context, 422);
+      expect(e.isErr()).toBe(true);
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await close(context, 404);
+    expect(e.isErr()).toBe(true);
+  });
+});
+
+Deno.test("PUT /projects/:id/reopen.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await reopen(context, 1);
+    expect(e.isOk()).toBe(true);
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.resetHandlers(...invalidHandlers);
+      const e = await reopen(context, 422);
+      expect(e.isErr()).toBe(true);
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await reopen(context, 404);
+    expect(e.isErr()).toBe(true);
+  });
+});

--- a/result/projects/close.ts
+++ b/result/projects/close.ts
@@ -1,0 +1,16 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { convertError } from "../../error.ts";
+import {
+  close as closeWithError,
+  reopen as reopenWithError,
+} from "../../throwable/projects/close.ts";
+
+export const close = ResultAsync.fromThrowable(
+  closeWithError,
+  convertError("unknown error close a project"),
+);
+
+export const reopen = ResultAsync.fromThrowable(
+  reopenWithError,
+  convertError("unknown error reopen a project"),
+);

--- a/result/projects/mod.ts
+++ b/result/projects/mod.ts
@@ -6,6 +6,7 @@ import type { ProjectQuery } from "../../throwable/projects/type.ts";
 import { update } from "./update.ts";
 import { deleteProject } from "./delete.ts";
 import { archive, unarchive } from "./archive.ts";
+import { close, reopen } from "./close.ts";
 import { ProjectUpdateInformation } from "../../throwable/projects/update.ts";
 
 export class Client {
@@ -83,5 +84,23 @@ export class Client {
    */
   unarchive(id: number): ReturnType<typeof unarchive> {
     return unarchive(this.#context, id);
+  }
+
+  /**
+   * Closes the project of given id or identifier.
+   *
+   * @param id Project identifier
+   */
+  close(id: number): ReturnType<typeof close> {
+    return close(this.#context, id);
+  }
+
+  /**
+   * Reopens the project of given id or identifier.
+   *
+   * @param id Project identifier
+   */
+  reopen(id: number): ReturnType<typeof reopen> {
+    return reopen(this.#context, id);
   }
 }

--- a/throwable/projects/close.ts
+++ b/throwable/projects/close.ts
@@ -1,0 +1,27 @@
+import { buildUrl } from "../../internal/url.ts";
+import type { Context } from "../../context.ts";
+import { assertResponse } from "../../error.ts";
+
+async function internal(
+  context: Context,
+  id: number,
+  method: "close" | "reopen",
+): Promise<void> {
+  const url = buildUrl(context.endpoint, "projects", `${id}`, `${method}.json`);
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+  });
+  await assertResponse(response);
+}
+
+export async function close(context: Context, id: number): Promise<void> {
+  return await internal(context, id, "close");
+}
+
+export async function reopen(context: Context, id: number): Promise<void> {
+  return await internal(context, id, "reopen");
+}

--- a/throwable/projects/mod.ts
+++ b/throwable/projects/mod.ts
@@ -6,6 +6,7 @@ import type { ProjectQuery } from "./type.ts";
 import { type ProjectUpdateInformation, update } from "./update.ts";
 import { deleteProject } from "./delete.ts";
 import { archive, unarchive } from "./archive.ts";
+import { close, reopen } from "./close.ts";
 
 export class Client {
   readonly #context: Context;
@@ -82,5 +83,23 @@ export class Client {
    */
   unarchive(id: number): ReturnType<typeof unarchive> {
     return unarchive(this.#context, id);
+  }
+
+  /**
+   * Closes the project of given id or identifier.
+   *
+   * @param id Project identifier
+   */
+  close(id: number): ReturnType<typeof close> {
+    return close(this.#context, id);
+  }
+
+  /**
+   * Reopens the project of given id or identifier.
+   *
+   * @param id Project identifier
+   */
+  reopen(id: number): ReturnType<typeof reopen> {
+    return reopen(this.#context, id);
   }
 }


### PR DESCRIPTION
## Summary

Add close/reopen for the Projects resource, alongside the existing archive/unarchive.

## Details

Redmine exposes `PUT /projects/:id/close` and `/reopen` with `accept_api_auth`, but only archive/unarchive were implemented. The new operations mirror the archive/unarchive structure.

## Confirmation

`nix run .#check-deno` (type-check, lint, 100 unit tests) passes.

## Limitation

e2e (close/reopen step) runs in CI against Redmine 5.1/6.0/6.1; not executed locally this time.

Closes #423.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for closing projects through the project client.
  - Added support for reopening projects through the project client.
  - Added error handling for unsuccessful close and reopen operations.

- **Documentation**
  - Updated the implementation status checklist to mark project closing and reopening as complete.

- **Tests**
  - Added coverage for successful and failed close/reopen requests, including end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->