### PR TITLE
test: tidy the shared mock helpers

### DIFF
--- a/_msw.ts
+++ b/_msw.ts
@@ -1,12 +1,6 @@
 import { HttpResponse } from "npm:msw@2.15.0";
 import { STATUS_CODE } from "jsr:@std/http@1.1.2/status";
 
-/**
- * A 422 Unprocessable Entity response carrying a Redmine-style error body.
- *
- * Shared by the module mocks so the msw `HttpResponseInit` type conflict is
- * suppressed in exactly one place instead of at every error handler.
- */
 export function unprocessableEntity() {
   return HttpResponse.json({ errors: ["sample error"] }, {
     // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
@@ -15,9 +9,6 @@ export function unprocessableEntity() {
   });
 }
 
-/**
- * A 404 Not Found response with an empty body.
- */
 export function notFound() {
   // @ts-expect-error: msw HttpResponseInit conflicts with Deno built-in type
   return new HttpResponse(null, { status: STATUS_CODE.NotFound });

--- a/projects/list.test.ts
+++ b/projects/list.test.ts
@@ -17,8 +17,6 @@ Deno.test("GET /projects.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      // Hit the endpoint whose /422/projects.json handler returns an error,
-      // without mutating the shared context object.
       const c = { ...context, endpoint: `${context.endpoint}/422` };
       await expect(fetchList(c)).rejects.toThrow();
     },

--- a/projects/list.test.ts
+++ b/projects/list.test.ts
@@ -17,9 +17,10 @@ Deno.test("GET /projects.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      // Simulate an endpoint that returns an error
-      context.endpoint += "/422";
-      await expect(fetchList(context)).rejects.toThrow();
+      // Hit the endpoint whose /422/projects.json handler returns an error,
+      // without mutating the shared context object.
+      const c = { ...context, endpoint: `${context.endpoint}/422` };
+      await expect(fetchList(c)).rejects.toThrow();
     },
   );
 });

--- a/wiki-pages/_mock.ts
+++ b/wiki-pages/_mock.ts
@@ -18,10 +18,6 @@ export type WikiPagePayload = {
   attachments?: { id: number; filename: string }[];
 };
 
-/**
- * Build a `wiki_page` response payload, letting each caller override only the
- * fields it cares about. Keeps the response shape defined in one place.
- */
 export function wikiPage(
   overrides: Partial<WikiPagePayload> = {},
 ): WikiPagePayload {


### PR DESCRIPTION
## Summary

Two small test-support cleanups: stop the projects list test from mutating the shared `context`, and drop the redundant doc comments added to the mock helpers.

## Details

`projects/list.test.ts` did `context.endpoint += "/422"` on the module-level `context`, corrupting it for any later reuse; it now passes a per-test copy, matching `projects/create`.

The docstrings on `unprocessableEntity` / `notFound` / `wikiPage` and the inline note in the list test only restated what the code (and the `@ts-expect-error` directives) already say; since these are test-only helpers, the comments are removed.

## Confirmation

`nix run .#check-deno` passes (103 tests / 299 steps).

## Limitation

Final PR of the test-mock cleanup stack (follows #439, #440, #441).

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation when validating error responses.
  * Confirmed list retrieval correctly rejects invalid responses.

* **Documentation**
  * Removed outdated internal comments from response and mock helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->