### PR TITLE
feat!: bundle over-long function arguments into options objects

### DIFF
--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -34,7 +34,10 @@ Deno.test({
     await t.step(
       "GET /projects/:id/wiki/:page.json should return a wiki page",
       async () => {
-        const result = await show(e2eContext, projectId, "E2ETestPage");
+        const result = await show(e2eContext, {
+          projectId,
+          title: "E2ETestPage",
+        });
         expect(result.isOk()).toBe(true);
         expect(result._unsafeUnwrap().title).toStrictEqual("E2ETestPage");
         expect(result._unsafeUnwrap().version).toBeGreaterThanOrEqual(1);
@@ -56,7 +59,10 @@ Deno.test({
     await t.step(
       "GET /projects/:id/wiki/:page.json should return a wiki page with comments",
       async () => {
-        const result = await show(e2eContext, projectId, "E2ECreatedPage");
+        const result = await show(e2eContext, {
+          projectId,
+          title: "E2ECreatedPage",
+        });
         expect(result.isOk()).toBe(true);
         const page = result._unsafeUnwrap();
         expect(page.title).toStrictEqual("E2ECreatedPage");
@@ -77,7 +83,10 @@ Deno.test({
         });
         expect(result.isOk()).toBe(true);
 
-        const showResult = await show(e2eContext, projectId, "E2ECreatedPage");
+        const showResult = await show(e2eContext, {
+          projectId,
+          title: "E2ECreatedPage",
+        });
         expect(showResult.isOk()).toBe(true);
         expect(showResult._unsafeUnwrap().text.includes("Updated by E2E test"))
           .toBe(
@@ -110,13 +119,11 @@ Deno.test({
         });
         expect(result.isOk()).toBe(true);
 
-        const showResult = await show(
-          e2eContext,
+        const showResult = await show(e2eContext, {
           projectId,
-          "E2ECreatedPage",
-          undefined,
-          ["attachments"],
-        );
+          title: "E2ECreatedPage",
+          includes: ["attachments"],
+        });
         expect(showResult.isOk()).toBe(true);
         const attachments = showResult._unsafeUnwrap().attachments;
         expect(attachments).toBeDefined();

--- a/result/repositories/mod.ts
+++ b/result/repositories/mod.ts
@@ -1,4 +1,5 @@
 import type { Context } from "../../context.ts";
+import type { RelatedIssueParams } from "../../throwable/repositories/related-issue.ts";
 import { addRelatedIssue, removeRelatedIssue } from "./related-issue.ts";
 
 export class Client {
@@ -11,49 +12,24 @@ export class Client {
   /**
    * Relate an issue to the revision of the project repository
    *
-   * @param projectId Project identifier
-   * @param rev Revision identifier
-   * @param issueId Issue identifier to relate
-   * @param repositoryId Repository identifier; when omitted the project's
-   * default repository is used
+   * @param params Parameters to relate an issue to the revision
    */
   addRelatedIssue(
-    projectId: number,
-    rev: string,
-    issueId: number,
-    repositoryId?: string,
+    params: RelatedIssueParams,
   ): ReturnType<typeof addRelatedIssue> {
-    return addRelatedIssue(
-      this.#context,
-      projectId,
-      rev,
-      issueId,
-      repositoryId,
-    );
+    return addRelatedIssue(this.#context, params);
   }
 
   /**
    * Remove the relation between an issue and the revision of the project
    * repository
    *
-   * @param projectId Project identifier
-   * @param rev Revision identifier
-   * @param issueId Related issue identifier to remove
-   * @param repositoryId Repository identifier; when omitted the project's
-   * default repository is used
+   * @param params Parameters to remove the relation between an issue and
+   * the revision
    */
   removeRelatedIssue(
-    projectId: number,
-    rev: string,
-    issueId: number,
-    repositoryId?: string,
+    params: RelatedIssueParams,
   ): ReturnType<typeof removeRelatedIssue> {
-    return removeRelatedIssue(
-      this.#context,
-      projectId,
-      rev,
-      issueId,
-      repositoryId,
-    );
+    return removeRelatedIssue(this.#context, params);
   }
 }

--- a/result/repositories/related-issue.test.ts
+++ b/result/repositories/related-issue.test.ts
@@ -10,7 +10,11 @@ server.listen();
 Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
-    const e = await addRelatedIssue(context, 1, "abc123", 42);
+    const e = await addRelatedIssue(context, {
+      projectId: 1,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isOk()).toBe(true);
   });
 
@@ -29,7 +33,11 @@ Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
           },
         ),
       );
-      const e = await addRelatedIssue(context, 1, "abc123", 42);
+      const e = await addRelatedIssue(context, {
+        projectId: 1,
+        rev: "abc123",
+        issueId: 42,
+      });
       expect(e.isOk()).toBe(true);
       expect(capturedPathname).toStrictEqual(
         "/projects/1/repository/revisions/abc123/issues.json",
@@ -51,7 +59,12 @@ Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
           },
         ),
       );
-      const e = await addRelatedIssue(context, 1, "abc123", 42, "svn-repo");
+      const e = await addRelatedIssue(context, {
+        projectId: 1,
+        rev: "abc123",
+        issueId: 42,
+        repositoryId: "svn-repo",
+      });
       expect(e.isOk()).toBe(true);
       expect(capturedPathname).toStrictEqual(
         "/projects/1/repository/svn-repo/revisions/abc123/issues.json",
@@ -61,13 +74,21 @@ Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
 
   await t.step("if got 422, should be err", async () => {
     server.resetHandlers(...invalidHandlers);
-    const e = await addRelatedIssue(context, 422, "abc123", 42);
+    const e = await addRelatedIssue(context, {
+      projectId: 422,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isErr()).toBe(true);
   });
 
   await t.step("if got 404, should be err", async () => {
     server.resetHandlers(...invalidHandlers);
-    const e = await addRelatedIssue(context, 404, "abc123", 42);
+    const e = await addRelatedIssue(context, {
+      projectId: 404,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isErr()).toBe(true);
   });
 });
@@ -75,7 +96,11 @@ Deno.test("POST .../revisions/:rev/issues.json", async (t) => {
 Deno.test("DELETE .../revisions/:rev/issues/:issue_id.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validHandlers);
-    const e = await removeRelatedIssue(context, 1, "abc123", 42);
+    const e = await removeRelatedIssue(context, {
+      projectId: 1,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isOk()).toBe(true);
   });
 
@@ -92,7 +117,11 @@ Deno.test("DELETE .../revisions/:rev/issues/:issue_id.json", async (t) => {
           },
         ),
       );
-      const e = await removeRelatedIssue(context, 1, "abc123", 42);
+      const e = await removeRelatedIssue(context, {
+        projectId: 1,
+        rev: "abc123",
+        issueId: 42,
+      });
       expect(e.isOk()).toBe(true);
       expect(capturedPathname).toStrictEqual(
         "/projects/1/repository/revisions/abc123/issues/42.json",
@@ -113,7 +142,12 @@ Deno.test("DELETE .../revisions/:rev/issues/:issue_id.json", async (t) => {
           },
         ),
       );
-      const e = await removeRelatedIssue(context, 1, "abc123", 42, "svn-repo");
+      const e = await removeRelatedIssue(context, {
+        projectId: 1,
+        rev: "abc123",
+        issueId: 42,
+        repositoryId: "svn-repo",
+      });
       expect(e.isOk()).toBe(true);
       expect(capturedPathname).toStrictEqual(
         "/projects/1/repository/svn-repo/revisions/abc123/issues/42.json",
@@ -123,13 +157,21 @@ Deno.test("DELETE .../revisions/:rev/issues/:issue_id.json", async (t) => {
 
   await t.step("if got 422, should be err", async () => {
     server.resetHandlers(...invalidHandlers);
-    const e = await removeRelatedIssue(context, 422, "abc123", 42);
+    const e = await removeRelatedIssue(context, {
+      projectId: 422,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isErr()).toBe(true);
   });
 
   await t.step("if got 404, should be err", async () => {
     server.resetHandlers(...invalidHandlers);
-    const e = await removeRelatedIssue(context, 404, "abc123", 42);
+    const e = await removeRelatedIssue(context, {
+      projectId: 404,
+      rev: "abc123",
+      issueId: 42,
+    });
     expect(e.isErr()).toBe(true);
   });
 });

--- a/result/wiki-pages/mod.ts
+++ b/result/wiki-pages/mod.ts
@@ -1,6 +1,6 @@
 import type { Context } from "../../context.ts";
 import type { WikiContent } from "../../throwable/wiki-pages/type.ts";
-import type { Include } from "../../throwable/wiki-pages/show.ts";
+import type { ShowWikiPageParams } from "../../throwable/wiki-pages/show.ts";
 import { fetchList } from "./list.ts";
 import { show } from "./show.ts";
 import { update } from "./update.ts";
@@ -26,29 +26,11 @@ export class Client {
   /**
    * Fetch a wiki page in the project
    *
-   * @param projectId The project ID
-   * @param title The title for querying
+   * @param params Parameters to identify the wiki page
    * @returns Wiki page
    */
-  show(projectId: number, title: string): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version: number,
-  ): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version: number | undefined,
-    includes: Include[],
-  ): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version?: number,
-    includes?: Include[],
-  ): ReturnType<typeof show> {
-    return show(this.#context, projectId, title, version, includes);
+  show(params: ShowWikiPageParams): ReturnType<typeof show> {
+    return show(this.#context, params);
   }
 
   /**

--- a/result/wiki-pages/show.test.ts
+++ b/result/wiki-pages/show.test.ts
@@ -14,7 +14,7 @@ server.listen();
 Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
-    const e = await show(context, 1, "sample-title");
+    const e = await show(context, { projectId: 1, title: "sample-title" });
     expect(e.isOk()).toBe(true);
     expect(e._unsafeUnwrap().title).toBe("sample-title");
   });
@@ -37,7 +37,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
         },
       ),
     );
-    const e = await show(context, 1, "sample-title");
+    const e = await show(context, { projectId: 1, title: "sample-title" });
     expect(e.isOk()).toBe(true);
     expect(e._unsafeUnwrap().title).toStrictEqual("sample-title");
     expect(e._unsafeUnwrap().comments).toBeUndefined();
@@ -66,9 +66,11 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
           },
         ),
       );
-      const e = await show(context, 1, "sample-title", undefined, [
-        "attachments",
-      ]);
+      const e = await show(context, {
+        projectId: 1,
+        title: "sample-title",
+        includes: ["attachments"],
+      });
       expect(e.isOk()).toBe(true);
       expect(capturedInclude).toStrictEqual("attachments");
       expect(e._unsafeUnwrap().attachments).toStrictEqual([
@@ -78,7 +80,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
   );
   await t.step("If got 422, should be error", async () => {
     server.resetHandlers(...invalidResponseHandlers);
-    const e = await show(context, 2, "sample-title");
+    const e = await show(context, { projectId: 2, title: "sample-title" });
     expect(e.isErr()).toBe(true);
     expect(e._unsafeUnwrapErr().message).toBe("Unprocessable Entity");
   });
@@ -87,7 +89,11 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
 Deno.test("GET /projects/:id/wiki/:page/:version.json", async (t) => {
   await t.step("if got 200, should be success", async () => {
     server.resetHandlers(...validResponseHandelers);
-    const e = await show(context, 1, "sample-title", 3);
+    const e = await show(context, {
+      projectId: 1,
+      title: "sample-title",
+      version: 3,
+    });
     expect(e.isOk()).toBe(true);
     expect(e._unsafeUnwrap().title).toBe("sample-title");
     expect(e._unsafeUnwrap().version).toBe(3);

--- a/throwable/repositories/mod.ts
+++ b/throwable/repositories/mod.ts
@@ -1,5 +1,9 @@
 import type { Context } from "../../context.ts";
-import { addRelatedIssue, removeRelatedIssue } from "./related-issue.ts";
+import {
+  addRelatedIssue,
+  type RelatedIssueParams,
+  removeRelatedIssue,
+} from "./related-issue.ts";
 
 export class Client {
   readonly #context: Context;
@@ -11,49 +15,24 @@ export class Client {
   /**
    * Relate an issue to the revision of the project repository
    *
-   * @param projectId Project identifier
-   * @param rev Revision identifier
-   * @param issueId Issue identifier to relate
-   * @param repositoryId Repository identifier; when omitted the project's
-   * default repository is used
+   * @param params Parameters to relate an issue to the revision
    */
   addRelatedIssue(
-    projectId: number,
-    rev: string,
-    issueId: number,
-    repositoryId?: string,
+    params: RelatedIssueParams,
   ): ReturnType<typeof addRelatedIssue> {
-    return addRelatedIssue(
-      this.#context,
-      projectId,
-      rev,
-      issueId,
-      repositoryId,
-    );
+    return addRelatedIssue(this.#context, params);
   }
 
   /**
    * Remove the relation between an issue and the revision of the project
    * repository
    *
-   * @param projectId Project identifier
-   * @param rev Revision identifier
-   * @param issueId Related issue identifier to remove
-   * @param repositoryId Repository identifier; when omitted the project's
-   * default repository is used
+   * @param params Parameters to remove the relation between an issue and
+   * the revision
    */
   removeRelatedIssue(
-    projectId: number,
-    rev: string,
-    issueId: number,
-    repositoryId?: string,
+    params: RelatedIssueParams,
   ): ReturnType<typeof removeRelatedIssue> {
-    return removeRelatedIssue(
-      this.#context,
-      projectId,
-      rev,
-      issueId,
-      repositoryId,
-    );
+    return removeRelatedIssue(this.#context, params);
   }
 }

--- a/throwable/repositories/related-issue.ts
+++ b/throwable/repositories/related-issue.ts
@@ -16,24 +16,29 @@ function revisionSegments(
   return [...withRepository, "revisions", rev];
 }
 
+export type RelatedIssueParams = {
+  /** Project identifier */
+  projectId: number;
+  /** Revision identifier */
+  rev: string;
+  /** Issue identifier to relate/remove */
+  issueId: number;
+  /** Repository identifier; when omitted the project's default repository is used */
+  repositoryId?: string;
+};
+
 /**
  * Relate an issue to the revision of the project repository
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @param projectId Project identifier
- * @param rev Revision identifier
- * @param issueId Issue identifier to relate
- * @param repositoryId Repository identifier; when omitted the project's
- * default repository is used
+ * @param params Parameters to relate an issue to the revision
  */
 export async function addRelatedIssue(
   context: Context,
-  projectId: number,
-  rev: string,
-  issueId: number,
-  repositoryId?: string,
+  params: RelatedIssueParams,
 ): Promise<void> {
+  const { projectId, rev, issueId, repositoryId } = params;
   const url = buildUrl(
     context.endpoint,
     ...revisionSegments(projectId, rev, repositoryId),
@@ -57,19 +62,14 @@ export async function addRelatedIssue(
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @param projectId Project identifier
- * @param rev Revision identifier
- * @param issueId Related issue identifier to remove
- * @param repositoryId Repository identifier; when omitted the project's
- * default repository is used
+ * @param params Parameters to remove the relation between an issue and the
+ * revision
  */
 export async function removeRelatedIssue(
   context: Context,
-  projectId: number,
-  rev: string,
-  issueId: number,
-  repositoryId?: string,
+  params: RelatedIssueParams,
 ): Promise<void> {
+  const { projectId, rev, issueId, repositoryId } = params;
   const url = buildUrl(
     context.endpoint,
     ...revisionSegments(projectId, rev, repositoryId),

--- a/throwable/wiki-pages/mod.ts
+++ b/throwable/wiki-pages/mod.ts
@@ -1,7 +1,7 @@
 import type { Context } from "../../context.ts";
 import type { WikiContent } from "./type.ts";
 import { fetchList } from "./list.ts";
-import { type Include, show } from "./show.ts";
+import { show, type ShowWikiPageParams } from "./show.ts";
 import { update } from "./update.ts";
 import { create } from "./create.ts";
 import { deleteWiki } from "./delete.ts";
@@ -25,29 +25,11 @@ export class Client {
   /**
    * Fetch a wiki page in the project
    *
-   * @param projectId The project ID
-   * @param title The title for querying
+   * @param params Parameters to identify the wiki page
    * @returns Wiki page
    */
-  show(projectId: number, title: string): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version: number,
-  ): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version: number | undefined,
-    includes: Include[],
-  ): ReturnType<typeof show>;
-  show(
-    projectId: number,
-    title: string,
-    version?: number,
-    includes?: Include[],
-  ): ReturnType<typeof show> {
-    return show(this.#context, projectId, title, version, includes);
+  show(params: ShowWikiPageParams): ReturnType<typeof show> {
+    return show(this.#context, params);
   }
 
   /**

--- a/throwable/wiki-pages/show.ts
+++ b/throwable/wiki-pages/show.ts
@@ -8,22 +8,30 @@ import { wikiDetail } from "./validator.ts";
 export type Include = "attachments";
 
 /**
+ * Parameters to identify the wiki page to show
+ */
+export type ShowWikiPageParams = {
+  /** Project identifier */
+  projectId: number;
+  /** Title for wiki page */
+  title: string;
+  /** Version of the wiki page */
+  version?: number;
+  /** Associations to include in the response */
+  includes?: Include[];
+};
+
+/**
  * Show the wiki page in the project
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @param projectId Project identifier
- * @param title Title for wiki page
- * @param version Version of the wiki page
- * @param includes Associations to include in the response
+ * @param params Parameters to identify the wiki page
  * @returns Wiki page object
  */
 export async function show(
   context: Context,
-  projectId: number,
-  title: string,
-  version?: number,
-  includes?: Include[],
+  { projectId, title, version, includes }: ShowWikiPageParams,
 ): Promise<WikiDetail> {
   const opts = {
     method: "GET",


### PR DESCRIPTION
## Summary

Bundle the non-context arguments of `wiki-pages` `show` and `repositories` `addRelatedIssue` / `removeRelatedIssue` into single options objects.

## Details

Per the Deno style guide, exported functions should take at most two arguments and put the rest into an options object; treating the conventional leading `context` argument as exempt, these three functions each exceeded the limit at context plus four arguments.

Bundling into `ShowWikiPageParams` and a shared `RelatedIssueParams` keeps every signature within context plus one argument, and it lets the `Client.show` positional overloads collapse into optional object properties. Non-exported helpers and the `RedmineResponseError` constructor are left untouched, matching the guide's focus on exported functions.

## Confirmation

Ran `nix run .#check-deno` and confirmed check, lint, and all 103 tests (299 steps) pass. This is a signature-only change with no runtime behavior change.

## Limitation

No lint rule enforces this constraint going forward; a context-aware custom Deno lint plugin was validated but deferred to separate-repository management per the author's preference.

BREAKING CHANGE: the affected public APIs now take an options object instead of positional arguments. `wiki.show` / the `./result/wiki-pages/show` export change from `show(context, projectId, title, version?, includes?)` to `show(context, { projectId, title, version?, includes? })` (the `Client.show` method takes the object alone), and `repository.addRelatedIssue` / `removeRelatedIssue` change from `(context, projectId, rev, issueId, repositoryId?)` to `(context, { projectId, rev, issueId, repositoryId? })`. Update call sites to pass an options object.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
  - Updated wiki page retrieval to use a single options object, supporting project, title, version, and attachment options.
  - Updated related-issue add/remove operations to use a single options object, with optional repository selection.
  - Existing response formats, error handling, versioned pages, attachments, and repository behavior remain unchanged.

- **Tests**
  - Updated coverage to validate the revised request formats and existing success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->