### PR TITLE
feat: implement Journal note update

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ Redmine rest api wrapper for deno.
   - [x] [`/my/account.:format`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#myaccountformat)
     - [x] [`GET`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#GET)
     - [x] [`PUT`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#PUT)
-- [ ] [Journals](https://www.redmine.org/projects/redmine/wiki/Rest_Journals)
-  - Official Page is not found...:
-    https://www.redmine.org/projects/redmine/wiki/Rest_Journals
+- [x] [Journals](https://www.redmine.org/projects/redmine/wiki/Rest_Journals)
+  - [x] [Updating a journal](https://www.redmine.org/projects/redmine/wiki/Rest_Journals#Updating-a-journal)
 
 ### external plugin
 

--- a/e2e/journals.test.ts
+++ b/e2e/journals.test.ts
@@ -15,105 +15,98 @@ Deno.test({
     let issueId: number | undefined;
     let journalId: number | undefined;
 
-    try {
-      await t.step(
-        "POST /issues.json should create an issue to attach a journal to",
-        async () => {
-          const projectsResult = await fetchProjects(e2eContext);
-          expect(projectsResult.isOk()).toBe(true);
-          const project = projectsResult._unsafeUnwrap().find((p) =>
-            p.identifier === "e2e-test-project"
-          );
-          expect(project).toBeDefined();
+    await t.step(
+      "POST /issues.json should create an issue to attach a journal to",
+      async () => {
+        const projectsResult = await fetchProjects(e2eContext);
+        expect(projectsResult.isOk()).toBe(true);
+        const project = projectsResult._unsafeUnwrap().find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        expect(project).toBeDefined();
 
-          const issuesBefore = await listIssues(e2eContext, {
-            projectId: project!.id,
-          });
-          expect(issuesBefore.isOk()).toBe(true);
-          const issues = issuesBefore._unsafeUnwrap();
-          expect(issues.length).toBeGreaterThan(0);
+        const issuesBefore = await listIssues(e2eContext, {
+          projectId: project!.id,
+        });
+        expect(issuesBefore.isOk()).toBe(true);
+        const issues = issuesBefore._unsafeUnwrap();
+        expect(issues.length).toBeGreaterThan(0);
 
-          const created = await createIssue(e2eContext, {
-            projectId: project!.id,
-            trackerId: issues[0].tracker.id,
-            statusId: issues[0].status.id,
-            priorityId: issues[0].priority.id,
-            subject,
-          });
-          expect(created.isOk()).toBe(true);
+        const created = await createIssue(e2eContext, {
+          projectId: project!.id,
+          trackerId: issues[0].tracker.id,
+          statusId: issues[0].status.id,
+          priorityId: issues[0].priority.id,
+          subject,
+        });
+        expect(created.isOk()).toBe(true);
 
-          // createIssue does not return the created id, so it is looked up
-          // by subject, mirroring the pattern in e2e/issues.test.ts.
-          const listAfter = await listIssues(e2eContext, {
-            projectId: project!.id,
-          });
-          expect(listAfter.isOk()).toBe(true);
-          const createdIssue = listAfter._unsafeUnwrap().find((i) =>
-            i.subject === subject
-          );
-          expect(createdIssue).toBeDefined();
-          issueId = createdIssue!.id;
-        },
-      );
+        // createIssue does not return the created id, so it is looked up
+        // by subject, mirroring the pattern in e2e/issues.test.ts.
+        const listAfter = await listIssues(e2eContext, {
+          projectId: project!.id,
+        });
+        expect(listAfter.isOk()).toBe(true);
+        const createdIssue = listAfter._unsafeUnwrap().find((i) =>
+          i.subject === subject
+        );
+        expect(createdIssue).toBeDefined();
+        issueId = createdIssue!.id;
+      },
+    );
 
-      await t.step(
-        "PUT /issues/:id.json with notes should create a journal",
-        async () => {
-          const result = await update(e2eContext, issueId!, {
-            notes: "journal note to edit",
-          });
-          expect(result.isOk()).toBe(true);
-        },
-      );
+    await t.step(
+      "PUT /issues/:id.json with notes should create a journal",
+      async () => {
+        const result = await update(e2eContext, issueId!, {
+          notes: "journal note to edit",
+        });
+        expect(result.isOk()).toBe(true);
+      },
+    );
 
-      await t.step(
-        "GET /issues/:id.json?include=journals should return the created journal",
-        async () => {
-          const showResult = await show(e2eContext, issueId!, ["journals"]);
-          expect(showResult.isOk()).toBe(true);
-          const journal = showResult._unsafeUnwrap().journals?.find((j) =>
-            j.notes === "journal note to edit"
-          );
-          expect(journal).toBeDefined();
-          journalId = journal!.id;
-        },
-      );
+    await t.step(
+      "GET /issues/:id.json?include=journals should return the created journal",
+      async () => {
+        const showResult = await show(e2eContext, issueId!, ["journals"]);
+        expect(showResult.isOk()).toBe(true);
+        const journal = showResult._unsafeUnwrap().journals?.find((j) =>
+          j.notes === "journal note to edit"
+        );
+        expect(journal).toBeDefined();
+        journalId = journal!.id;
+      },
+    );
 
-      await t.step(
-        "PUT /journals/:id.json should update the journal note",
-        async () => {
-          const result = await updateJournal(e2eContext, journalId!, {
-            notes: "edited journal note",
-          });
-          expect(result.isOk()).toBe(true);
-        },
-      );
+    await t.step(
+      "PUT /journals/:id.json should update the journal note",
+      async () => {
+        const result = await updateJournal(e2eContext, journalId!, {
+          notes: "edited journal note",
+        });
+        expect(result.isOk()).toBe(true);
+      },
+    );
 
-      await t.step(
-        "GET /issues/:id.json?include=journals should reflect the edited note",
-        async () => {
-          const showResult = await show(e2eContext, issueId!, ["journals"]);
-          expect(showResult.isOk()).toBe(true);
-          const journal = showResult._unsafeUnwrap().journals?.find((j) =>
-            j.id === journalId
-          );
-          expect(journal).toBeDefined();
-          expect(journal!.notes).toStrictEqual("edited journal note");
-        },
-      );
-    } finally {
-      await t.step(
-        "DELETE /issues/:id.json should clean up the created issue",
-        async () => {
-          if (issueId !== undefined) {
-            const deleted = await deleteIssue(e2eContext, issueId);
-            expect(deleted.isOk(), "cleanup must delete the created issue")
-              .toBe(
-                true,
-              );
-          }
-        },
-      );
-    }
+    await t.step(
+      "GET /issues/:id.json?include=journals should reflect the edited note",
+      async () => {
+        const showResult = await show(e2eContext, issueId!, ["journals"]);
+        expect(showResult.isOk()).toBe(true);
+        const journal = showResult._unsafeUnwrap().journals?.find((j) =>
+          j.id === journalId
+        );
+        expect(journal).toBeDefined();
+        expect(journal!.notes).toStrictEqual("edited journal note");
+      },
+    );
+
+    await t.step(
+      "DELETE /issues/:id.json should clean up the created issue",
+      async () => {
+        const deleted = await deleteIssue(e2eContext, issueId!);
+        expect(deleted.isOk()).toBe(true);
+      },
+    );
   },
 });

--- a/e2e/journals.test.ts
+++ b/e2e/journals.test.ts
@@ -1,0 +1,119 @@
+import { expect } from "jsr:@std/expect@1.0.20";
+import { e2eContext } from "./context.ts";
+import { listIssues } from "../result/issues/list.ts";
+import { show } from "../result/issues/show.ts";
+import { createIssue } from "../result/issues/create.ts";
+import { update } from "../result/issues/update.ts";
+import { deleteIssue } from "../result/issues/delete.ts";
+import { fetchList as fetchProjects } from "../result/projects/list.ts";
+import { update as updateJournal } from "../result/journals/update.ts";
+
+Deno.test({
+  name: "E2E: Journals API",
+  fn: async (t) => {
+    const subject = "E2E Journal Issue";
+    let issueId: number | undefined;
+    let journalId: number | undefined;
+
+    try {
+      await t.step(
+        "POST /issues.json should create an issue to attach a journal to",
+        async () => {
+          const projectsResult = await fetchProjects(e2eContext);
+          expect(projectsResult.isOk()).toBe(true);
+          const project = projectsResult._unsafeUnwrap().find((p) =>
+            p.identifier === "e2e-test-project"
+          );
+          expect(project).toBeDefined();
+
+          const issuesBefore = await listIssues(e2eContext, {
+            projectId: project!.id,
+          });
+          expect(issuesBefore.isOk()).toBe(true);
+          const issues = issuesBefore._unsafeUnwrap();
+          expect(issues.length).toBeGreaterThan(0);
+
+          const created = await createIssue(e2eContext, {
+            projectId: project!.id,
+            trackerId: issues[0].tracker.id,
+            statusId: issues[0].status.id,
+            priorityId: issues[0].priority.id,
+            subject,
+          });
+          expect(created.isOk()).toBe(true);
+
+          // createIssue does not return the created id, so it is looked up
+          // by subject, mirroring the pattern in e2e/issues.test.ts.
+          const listAfter = await listIssues(e2eContext, {
+            projectId: project!.id,
+          });
+          expect(listAfter.isOk()).toBe(true);
+          const createdIssue = listAfter._unsafeUnwrap().find((i) =>
+            i.subject === subject
+          );
+          expect(createdIssue).toBeDefined();
+          issueId = createdIssue!.id;
+        },
+      );
+
+      await t.step(
+        "PUT /issues/:id.json with notes should create a journal",
+        async () => {
+          const result = await update(e2eContext, issueId!, {
+            notes: "journal note to edit",
+          });
+          expect(result.isOk()).toBe(true);
+        },
+      );
+
+      await t.step(
+        "GET /issues/:id.json?include=journals should return the created journal",
+        async () => {
+          const showResult = await show(e2eContext, issueId!, ["journals"]);
+          expect(showResult.isOk()).toBe(true);
+          const journal = showResult._unsafeUnwrap().journals?.find((j) =>
+            j.notes === "journal note to edit"
+          );
+          expect(journal).toBeDefined();
+          journalId = journal!.id;
+        },
+      );
+
+      await t.step(
+        "PUT /journals/:id.json should update the journal note",
+        async () => {
+          const result = await updateJournal(e2eContext, journalId!, {
+            notes: "edited journal note",
+          });
+          expect(result.isOk()).toBe(true);
+        },
+      );
+
+      await t.step(
+        "GET /issues/:id.json?include=journals should reflect the edited note",
+        async () => {
+          const showResult = await show(e2eContext, issueId!, ["journals"]);
+          expect(showResult.isOk()).toBe(true);
+          const journal = showResult._unsafeUnwrap().journals?.find((j) =>
+            j.id === journalId
+          );
+          expect(journal).toBeDefined();
+          expect(journal!.notes).toStrictEqual("edited journal note");
+        },
+      );
+    } finally {
+      await t.step(
+        "DELETE /issues/:id.json should clean up the created issue",
+        async () => {
+          if (issueId !== undefined) {
+            const deleted = await deleteIssue(e2eContext, issueId);
+            expect(deleted.isOk(), "cleanup must delete the created issue")
+              .toBe(
+                true,
+              );
+          }
+        },
+      );
+    }
+  },
+});

--- a/result/journals/_mock.ts
+++ b/result/journals/_mock.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+
+export const context = {
+  apiKey: "sample",
+  endpoint: "http://redmine.example.com",
+};
+
+export const validHandlers = [
+  http.put(`${context.endpoint}/journals/:id.json`, () => {
+    return HttpResponse.json({});
+  }),
+];
+
+export const invalidHandlers = [
+  http.put(`${context.endpoint}/journals/422.json`, () => {
+    return HttpResponse.json({
+      errors: ["sample error"],
+    }, {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      status: STATUS_CODE.UnprocessableEntity,
+      statusText: "Unprocessable Entity",
+    });
+  }),
+  http.put(`${context.endpoint}/journals/404.json`, () => {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+  }),
+];

--- a/result/journals/mod.ts
+++ b/result/journals/mod.ts
@@ -1,0 +1,21 @@
+import type { Context } from "../../context.ts";
+import { update } from "./update.ts";
+import type { UpdateJournalQuery } from "../../throwable/journals/type.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Updates the note of the journal of given id.
+   *
+   * @param id Journal identifier
+   * @param journal The journal attributes to update it
+   */
+  update(id: number, journal: UpdateJournalQuery): ReturnType<typeof update> {
+    return update(this.#context, id, journal);
+  }
+}

--- a/result/journals/update.test.ts
+++ b/result/journals/update.test.ts
@@ -1,0 +1,57 @@
+import { update } from "./update.ts";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { expect } from "jsr:@std/expect@1.0.20";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("PUT /journals/:id.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await update(context, 1, { notes: "edited" });
+    expect(e.isOk()).toBe(true);
+  });
+
+  await t.step(
+    "if get invalid response with error object, should be err with error text",
+    async () => {
+      server.resetHandlers(...invalidHandlers);
+      const e = await update(context, 422, { notes: "edited" });
+      expect(e.isErr()).toBe(true);
+    },
+  );
+
+  await t.step("if get invalid response with unexpected format", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await update(context, 404, { notes: "edited" });
+    expect(e.isErr()).toBe(true);
+  });
+
+  await t.step(
+    "should send camelCase attributes as snake_case",
+    async () => {
+      let captured: Record<string, unknown> | undefined;
+      server.resetHandlers(
+        http.put(
+          `${context.endpoint}/journals/:id.json`,
+          async ({ request }) => {
+            const body = await request.json() as {
+              journal: typeof captured;
+            };
+            captured = body.journal;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await update(context, 1, {
+        notes: "edited",
+        privateNotes: true,
+      });
+      expect(e.isOk()).toBe(true);
+      expect(captured?.notes).toStrictEqual("edited");
+      expect(captured?.private_notes).toStrictEqual(true);
+    },
+  );
+});

--- a/result/journals/update.ts
+++ b/result/journals/update.ts
@@ -1,0 +1,8 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { update as updateWithError } from "../../throwable/journals/update.ts";
+import { convertError } from "../../error.ts";
+
+export const update = ResultAsync.fromThrowable(
+  updateWithError,
+  convertError("unknown error update a journal"),
+);

--- a/result/mod.ts
+++ b/result/mod.ts
@@ -18,6 +18,7 @@ import { Client as Membership } from "./memberships/mod.ts";
 import { Client as MyAccount } from "./my-account/mod.ts";
 import { Client as Group } from "./groups/mod.ts";
 import { Client as IssueRelation } from "./issue-relations/mod.ts";
+import { Client as Journal } from "./journals/mod.ts";
 import { Client as Attachment } from "./attachments/mod.ts";
 import { Client as FileClient } from "./files/mod.ts";
 import { Client as Search } from "./search/mod.ts";
@@ -43,6 +44,7 @@ export class Redmine {
   readonly myAccount: MyAccount;
   readonly group: Group;
   readonly issueRelation: IssueRelation;
+  readonly journal: Journal;
   readonly attachment: Attachment;
   readonly file: FileClient;
   readonly search: Search;
@@ -68,6 +70,7 @@ export class Redmine {
     this.myAccount = new MyAccount(this.#context);
     this.group = new Group(this.#context);
     this.issueRelation = new IssueRelation(this.#context);
+    this.journal = new Journal(this.#context);
     this.attachment = new Attachment(this.#context);
     this.file = new FileClient(this.#context);
     this.search = new Search(this.#context);

--- a/throwable/journals/mod.ts
+++ b/throwable/journals/mod.ts
@@ -1,0 +1,21 @@
+import type { Context } from "../../context.ts";
+import { update } from "./update.ts";
+import type { UpdateJournalQuery } from "./type.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Updates the note of the journal of given id.
+   *
+   * @param id Journal identifier
+   * @param journal The journal attributes to update it
+   */
+  update(id: number, journal: UpdateJournalQuery): ReturnType<typeof update> {
+    return update(this.#context, id, journal);
+  }
+}

--- a/throwable/journals/type.ts
+++ b/throwable/journals/type.ts
@@ -1,0 +1,4 @@
+export type UpdateJournalQuery = {
+  notes?: string;
+  privateNotes?: boolean;
+};

--- a/throwable/journals/update.ts
+++ b/throwable/journals/update.ts
@@ -1,0 +1,33 @@
+import { parse } from "jsr:@valibot/valibot@1.4.2";
+import { buildUrl } from "../../internal/url.ts";
+import type { Context } from "../../context.ts";
+import type { UpdateJournalQuery } from "./type.ts";
+import { toUpdateJournalQuery } from "./validator.ts";
+import { assertResponse } from "../../error.ts";
+
+/**
+ * Update the note of the journal of given id
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param id Journal identifier
+ * @param journal Journal attributes to update it
+ */
+export async function update(
+  context: Context,
+  id: number,
+  journal: UpdateJournalQuery,
+): Promise<void> {
+  const url = buildUrl(context.endpoint, "journals", `${id}.json`);
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Redmine-API-Key": context.apiKey,
+    },
+    body: JSON.stringify({
+      journal: parse(toUpdateJournalQuery, journal),
+    }),
+  });
+  await assertResponse(response);
+}

--- a/throwable/journals/validator.ts
+++ b/throwable/journals/validator.ts
@@ -1,0 +1,21 @@
+import {
+  boolean,
+  object,
+  optional,
+  pipe,
+  string,
+  transform,
+} from "jsr:@valibot/valibot@1.4.2";
+import { objectToSnake } from "npm:ts-case-convert@2.3.1";
+
+const updateJournalQuerySchema = object({
+  notes: optional(string()),
+  privateNotes: optional(boolean()),
+});
+
+export const toUpdateJournalQuery = pipe(
+  updateJournalQuerySchema,
+  transform((input) => {
+    return objectToSnake(input);
+  }),
+);

--- a/throwable/mod.ts
+++ b/throwable/mod.ts
@@ -18,6 +18,7 @@ import { Client as Membership } from "./memberships/mod.ts";
 import { Client as MyAccount } from "./my-account/mod.ts";
 import { Client as Group } from "./groups/mod.ts";
 import { Client as IssueRelation } from "./issue-relations/mod.ts";
+import { Client as Journal } from "./journals/mod.ts";
 import { Client as Attachment } from "./attachments/mod.ts";
 import { Client as FileClient } from "./files/mod.ts";
 import { Client as Search } from "./search/mod.ts";
@@ -43,6 +44,7 @@ export class Redmine {
   readonly myAccount: MyAccount;
   readonly group: Group;
   readonly issueRelation: IssueRelation;
+  readonly journal: Journal;
   readonly attachment: Attachment;
   readonly file: FileClient;
   readonly search: Search;
@@ -68,6 +70,7 @@ export class Redmine {
     this.myAccount = new MyAccount(this.#context);
     this.group = new Group(this.#context);
     this.issueRelation = new IssueRelation(this.#context);
+    this.journal = new Journal(this.#context);
     this.attachment = new Attachment(this.#context);
     this.file = new FileClient(this.#context);
     this.search = new Search(this.#context);


### PR DESCRIPTION
## Summary

Add a `journals` resource with an `update` operation (`PUT /journals/:id`), the only journal endpoint Redmine exposes over REST.

## Details

`JournalsController#update` has `accept_api_auth`, so a journal note can be edited via REST, but no journals resource existed. The resource mirrors the existing single-operation resources and is registered on the top-level client. `GET /journals/:id/diff` and `DELETE` are not `accept_api_auth` (web-only) and are out of scope.

## Confirmation

`nix run .#check-deno` (type-check, lint, 101 unit tests) passes.

## Limitation

e2e (create issue, add note, edit the journal, verify) runs in CI against Redmine 5.1/6.0/6.1; not executed locally this time.

Closes #424.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating Redmine journals through the client API.
  * Journal updates can modify notes and private-note status.
  * Added journal access through the main Redmine client.

* **Bug Fixes**
  * Journal update payloads are correctly formatted for the API.

* **Tests**
  * Added coverage for successful updates, validation errors, missing journals, and end-to-end journal editing.

* **Documentation**
  * Updated implementation status to mark journal creation and updating as supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->