### PR TITLE
refactor: introduce walkPages and rebase list paging on it

### DIFF
--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "jsr:@std/expect@1.0.20";
-import { fetchAllPages, type Page } from "./paging.ts";
+import { fetchAllPages, type Page, walkPages } from "./paging.ts";
 
 const nextTick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -130,6 +130,113 @@ Deno.test("stops at the requested limit and slices off the over-fetch", async ()
     { limit: 100, offset: 100 },
     { limit: 50, offset: 200 },
   ]);
+});
+
+Deno.test("walkPages yields every item in ascending offset order", async () => {
+  const result = await Array.fromAsync(walkPages(finiteSource(23), {
+    pageSize: 10,
+  }));
+  expect(result).toStrictEqual(range(0, 23));
+});
+
+Deno.test("walkPages fetches nothing beyond the first page when the consumer breaks inside it", async () => {
+  const calls: number[] = [];
+  const source = finiteSource(100);
+  const counted: typeof source = (limit, offset) => {
+    calls.push(offset);
+    return source(limit, offset);
+  };
+  const collected: number[] = [];
+  for await (const item of walkPages(counted, { pageSize: 10 })) {
+    collected.push(item);
+    if (collected.length >= 10) {
+      break;
+    }
+  }
+  expect(collected).toStrictEqual(range(0, 10));
+  expect(calls).toStrictEqual([0]);
+});
+
+Deno.test("walkPages wastes at most the read-ahead window when the consumer breaks later", async () => {
+  const calls: number[] = [];
+  const source = finiteSource(100);
+  const counted: typeof source = (limit, offset) => {
+    calls.push(offset);
+    return source(limit, offset);
+  };
+  const collected: number[] = [];
+  for await (
+    const item of walkPages(counted, { pageSize: 10, concurrency: 3 })
+  ) {
+    collected.push(item);
+    if (collected.length >= 11) {
+      break;
+    }
+  }
+  expect(collected).toStrictEqual(range(0, 11));
+  // First page, the initial window of three, and the one refill that replaces
+  // the consumed page; the remaining five pages are never requested.
+  expect(calls).toStrictEqual([0, 10, 20, 30, 40]);
+});
+
+Deno.test("walkPages surfaces a page failure only after every earlier item is yielded", async () => {
+  const collected: number[] = [];
+  await expect((async () => {
+    const pages = walkPages<number>(
+      async (limit, offset) => {
+        if (offset === 20) {
+          throw new Error("page 20 failed");
+        }
+        // The failing page settles first; ordered surfacing must still deliver
+        // the whole preceding page.
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        return {
+          items: range(offset, Math.min(offset + limit, 30)),
+          totalCount: 30,
+        };
+      },
+      { pageSize: 10 },
+    );
+    for await (const item of pages) {
+      collected.push(item);
+    }
+  })()).rejects.toThrow("page 20 failed");
+  expect(collected).toStrictEqual(range(0, 20));
+});
+
+Deno.test("walkPages leaves no unhandled rejection behind when the consumer stops early", async () => {
+  // Read-ahead pages that reject after the consumer breaks would surface as
+  // unhandled rejections and crash the test run if the generator did not
+  // capture them.
+  const collected: number[] = [];
+  for await (
+    const item of walkPages<number>(
+      (limit, offset) => {
+        if (offset === 0) {
+          return Promise.resolve({
+            items: range(0, limit),
+            totalCount: 40,
+          });
+        }
+        return new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error(`page ${offset} failed`)), 1)
+        );
+      },
+      { pageSize: 10 },
+    )
+  ) {
+    collected.push(item);
+    if (collected.length >= 10) {
+      break;
+    }
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  expect(collected).toStrictEqual(range(0, 10));
+});
+
+Deno.test("walkPages rejects a pageSize outside Redmine's 1-to-100 range on first iteration", async () => {
+  const pages = walkPages(finiteSource(50), { pageSize: 101 });
+  await expect(pages.next()).rejects.toThrow(RangeError);
 });
 
 Deno.test("stops early when the source is exhausted before the limit", async () => {

--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -11,8 +11,6 @@ function range(start: number, end: number): number[] {
   return values;
 }
 
-// A finite source of ascending integers, returning at most `limit` of them
-// from `offset` and reporting the fixed total.
 function finiteSource(
   total: number,
 ): (limit: number, offset: number) => Promise<Page<number>> {
@@ -205,8 +203,6 @@ Deno.test("walkPages surfaces a page failure only after every earlier item is yi
 });
 
 Deno.test("walkPages surfaces a synchronously thrown page failure in order too", async () => {
-  // A non-async fetchPage can throw before ever producing a promise; that
-  // failure must still wait its turn instead of escaping the read-ahead fill.
   const collected: number[] = [];
   await expect((async () => {
     const pages = walkPages<number>(

--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -204,6 +204,36 @@ Deno.test("walkPages surfaces a page failure only after every earlier item is yi
   expect(collected).toStrictEqual(range(0, 20));
 });
 
+Deno.test("walkPages surfaces a synchronously thrown page failure in order too", async () => {
+  // A non-async fetchPage can throw before ever producing a promise; that
+  // failure must still wait its turn instead of escaping the read-ahead fill.
+  const collected: number[] = [];
+  await expect((async () => {
+    const pages = walkPages<number>(
+      (limit, offset) => {
+        if (offset === 20) {
+          throw new Error("page 20 failed");
+        }
+        return new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                items: range(offset, Math.min(offset + limit, 30)),
+                totalCount: 30,
+              }),
+            5,
+          )
+        );
+      },
+      { pageSize: 10 },
+    );
+    for await (const item of pages) {
+      collected.push(item);
+    }
+  })()).rejects.toThrow("page 20 failed");
+  expect(collected).toStrictEqual(range(0, 20));
+});
+
 Deno.test("walkPages leaves no unhandled rejection behind when the consumer stops early", async () => {
   // Read-ahead pages that reject after the consumer breaks would surface as
   // unhandled rejections and crash the test run if the generator did not

--- a/internal/paging.ts
+++ b/internal/paging.ts
@@ -18,7 +18,7 @@ export type Page<T> = {
 export type FetchPage<T> = (limit: number, offset: number) => Promise<Page<T>>;
 
 /**
- * Options controlling how {@link fetchAllPages} walks a paged resource.
+ * Options controlling how {@link walkPages} walks a paged resource.
  */
 export type PagingOptions = {
   /**
@@ -27,8 +27,8 @@ export type PagingOptions = {
    */
   pageSize: number;
   /**
-   * Upper bound on the number of items to return. When set, paging walks
-   * sequentially and stops as soon as this many items are collected, which
+   * Upper bound on the number of items to yield. When set, paging walks
+   * sequentially and stops as soon as this many items are yielded, which
    * skips the `total_count` probe and avoids over-fetching the final page.
    */
   limit?: number;
@@ -45,23 +45,27 @@ export type PagingOptions = {
 const DEFAULT_CONCURRENCY = 6;
 
 /**
- * Walk every page of a Redmine list resource and return the aggregated items
- * in page order.
+ * Walk every page of a Redmine list resource and yield the items in page
+ * order.
  *
  * With `options.limit` set the walk is sequential and stops once enough items
- * are collected. Without it, the first page is fetched (its reported total
- * drives how many pages remain) and the rest are fetched with bounded
- * parallelism.
+ * are yielded. Without it, the first page is fetched (its reported total
+ * drives how many pages remain) and later pages are read ahead with bounded
+ * parallelism, so an early `break` leaves at most `concurrency` requests
+ * wasted instead of fetching the whole resource.
+ *
+ * A page failure surfaces once iteration reaches that page, so every item
+ * before it is guaranteed to have been yielded already.
  *
  * @typeParam T Element type of the list
  * @param fetchPage Fetches and parses a single page
  * @param options Page size, optional item cap, and concurrency bound
- * @returns Every item across all pages, in ascending offset order
+ * @returns Items across all pages, in ascending offset order
  */
-export async function fetchAllPages<T>(
+export async function* walkPages<T>(
   fetchPage: FetchPage<T>,
   options: PagingOptions,
-): Promise<T[]> {
+): AsyncGenerator<T> {
   if (
     !Number.isInteger(options.pageSize) ||
     options.pageSize < 1 ||
@@ -72,64 +76,109 @@ export async function fetchAllPages<T>(
     );
   }
   if (options.limit !== undefined) {
-    return await collectUpToLimit(fetchPage, options.pageSize, options.limit);
+    yield* walkUpToLimit(fetchPage, options.pageSize, options.limit);
+    return;
   }
-  return await collectAll(
+  yield* walkWithReadAhead(
     fetchPage,
     options.pageSize,
     Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY),
   );
 }
 
-async function collectUpToLimit<T>(
+/**
+ * Walk every page of a Redmine list resource and return the aggregated items
+ * in page order.
+ *
+ * Thin aggregation over {@link walkPages}; see there for the walking
+ * strategy.
+ *
+ * @typeParam T Element type of the list
+ * @param fetchPage Fetches and parses a single page
+ * @param options Page size, optional item cap, and concurrency bound
+ * @returns Every item across all pages, in ascending offset order
+ */
+export async function fetchAllPages<T>(
+  fetchPage: FetchPage<T>,
+  options: PagingOptions,
+): Promise<T[]> {
+  return await Array.fromAsync(walkPages(fetchPage, options));
+}
+
+async function* walkUpToLimit<T>(
   fetchPage: FetchPage<T>,
   pageSize: number,
   limit: number,
-): Promise<T[]> {
-  const items: T[] = [];
-  while (items.length < limit) {
-    const fetchSize = Math.min(pageSize, limit - items.length);
-    const page = await fetchPage(fetchSize, items.length);
-    items.push(...page.items);
+): AsyncGenerator<T> {
+  let count = 0;
+  while (count < limit) {
+    const fetchSize = Math.min(pageSize, limit - count);
+    const page = await fetchPage(fetchSize, count);
+    for (const item of page.items) {
+      yield item;
+      count++;
+      // Guards against a server returning more items than requested pushing
+      // the walk past the cap.
+      if (count >= limit) {
+        return;
+      }
+    }
     // A short page means the resource is exhausted, so there is nothing left
     // to walk even though the requested limit is not yet reached.
     if (page.items.length < fetchSize) {
-      break;
+      return;
     }
   }
-  return items.slice(0, limit);
 }
 
-async function collectAll<T>(
+type SettledPage<T> =
+  | { ok: true; page: Page<T> }
+  | { ok: false; error: unknown };
+
+async function* walkWithReadAhead<T>(
   fetchPage: FetchPage<T>,
   pageSize: number,
   concurrency: number,
-): Promise<T[]> {
+): AsyncGenerator<T> {
   // The first full page also reports total_count, so no separate probe request
   // is needed.
   const first = await fetchPage(pageSize, 0);
-  if (first.totalCount <= pageSize) {
-    return first.items;
-  }
+  yield* first.items;
   const offsets: number[] = [];
   for (let offset = pageSize; offset < first.totalCount; offset += pageSize) {
     offsets.push(offset);
   }
-  // Results are written back at their page index so aggregation order is
-  // independent of the order in which concurrent requests settle.
-  const pages: T[][] = new Array(offsets.length);
   let next = 0;
-  const worker = async (): Promise<void> => {
-    // `next++` reads and advances synchronously before any await, so each
-    // worker claims a distinct index without further coordination.
-    for (let index = next++; index < offsets.length; index = next++) {
-      pages[index] = (await fetchPage(pageSize, offsets[index])).items;
+  let current = 0;
+  const inflight = new Map<number, Promise<SettledPage<T>>>();
+  const fill = () => {
+    while (inflight.size < concurrency && next < offsets.length) {
+      const index = next++;
+      // Read-ahead promises must never reject: a rejection settling while
+      // iteration is still consuming earlier pages (or after the consumer
+      // broke out) would be detected as unhandled. Failures are carried as
+      // values instead and re-thrown once iteration reaches the failing page.
+      inflight.set(
+        index,
+        fetchPage(pageSize, offsets[index]).then(
+          (page) => ({ ok: true as const, page }),
+          (error) => ({ ok: false as const, error }),
+        ),
+      );
     }
   };
-  const workers = Array.from(
-    { length: Math.min(concurrency, offsets.length) },
-    () => worker(),
-  );
-  await Promise.all(workers);
-  return [first.items, ...pages].flat();
+  fill();
+  // Awaiting pages in index order keeps yields ordered and makes a failing
+  // page surface only after every earlier item has been yielded, regardless
+  // of the order in which the read-ahead requests settle.
+  while (current < offsets.length) {
+    const settled = await inflight.get(current)!;
+    inflight.delete(current);
+    current++;
+    if (!settled.ok) {
+      throw settled.error;
+    }
+    fill();
+    yield* settled.page.items;
+  }
 }

--- a/internal/paging.ts
+++ b/internal/paging.ts
@@ -151,20 +151,26 @@ async function* walkWithReadAhead<T>(
   let next = 0;
   let current = 0;
   const inflight = new Map<number, Promise<SettledPage<T>>>();
+  const settle = (index: number): Promise<SettledPage<T>> => {
+    // Read-ahead promises must never reject: a rejection settling while
+    // iteration is still consuming earlier pages (or after the consumer
+    // broke out) would be detected as unhandled. Failures are carried as
+    // values instead and re-thrown once iteration reaches the failing page.
+    try {
+      return fetchPage(pageSize, offsets[index]).then(
+        (page) => ({ ok: true as const, page }),
+        (error) => ({ ok: false as const, error }),
+      );
+    } catch (error) {
+      // A synchronously throwing fetchPage would otherwise escape the settle
+      // wrapping and surface out of order, before earlier pages are yielded.
+      return Promise.resolve({ ok: false as const, error });
+    }
+  };
   const fill = () => {
     while (inflight.size < concurrency && next < offsets.length) {
-      const index = next++;
-      // Read-ahead promises must never reject: a rejection settling while
-      // iteration is still consuming earlier pages (or after the consumer
-      // broke out) would be detected as unhandled. Failures are carried as
-      // values instead and re-thrown once iteration reaches the failing page.
-      inflight.set(
-        index,
-        fetchPage(pageSize, offsets[index]).then(
-          (page) => ({ ok: true as const, page }),
-          (error) => ({ ok: false as const, error }),
-        ),
-      );
+      inflight.set(next, settle(next));
+      next++;
     }
   };
   fill();

--- a/memberships/list.ts
+++ b/memberships/list.ts
@@ -1,5 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
+import { fetchAllPages } from "../internal/paging.ts";
 import type { Context } from "../context.ts";
 import type { Membership } from "./type.ts";
 import { membershipSchema } from "./validator.ts";
@@ -25,16 +26,9 @@ export async function fetchList(
   context: Context,
   projectId: number,
 ): Promise<Membership[]> {
-  const opts: RequestInit = {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Redmine-API-Key": context.apiKey,
-    },
-  };
-  // The memberships listing is paginated (default limit 25), so walk the pages
-  // sequentially until every membership has been collected.
-  const fetchPage = async (offset: number) => {
+  // The memberships listing is paginated (default limit 25), so walk every
+  // page until each membership has been collected.
+  return await fetchAllPages(async (limit, offset) => {
     const url = buildUrl(
       context.endpoint,
       "projects",
@@ -42,18 +36,18 @@ export async function fetchList(
       "memberships.json",
     );
     url.search = new URLSearchParams({
-      limit: `${pageSize}`,
+      limit: `${limit}`,
       offset: `${offset}`,
     }).toString();
-    const response = await fetch(url, opts);
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Redmine-API-Key": context.apiKey,
+      },
+    });
     await assertResponse(response);
-    return parse(responseSchema, await response.json());
-  };
-
-  const first = await fetchPage(0);
-  const memberships = [...first.memberships];
-  for (let offset = pageSize; offset < first.total_count; offset += pageSize) {
-    memberships.push(...(await fetchPage(offset)).memberships);
-  }
-  return memberships;
+    const parsed = parse(responseSchema, await response.json());
+    return { items: parsed.memberships, totalCount: parsed.total_count };
+  }, { pageSize });
 }


### PR DESCRIPTION
## Summary

Introduce an AsyncGenerator paging core (`walkPages`) and reimplement `fetchAllPages` and the hand-rolled memberships paging on top of it.

## Details

A follow-up change exposes lazy iteration publicly, which needs the paging core itself to be a generator, and folding the memberships walk into the shared helper leaves only one paging strategy in the codebase.

Read-ahead failures are carried as settled values and re-thrown in page order because a rejection settling before its turn would be detected as an unhandled rejection.

## Confirmation

Ran `nix run .#check-deno`; format, lint, type check, and 109 tests passed with 0 failures.

## Limitation

Public behavior is unchanged; lazy iteration is exposed by the follow-up PRs in this stack.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming pagination via a new page-walking generator.
  * Added bounded read-ahead to speed up paging while preserving item order.
  * Supports early termination once a requested limit is reached.
* **Bug Fixes**
  * Pagination errors now surface in correct order, after all previously yielded items.
  * Prevents unnecessary subsequent page requests when iteration stops early.
  * Avoids unhandled rejections from background prefetch when stopping early.
* **Improvements**
  * Memberships list now uses the shared pagination logic for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->