### PR TITLE
feat: implement Repository add/remove related issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Redmine rest api wrapper for deno.
     - [x] [`PUT`](https://www.redmine.org/projects/redmine/wiki/Rest_MyAccount#PUT)
 - [x] [Journals](https://www.redmine.org/projects/redmine/wiki/Rest_Journals)
   - [x] [Updating a journal](https://www.redmine.org/projects/redmine/wiki/Rest_Journals#Updating-a-journal)
+- [x] [Repositories](https://www.redmine.org/projects/redmine/wiki/Rest_api)
+  - [x] `Adding a related issue to a revision`
+    (`POST /projects/:id/repository/(:repository_id/)revisions/:rev/issues`)
+  - [x] `Removing a related issue from a revision`
+    (`DELETE /projects/:id/repository/(:repository_id/)revisions/:rev/issues/:issue_id`)
 
 ### external plugin
 

--- a/result/mod.ts
+++ b/result/mod.ts
@@ -19,6 +19,7 @@ import { Client as MyAccount } from "./my-account/mod.ts";
 import { Client as Group } from "./groups/mod.ts";
 import { Client as IssueRelation } from "./issue-relations/mod.ts";
 import { Client as Journal } from "./journals/mod.ts";
+import { Client as Repository } from "./repositories/mod.ts";
 import { Client as Attachment } from "./attachments/mod.ts";
 import { Client as FileClient } from "./files/mod.ts";
 import { Client as Search } from "./search/mod.ts";
@@ -45,6 +46,7 @@ export class Redmine {
   readonly group: Group;
   readonly issueRelation: IssueRelation;
   readonly journal: Journal;
+  readonly repository: Repository;
   readonly attachment: Attachment;
   readonly file: FileClient;
   readonly search: Search;
@@ -71,6 +73,7 @@ export class Redmine {
     this.group = new Group(this.#context);
     this.issueRelation = new IssueRelation(this.#context);
     this.journal = new Journal(this.#context);
+    this.repository = new Repository(this.#context);
     this.attachment = new Attachment(this.#context);
     this.file = new FileClient(this.#context);
     this.search = new Search(this.#context);

--- a/result/repositories/_mock.ts
+++ b/result/repositories/_mock.ts
@@ -1,0 +1,75 @@
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+
+export const context = {
+  apiKey: "sample",
+  endpoint: "http://redmine.example.com",
+};
+
+export const validHandlers = [
+  http.post(
+    `${context.endpoint}/projects/:id/repository/:repositoryId/revisions/:rev/issues.json`,
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
+  http.post(
+    `${context.endpoint}/projects/:id/repository/revisions/:rev/issues.json`,
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
+  http.delete(
+    `${context.endpoint}/projects/:id/repository/:repositoryId/revisions/:rev/issues/:issueId.json`,
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
+  http.delete(
+    `${context.endpoint}/projects/:id/repository/revisions/:rev/issues/:issueId.json`,
+    () => {
+      return HttpResponse.json({});
+    },
+  ),
+];
+
+export const invalidHandlers = [
+  http.post(
+    `${context.endpoint}/projects/422/repository/revisions/:rev/issues.json`,
+    () => {
+      return HttpResponse.json({
+        errors: ["sample error"],
+      }, {
+        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+        status: STATUS_CODE.UnprocessableEntity,
+        statusText: "Unprocessable Entity",
+      });
+    },
+  ),
+  http.post(
+    `${context.endpoint}/projects/404/repository/revisions/:rev/issues.json`,
+    () => {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    },
+  ),
+  http.delete(
+    `${context.endpoint}/projects/422/repository/revisions/:rev/issues/:issueId.json`,
+    () => {
+      return HttpResponse.json({
+        errors: ["sample error"],
+      }, {
+        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+        status: STATUS_CODE.UnprocessableEntity,
+        statusText: "Unprocessable Entity",
+      });
+    },
+  ),
+  http.delete(
+    `${context.endpoint}/projects/404/repository/revisions/:rev/issues/:issueId.json`,
+    () => {
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    },
+  ),
+];

--- a/result/repositories/mod.ts
+++ b/result/repositories/mod.ts
@@ -1,0 +1,59 @@
+import type { Context } from "../../context.ts";
+import { addRelatedIssue, removeRelatedIssue } from "./related-issue.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Relate an issue to the revision of the project repository
+   *
+   * @param projectId Project identifier
+   * @param rev Revision identifier
+   * @param issueId Issue identifier to relate
+   * @param repositoryId Repository identifier; when omitted the project's
+   * default repository is used
+   */
+  addRelatedIssue(
+    projectId: number,
+    rev: string,
+    issueId: number,
+    repositoryId?: string,
+  ): ReturnType<typeof addRelatedIssue> {
+    return addRelatedIssue(
+      this.#context,
+      projectId,
+      rev,
+      issueId,
+      repositoryId,
+    );
+  }
+
+  /**
+   * Remove the relation between an issue and the revision of the project
+   * repository
+   *
+   * @param projectId Project identifier
+   * @param rev Revision identifier
+   * @param issueId Related issue identifier to remove
+   * @param repositoryId Repository identifier; when omitted the project's
+   * default repository is used
+   */
+  removeRelatedIssue(
+    projectId: number,
+    rev: string,
+    issueId: number,
+    repositoryId?: string,
+  ): ReturnType<typeof removeRelatedIssue> {
+    return removeRelatedIssue(
+      this.#context,
+      projectId,
+      rev,
+      issueId,
+      repositoryId,
+    );
+  }
+}

--- a/result/repositories/related-issue.test.ts
+++ b/result/repositories/related-issue.test.ts
@@ -1,0 +1,135 @@
+import { addRelatedIssue, removeRelatedIssue } from "./related-issue.ts";
+import { context, invalidHandlers, validHandlers } from "./_mock.ts";
+import { http, HttpResponse } from "npm:msw@2.15.0";
+import { setupServer } from "npm:msw@2.15.0/node";
+import { expect } from "jsr:@std/expect@1.0.20";
+
+const server = setupServer();
+server.listen();
+
+Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await addRelatedIssue(context, 1, "abc123", 42);
+    expect(e.isOk()).toBe(true);
+  });
+
+  await t.step(
+    "should target the default repository path and send issue_id in the body",
+    async () => {
+      let capturedPathname: string | undefined;
+      let capturedBody: unknown;
+      server.resetHandlers(
+        http.post(
+          `${context.endpoint}/projects/:id/repository/revisions/:rev/issues.json`,
+          async ({ request }) => {
+            capturedPathname = new URL(request.url).pathname;
+            capturedBody = await request.json();
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await addRelatedIssue(context, 1, "abc123", 42);
+      expect(e.isOk()).toBe(true);
+      expect(capturedPathname).toStrictEqual(
+        "/projects/1/repository/revisions/abc123/issues.json",
+      );
+      expect(capturedBody).toStrictEqual({ issue_id: 42 });
+    },
+  );
+
+  await t.step(
+    "should include the repository id in the path when provided",
+    async () => {
+      let capturedPathname: string | undefined;
+      server.resetHandlers(
+        http.post(
+          `${context.endpoint}/projects/:id/repository/:repositoryId/revisions/:rev/issues.json`,
+          ({ request }) => {
+            capturedPathname = new URL(request.url).pathname;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await addRelatedIssue(context, 1, "abc123", 42, "svn-repo");
+      expect(e.isOk()).toBe(true);
+      expect(capturedPathname).toStrictEqual(
+        "/projects/1/repository/svn-repo/revisions/abc123/issues.json",
+      );
+    },
+  );
+
+  await t.step("if got 422, should be err", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await addRelatedIssue(context, 422, "abc123", 42);
+    expect(e.isErr()).toBe(true);
+  });
+
+  await t.step("if got 404, should be err", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await addRelatedIssue(context, 404, "abc123", 42);
+    expect(e.isErr()).toBe(true);
+  });
+});
+
+Deno.test("DELETE .../revisions/:rev/issues/:issue_id.json", async (t) => {
+  await t.step("if got 200, should be success", async () => {
+    server.resetHandlers(...validHandlers);
+    const e = await removeRelatedIssue(context, 1, "abc123", 42);
+    expect(e.isOk()).toBe(true);
+  });
+
+  await t.step(
+    "should target the default repository path with the issue id",
+    async () => {
+      let capturedPathname: string | undefined;
+      server.resetHandlers(
+        http.delete(
+          `${context.endpoint}/projects/:id/repository/revisions/:rev/issues/:issueId.json`,
+          ({ request }) => {
+            capturedPathname = new URL(request.url).pathname;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await removeRelatedIssue(context, 1, "abc123", 42);
+      expect(e.isOk()).toBe(true);
+      expect(capturedPathname).toStrictEqual(
+        "/projects/1/repository/revisions/abc123/issues/42.json",
+      );
+    },
+  );
+
+  await t.step(
+    "should include the repository id in the path when provided",
+    async () => {
+      let capturedPathname: string | undefined;
+      server.resetHandlers(
+        http.delete(
+          `${context.endpoint}/projects/:id/repository/:repositoryId/revisions/:rev/issues/:issueId.json`,
+          ({ request }) => {
+            capturedPathname = new URL(request.url).pathname;
+            return HttpResponse.json({});
+          },
+        ),
+      );
+      const e = await removeRelatedIssue(context, 1, "abc123", 42, "svn-repo");
+      expect(e.isOk()).toBe(true);
+      expect(capturedPathname).toStrictEqual(
+        "/projects/1/repository/svn-repo/revisions/abc123/issues/42.json",
+      );
+    },
+  );
+
+  await t.step("if got 422, should be err", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await removeRelatedIssue(context, 422, "abc123", 42);
+    expect(e.isErr()).toBe(true);
+  });
+
+  await t.step("if got 404, should be err", async () => {
+    server.resetHandlers(...invalidHandlers);
+    const e = await removeRelatedIssue(context, 404, "abc123", 42);
+    expect(e.isErr()).toBe(true);
+  });
+});

--- a/result/repositories/related-issue.ts
+++ b/result/repositories/related-issue.ts
@@ -1,0 +1,16 @@
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { convertError } from "../../error.ts";
+import {
+  addRelatedIssue as addRelatedIssueWithError,
+  removeRelatedIssue as removeRelatedIssueWithError,
+} from "../../throwable/repositories/related-issue.ts";
+
+export const addRelatedIssue = ResultAsync.fromThrowable(
+  addRelatedIssueWithError,
+  convertError("unknown error add a related issue to the revision"),
+);
+
+export const removeRelatedIssue = ResultAsync.fromThrowable(
+  removeRelatedIssueWithError,
+  convertError("unknown error remove a related issue from the revision"),
+);

--- a/throwable/mod.ts
+++ b/throwable/mod.ts
@@ -19,6 +19,7 @@ import { Client as MyAccount } from "./my-account/mod.ts";
 import { Client as Group } from "./groups/mod.ts";
 import { Client as IssueRelation } from "./issue-relations/mod.ts";
 import { Client as Journal } from "./journals/mod.ts";
+import { Client as Repository } from "./repositories/mod.ts";
 import { Client as Attachment } from "./attachments/mod.ts";
 import { Client as FileClient } from "./files/mod.ts";
 import { Client as Search } from "./search/mod.ts";
@@ -45,6 +46,7 @@ export class Redmine {
   readonly group: Group;
   readonly issueRelation: IssueRelation;
   readonly journal: Journal;
+  readonly repository: Repository;
   readonly attachment: Attachment;
   readonly file: FileClient;
   readonly search: Search;
@@ -71,6 +73,7 @@ export class Redmine {
     this.group = new Group(this.#context);
     this.issueRelation = new IssueRelation(this.#context);
     this.journal = new Journal(this.#context);
+    this.repository = new Repository(this.#context);
     this.attachment = new Attachment(this.#context);
     this.file = new FileClient(this.#context);
     this.search = new Search(this.#context);

--- a/throwable/repositories/mod.ts
+++ b/throwable/repositories/mod.ts
@@ -1,0 +1,59 @@
+import type { Context } from "../../context.ts";
+import { addRelatedIssue, removeRelatedIssue } from "./related-issue.ts";
+
+export class Client {
+  readonly #context: Context;
+
+  constructor(context: Context) {
+    this.#context = context;
+  }
+
+  /**
+   * Relate an issue to the revision of the project repository
+   *
+   * @param projectId Project identifier
+   * @param rev Revision identifier
+   * @param issueId Issue identifier to relate
+   * @param repositoryId Repository identifier; when omitted the project's
+   * default repository is used
+   */
+  addRelatedIssue(
+    projectId: number,
+    rev: string,
+    issueId: number,
+    repositoryId?: string,
+  ): ReturnType<typeof addRelatedIssue> {
+    return addRelatedIssue(
+      this.#context,
+      projectId,
+      rev,
+      issueId,
+      repositoryId,
+    );
+  }
+
+  /**
+   * Remove the relation between an issue and the revision of the project
+   * repository
+   *
+   * @param projectId Project identifier
+   * @param rev Revision identifier
+   * @param issueId Related issue identifier to remove
+   * @param repositoryId Repository identifier; when omitted the project's
+   * default repository is used
+   */
+  removeRelatedIssue(
+    projectId: number,
+    rev: string,
+    issueId: number,
+    repositoryId?: string,
+  ): ReturnType<typeof removeRelatedIssue> {
+    return removeRelatedIssue(
+      this.#context,
+      projectId,
+      rev,
+      issueId,
+      repositoryId,
+    );
+  }
+}

--- a/throwable/repositories/related-issue.ts
+++ b/throwable/repositories/related-issue.ts
@@ -1,0 +1,88 @@
+import { buildUrl } from "../../internal/url.ts";
+import type { Context } from "../../context.ts";
+import { assertResponse } from "../../error.ts";
+
+// Redmine falls back to the project's default repository when repository_id
+// is absent, so it is an optional path segment.
+function revisionSegments(
+  projectId: number,
+  rev: string,
+  repositoryId?: string,
+): string[] {
+  const base = ["projects", `${projectId}`, "repository"];
+  const withRepository = repositoryId === undefined
+    ? base
+    : [...base, repositoryId];
+  return [...withRepository, "revisions", rev];
+}
+
+/**
+ * Relate an issue to the revision of the project repository
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param projectId Project identifier
+ * @param rev Revision identifier
+ * @param issueId Issue identifier to relate
+ * @param repositoryId Repository identifier; when omitted the project's
+ * default repository is used
+ */
+export async function addRelatedIssue(
+  context: Context,
+  projectId: number,
+  rev: string,
+  issueId: number,
+  repositoryId?: string,
+): Promise<void> {
+  const url = buildUrl(
+    context.endpoint,
+    ...revisionSegments(projectId, rev, repositoryId),
+    "issues.json",
+  );
+  await assertResponse(
+    await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+      body: JSON.stringify({ issue_id: issueId }),
+    }),
+  );
+}
+
+/**
+ * Remove the relation between an issue and the revision of the project
+ * repository
+ * This may throw `Error`
+ *
+ * @param context REST endpoint context
+ * @param projectId Project identifier
+ * @param rev Revision identifier
+ * @param issueId Related issue identifier to remove
+ * @param repositoryId Repository identifier; when omitted the project's
+ * default repository is used
+ */
+export async function removeRelatedIssue(
+  context: Context,
+  projectId: number,
+  rev: string,
+  issueId: number,
+  repositoryId?: string,
+): Promise<void> {
+  const url = buildUrl(
+    context.endpoint,
+    ...revisionSegments(projectId, rev, repositoryId),
+    "issues",
+    `${issueId}.json`,
+  );
+  await assertResponse(
+    await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Add a `repositories` resource with `addRelatedIssue`/`removeRelatedIssue` that link or unlink an issue to a repository revision, the REST-accessible repository actions.

## Details

`RepositoriesController#add_related_issue` and `#remove_related_issue` have `accept_api_auth`.

`repository_id` is optional in the path, falling back to the project's default repository.

The resource is registered on the top-level client.

## Confirmation

`nix run .#check-deno` (type-check, lint, 103 unit tests) passes.

## Limitation

No e2e test: exercising these endpoints needs an SCM repository with a changeset (revision) fixture, which the e2e harness does not set up.

Unit tests cover both URL forms (with/without repository_id), the request body, and error handling.

Scope is limited to the two `accept_api_auth` actions; other repository endpoints are web-only.

Closes #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository support to the Redmine client.
  * Added operations to add or remove issues related to repository revisions.
  * Supports both default repositories and explicitly specified repositories.
  * Added consistent handling for successful requests and API errors.

* **Documentation**
  * Updated implementation status documentation with repository-related operations and endpoint patterns.

* **Tests**
  * Added coverage for adding and removing related issues, including default and specified repository paths and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->