### PR TITLE
test: make wiki mocks match the real API and share the payload shape

### DIFF
--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -7,7 +7,7 @@ export const context = {
   endpoint: "http://redmine.example.com",
 };
 
-export interface WikiPagePayload {
+export type WikiPagePayload = {
   title: string;
   version: number;
   text: string;
@@ -16,7 +16,7 @@ export interface WikiPagePayload {
   created_on: string;
   updated_on: string;
   attachments?: { id: number; filename: string }[];
-}
+};
 
 /**
  * Build a `wiki_page` response payload, letting each caller override only the

--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -7,13 +7,24 @@ export const context = {
   endpoint: "http://redmine.example.com",
 };
 
+export interface WikiPagePayload {
+  title: string;
+  version: number;
+  text: string;
+  author: { id: number; name: string; login?: string };
+  comments: string | null;
+  created_on: string;
+  updated_on: string;
+  attachments?: { id: number; filename: string }[];
+}
+
 /**
  * Build a `wiki_page` response payload, letting each caller override only the
  * fields it cares about. Keeps the response shape defined in one place.
  */
 export function wikiPage(
-  overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
+  overrides: Partial<WikiPagePayload> = {},
+): WikiPagePayload {
   return {
     title: "sample-title",
     version: 3,
@@ -53,7 +64,7 @@ export const validResponseHandlers = [
     const { id, page } = params;
     return HttpResponse.json({
       wiki_page: wikiPage({
-        title: page,
+        title: String(page),
         text: `# sample page on project ${id}`,
       }),
     });
@@ -64,7 +75,7 @@ export const validResponseHandlers = [
       const { id, page, version } = params;
       return HttpResponse.json({
         wiki_page: wikiPage({
-          title: page,
+          title: String(page),
           version: Number(version),
           text: `# sample page on project ${id}`,
         }),

--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -7,6 +7,25 @@ export const context = {
   endpoint: "http://redmine.example.com",
 };
 
+/**
+ * Build a `wiki_page` response payload, letting each caller override only the
+ * fields it cares about. Keeps the response shape defined in one place.
+ */
+export function wikiPage(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    title: "sample-title",
+    version: 3,
+    text: "# sample page",
+    author: { id: 1, name: "Admin User", login: "admin" },
+    comments: "Updated via API",
+    created_on: "2023-01-01T00:00:00Z",
+    updated_on: "2023-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
 export const validResponseHandlers = [
   http.get(
     `${context.endpoint}/projects/:id/wiki/index.json`,
@@ -33,19 +52,10 @@ export const validResponseHandlers = [
   http.get(`${context.endpoint}/projects/:id/wiki/:page.json`, ({ params }) => {
     const { id, page } = params;
     return HttpResponse.json({
-      wiki_page: {
+      wiki_page: wikiPage({
         title: page,
-        version: 3,
         text: `# sample page on project ${id}`,
-        author: {
-          id: 1,
-          name: "Admin User",
-          login: "admin",
-        },
-        comments: "Updated via API",
-        created_on: "2023-01-01T00:00:00Z",
-        updated_on: "2023-01-02T00:00:00Z",
-      },
+      }),
     });
   }),
   http.get(
@@ -53,19 +63,11 @@ export const validResponseHandlers = [
     ({ params }) => {
       const { id, page, version } = params;
       return HttpResponse.json({
-        wiki_page: {
+        wiki_page: wikiPage({
           title: page,
           version: Number(version),
           text: `# sample page on project ${id}`,
-          author: {
-            id: 1,
-            name: "Admin User",
-            login: "admin",
-          },
-          comments: "Updated via API",
-          created_on: "2023-01-01T00:00:00Z",
-          updated_on: "2023-01-02T00:00:00Z",
-        },
+        }),
       });
     },
   ),
@@ -117,9 +119,8 @@ export const validResponseHandlers = [
   http.delete(
     `${context.endpoint}/projects/:id/wiki/:page.json`,
     () => {
-      return HttpResponse.json({
-        status: STATUS_CODE.NoContent,
-      });
+      // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
+      return new HttpResponse(null, { status: STATUS_CODE.NoContent });
     },
   ),
 ];

--- a/wiki-pages/show.test.ts
+++ b/wiki-pages/show.test.ts
@@ -25,7 +25,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
         ({ params }) => {
           return HttpResponse.json({
             wiki_page: wikiPage({
-              title: params.page,
+              title: String(params.page),
               version: 1,
               text: "# page content",
               author: { id: 1, name: "Admin" },
@@ -50,7 +50,7 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
             capturedInclude = new URL(request.url).searchParams.get("include");
             return HttpResponse.json({
               wiki_page: wikiPage({
-                title: params.page,
+                title: String(params.page),
                 version: 1,
                 text: "# page content",
                 author: { id: 1, name: "Admin" },

--- a/wiki-pages/show.test.ts
+++ b/wiki-pages/show.test.ts
@@ -4,6 +4,7 @@ import {
   context,
   invalidResponseHandlers,
   validResponseHandlers,
+  wikiPage,
 } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -23,15 +24,13 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
         `${context.endpoint}/projects/:id/wiki/:page.json`,
         ({ params }) => {
           return HttpResponse.json({
-            wiki_page: {
+            wiki_page: wikiPage({
               title: params.page,
               version: 1,
               text: "# page content",
               author: { id: 1, name: "Admin" },
               comments: null,
-              created_on: "2023-01-01T00:00:00Z",
-              updated_on: "2023-01-01T00:00:00Z",
-            },
+            }),
           });
         },
       ),
@@ -50,16 +49,14 @@ Deno.test("GET /projects/:id/wiki/:page.json", async (t) => {
           ({ request, params }) => {
             capturedInclude = new URL(request.url).searchParams.get("include");
             return HttpResponse.json({
-              wiki_page: {
+              wiki_page: wikiPage({
                 title: params.page,
                 version: 1,
                 text: "# page content",
                 author: { id: 1, name: "Admin" },
                 comments: null,
-                created_on: "2023-01-01T00:00:00Z",
-                updated_on: "2023-01-01T00:00:00Z",
                 attachments: [{ id: 7, filename: "note.txt" }],
-              },
+              }),
             });
           },
         ),


### PR DESCRIPTION
## Summary

Return a real 204 from the wiki delete mock and extract a shared `wiki_page` payload factory.

## Details

The wiki delete success mock returned HTTP 200 with a `{ status: 204 }` body; it now returns a real 204 No Content, matching Redmine and the other modules' delete mocks. The `wiki_page` payload, previously hand-rolled in two mock handlers and two show test steps, is now a `wikiPage(overrides)` factory so the shape lives in one place.

## Confirmation

`nix run .#check-deno` passes (103 tests / 299 steps).

## Limitation

Stacked on #439 → the naming PR; review/merge after those.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85