### PR TITLE
test: extract shared msw error-response helpers

### DIFF
--- a/_msw.ts
+++ b/_msw.ts
@@ -1,0 +1,26 @@
+import { HttpResponse } from "npm:msw@2.15.0";
+import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+
+/**
+ * A 422 Unprocessable Entity response carrying a Redmine-style error body.
+ *
+ * Shared by the module mocks so the msw `HttpResponseInit` type conflict is
+ * suppressed in exactly one place instead of at every error handler.
+ */
+export function unprocessableEntity() {
+  return HttpResponse.json({ errors: ["sample error"] }, {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    status: STATUS_CODE.UnprocessableEntity,
+    statusText: "Unprocessable Entity",
+  });
+}
+
+/**
+ * A 404 Not Found response with an empty body.
+ */
+export function notFound() {
+  return HttpResponse.json({}, {
+    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+    status: STATUS_CODE.NotFound,
+  });
+}

--- a/_msw.ts
+++ b/_msw.ts
@@ -19,8 +19,6 @@ export function unprocessableEntity() {
  * A 404 Not Found response with an empty body.
  */
 export function notFound() {
-  return HttpResponse.json({}, {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    status: STATUS_CODE.NotFound,
-  });
+  // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+  return new HttpResponse(null, { status: STATUS_CODE.NotFound });
 }

--- a/attachments/_mock.ts
+++ b/attachments/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -34,42 +35,21 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/attachments/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/attachments/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.patch(`${context.endpoint}/attachments/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.patch(`${context.endpoint}/attachments/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/attachments/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/attachments/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/custom-fields/_mock.ts
+++ b/custom-fields/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -61,12 +61,6 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/custom_fields.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
 ];

--- a/enumerations/_mock.ts
+++ b/enumerations/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -52,57 +52,36 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/enumerations/issue_priorities.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(
     `${context.endpoint}/enumerations/time_entry_activities.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.get(
     `${context.endpoint}/enumerations/document_categories.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
 ];
 
 export const notFoundHandlers = [
   http.get(`${context.endpoint}/enumerations/issue_priorities.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(
     `${context.endpoint}/enumerations/time_entry_activities.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
   http.get(
     `${context.endpoint}/enumerations/document_categories.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
 ];

--- a/files/_mock.ts
+++ b/files/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -55,29 +56,15 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/projects/422/files.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/404/files.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/projects/422/files.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/projects/404/files.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/groups/_mock.ts
+++ b/groups/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -60,92 +61,45 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/groups.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/groups.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/groups/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/groups/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/groups/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/groups/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/groups/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/groups/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/groups/422/users.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/groups/404/users.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(
     `${context.endpoint}/groups/422/users/:user_id.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.delete(
     `${context.endpoint}/groups/404/users/:user_id.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
 ];

--- a/issue-categories/_mock.ts
+++ b/issue-categories/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -57,78 +58,43 @@ export const invalidHandlers = [
   http.get(
     `${context.endpoint}/projects/422/issue_categories.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.get(
     `${context.endpoint}/projects/404/issue_categories.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
   http.get(`${context.endpoint}/issue_categories/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/issue_categories/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(
     `${context.endpoint}/projects/422/issue_categories.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.post(
     `${context.endpoint}/projects/404/issue_categories.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
   http.put(`${context.endpoint}/issue_categories/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/issue_categories/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/issue_categories/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/issue_categories/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/issue-relations/_mock.ts
+++ b/issue-relations/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -48,55 +49,27 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/issues/422/relations.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/issues/404/relations.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/relations/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/relations/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/issues/422/relations.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/issues/404/relations.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/relations/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/relations/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/issue-statuses/_mock.ts
+++ b/issue-statuses/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -20,12 +20,6 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/issue_statuses.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
 ];

--- a/issues/_mock.ts
+++ b/issues/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -136,81 +136,33 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/issues.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/issues/:id.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/issues/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/issues/404.json`, () => {
-    return HttpResponse.json({}, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.NotFound,
-    });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/issues/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/issues/404.json`, () => {
-    return HttpResponse.json({}, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.NotFound,
-    });
+    return notFound();
   }),
   http.post(`${context.endpoint}/issues/422/watchers.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/issues/404/watchers.json`, () => {
-    return HttpResponse.json({}, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.NotFound,
-    });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/issues/422/watchers/:userId.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/issues/404/watchers/:userId.json`, () => {
-    return HttpResponse.json({}, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.NotFound,
-    });
+    return notFound();
   }),
 ];

--- a/journals/_mock.ts
+++ b/journals/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -14,16 +14,9 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.put(`${context.endpoint}/journals/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/journals/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/memberships/_mock.ts
+++ b/memberships/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -60,68 +61,33 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/projects/422/memberships.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/404/memberships.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/memberships/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/memberships/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/projects/422/memberships.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/projects/404/memberships.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/memberships/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/memberships/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/memberships/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/memberships/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/my-account/_mock.ts
+++ b/my-account/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -33,32 +34,18 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/my/account.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/my/account.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
 ];
 
 export const notFoundHandlers = [
   http.get(`${context.endpoint}/my/account.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/my/account.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/news/_mock.ts
+++ b/news/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -85,51 +86,24 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/news.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/422/news.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/404/news.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/news/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/projects/422/news.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/news/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/news/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/projects/_mock.ts
+++ b/projects/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -112,121 +112,58 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.put(`${context.endpoint}/projects/422/archive.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/projects/404/archive.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/projects/422/unarchive.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/projects/404/unarchive.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/projects/422/close.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/projects/404/close.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/projects/422/reopen.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/projects/404/reopen.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/422/projects.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/404/projects.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/projects/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/projects/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/422/projects.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/404/projects.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/projects/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 
   http.put(`${context.endpoint}/projects/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/queries/_mock.ts
+++ b/queries/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -20,12 +20,6 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/queries.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
 ];

--- a/repositories/_mock.ts
+++ b/repositories/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -37,39 +37,25 @@ export const invalidHandlers = [
   http.post(
     `${context.endpoint}/projects/422/repository/revisions/:rev/issues.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.post(
     `${context.endpoint}/projects/404/repository/revisions/:rev/issues.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
   http.delete(
     `${context.endpoint}/projects/422/repository/revisions/:rev/issues/:issueId.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.delete(
     `${context.endpoint}/projects/404/repository/revisions/:rev/issues/:issueId.json`,
     () => {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     },
   ),
 ];

--- a/roles/_mock.ts
+++ b/roles/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -32,25 +32,12 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/roles.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/roles/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/roles/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/search/_mock.ts
+++ b/search/_mock.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
-import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -47,15 +47,8 @@ export const invalidHandlers = [
   http.get(`${context.endpoint}/search.json`, ({ request }) => {
     const q = new URL(request.url).searchParams.get("q");
     if (q === "404") {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+      return notFound();
     }
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
 ];

--- a/time-entries/_mock.ts
+++ b/time-entries/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -72,68 +73,33 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/422/time_entries.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/404/time_entries.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/time_entries/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/time_entries/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/422/time_entries.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/404/time_entries.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/time_entries/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/time_entries/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/time_entries/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/time_entries/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/users/_mock.ts
+++ b/users/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -69,68 +70,33 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/422/users.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/404/users.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/users/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/users/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/422/users.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/404/users.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/users/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/users/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/users/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/users/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/versions/_mock.ts
+++ b/versions/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -70,68 +71,33 @@ export const validHandlers = [
 
 export const invalidHandlers = [
   http.get(`${context.endpoint}/projects/422/versions.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/projects/404/versions.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.get(`${context.endpoint}/versions/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.get(`${context.endpoint}/versions/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.post(`${context.endpoint}/projects/422/versions.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.post(`${context.endpoint}/projects/404/versions.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.put(`${context.endpoint}/versions/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.put(`${context.endpoint}/versions/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
   http.delete(`${context.endpoint}/versions/422.json`, () => {
-    return HttpResponse.json({
-      errors: ["sample error"],
-    }, {
-      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-      status: STATUS_CODE.UnprocessableEntity,
-      statusText: "Unprocessable Entity",
-    });
+    return unprocessableEntity();
   }),
   http.delete(`${context.endpoint}/versions/404.json`, () => {
-    // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-    return new HttpResponse(null, { status: STATUS_CODE.NotFound });
+    return notFound();
   }),
 ];

--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
+import { notFound, unprocessableEntity } from "../_msw.ts";
 
 export const context = {
   apiKey: "sample",
@@ -127,37 +128,19 @@ export const invalidResponseHandlers = [
   http.get(
     `${context.endpoint}/projects/:id/wiki/index.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.get(
     `${context.endpoint}/projects/:id/wiki/:page.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.UnprocessableEntity,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.put(
     `${context.endpoint}/projects/:id/wiki/:page.json`,
     () => {
-      return HttpResponse.json({
-        errors: ["sample error"],
-      }, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: 422,
-        statusText: "Unprocessable Entity",
-      });
+      return unprocessableEntity();
     },
   ),
   http.put(
@@ -180,10 +163,7 @@ export const invalidResponseHandlers = [
   http.delete(
     `${context.endpoint}/projects/:id/wiki/notfound.json`,
     () => {
-      return HttpResponse.json({}, {
-        // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
-        status: STATUS_CODE.NotFound,
-      });
+      return notFound();
     },
   ),
 ];


### PR DESCRIPTION
## Summary

Deduplicate the copy-pasted 422/404 msw error responses across every module mock into a shared `_msw.ts`.

## Details

Each `_mock.ts` hand-rolled the same 422 body and 404 response; the 422 block alone repeated an identical `@ts-expect-error` for msw's `HttpResponseInit` type conflict ~140 times. `_msw.ts` exposes `unprocessableEntity()` and `notFound()`, so the error shape and the single type suppression live in one place. Success handlers and the rare Forbidden/Conflict cases stay inline.

## Confirmation

`nix run .#check-deno` passes (check, lint, 103 unit tests / 299 steps). Pure test-support change; no product code touched.

## Limitation

First of a 4-PR stack of test/mock cleanups; the later PRs branch off this one.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized simulated API error responses across mocked endpoints.
  * Invalid requests now consistently return **422 (Unprocessable Entity)** and **404 (Not Found)** responses.
  * Error response formatting is unified across multiple resources (including attachments, projects, issues, users, and more), improving consistency in mock-driven scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->