### PR TITLE
test: fix mock identifier typo and misleading issue test names

### DIFF
--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -8,7 +8,7 @@ import { setupServer } from "npm:msw@2.15.0/node";
 const server = setupServer();
 server.listen();
 
-Deno.test("GET /projects/issues.json", async (t) => {
+Deno.test("GET /issues.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
     const issues = await listIssues(context);

--- a/issues/show.test.ts
+++ b/issues/show.test.ts
@@ -7,7 +7,7 @@ import { setupServer } from "npm:msw@2.15.0/node";
 const server = setupServer();
 server.listen();
 
-Deno.test("GET /projects/issues/:id.json", async (t) => {
+Deno.test("GET /issues/:id.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
     const issue = await show(context, 1);

--- a/issues/update.test.ts
+++ b/issues/update.test.ts
@@ -7,7 +7,7 @@ import { http, HttpResponse } from "npm:msw@2.15.0";
 const server = setupServer();
 server.listen();
 
-Deno.test("PUT /projects/issues/:id.json", async (t) => {
+Deno.test("PUT /issues/:id.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
     await expect(update(context, 1, { notes: "sample" })).resolves

--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -7,7 +7,7 @@ export const context = {
   endpoint: "http://redmine.example.com",
 };
 
-export const validResponseHandelers = [
+export const validResponseHandlers = [
   http.get(
     `${context.endpoint}/projects/:id/wiki/index.json`,
     () => {

--- a/wiki-pages/create.test.ts
+++ b/wiki-pages/create.test.ts
@@ -3,7 +3,7 @@ import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
-  validResponseHandelers,
+  validResponseHandlers,
 } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ server.listen();
 
 Deno.test("POST /project/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
-    server.resetHandlers(...validResponseHandelers);
+    server.resetHandlers(...validResponseHandlers);
     await expect(create(context, 1, {
       title: "create",
       text: "sample text",

--- a/wiki-pages/delete.test.ts
+++ b/wiki-pages/delete.test.ts
@@ -3,7 +3,7 @@ import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
-  validResponseHandelers,
+  validResponseHandlers,
 } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -12,7 +12,7 @@ server.listen();
 
 Deno.test("DELETE /projects/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
-    server.resetHandlers(...validResponseHandelers);
+    server.resetHandlers(...validResponseHandlers);
     await expect(deleteWiki(context, 1, "sample-title")).resolves
       .toBeUndefined();
   });

--- a/wiki-pages/list.test.ts
+++ b/wiki-pages/list.test.ts
@@ -4,7 +4,7 @@ import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
-  validResponseHandelers,
+  validResponseHandlers,
 } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 
@@ -13,7 +13,7 @@ server.listen();
 
 Deno.test("GET /projects/:id/wiki/index.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
-    server.resetHandlers(...validResponseHandelers);
+    server.resetHandlers(...validResponseHandlers);
     const wikis = await fetchList(context, 1);
     expect(wikis.length).toBe(2);
   });

--- a/wiki-pages/show.test.ts
+++ b/wiki-pages/show.test.ts
@@ -3,7 +3,7 @@ import { expect } from "jsr:@std/expect@1.0.20";
 import {
   context,
   invalidResponseHandlers,
-  validResponseHandelers,
+  validResponseHandlers,
 } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -13,7 +13,7 @@ server.listen();
 
 Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
-    server.resetHandlers(...validResponseHandelers);
+    server.resetHandlers(...validResponseHandlers);
     const wiki = await show(context, { projectId: 1, title: "sample-title" });
     expect(wiki.title).toBe("sample-title");
   });
@@ -85,7 +85,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
 
 Deno.test("GET /projects/:id/wiki/:page/:version.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
-    server.resetHandlers(...validResponseHandelers);
+    server.resetHandlers(...validResponseHandlers);
     const wiki = await show(context, {
       projectId: 1,
       title: "sample-title",


### PR DESCRIPTION
## Summary

Fix two copy-paste artifacts inherited from the old result/ suites: a misspelled mock export and three mislabeled issue test suites.

## Details

The wiki mock exported `validResponseHandelers` (misspelled), forcing every importer to reproduce the typo — renamed to `validResponseHandlers`. Three issue test suites were named after `/projects/issues...`, a route that does not exist; the tested endpoints are `/issues...`.

## Confirmation

`nix run .#check-deno` passes (103 tests / 299 steps).

## Limitation

Stacked on #439 (its base branch); review/merge after it.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85