### PR TITLE
feat!: unify list function names to list

### DIFF
--- a/custom-fields/list.test.ts
+++ b/custom-fields/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /custom_fields.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const customFields = await fetchList(context);
+    const customFields = await list(context);
     expect(customFields).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
     "if got 200, should return custom fields with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const customFields = await fetchList(context);
+      const customFields = await list(context);
       expect(customFields.length).toStrictEqual(3);
       expect(customFields[0]).toStrictEqual({
         id: 1,
@@ -67,7 +67,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/custom-fields/list.ts
+++ b/custom-fields/list.ts
@@ -13,7 +13,7 @@ import { listCustomFieldResponse } from "./validator.ts";
  * @param context REST endpoint context
  * @return Array of CustomField
  */
-export async function fetchList(context: Context): Promise<CustomField[]> {
+export async function list(context: Context): Promise<CustomField[]> {
   const endpoint = buildUrl(context.endpoint, "custom_fields.json");
   const response = await fetch(
     endpoint,

--- a/custom-fields/mod.ts
+++ b/custom-fields/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 
 export class Client {
   readonly #context: Context;
@@ -11,7 +11,7 @@ export class Client {
   /**
    * Return the list of custom fields
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 }

--- a/e2e/custom-fields.test.ts
+++ b/e2e/custom-fields.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../custom-fields/list.ts";
+import { list } from "../custom-fields/list.ts";
 
 Deno.test("E2E: Custom Fields API", async (t) => {
   await t.step(
     "GET /custom_fields.json should return an array of custom fields",
     async () => {
-      const customFields = await fetchList(e2eContext);
+      const customFields = await list(e2eContext);
       expect(Array.isArray(customFields)).toBe(true);
       // e2e/setup.ts seeds an "E2E CF" issue custom field, so the list is
       // non-empty and contains it.

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -1,9 +1,9 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../files/list.ts";
+import { list } from "../files/list.ts";
 import { create } from "../files/create.ts";
 import { upload } from "../files/upload.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Files API",
@@ -41,7 +41,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/files.json should return files",
       async () => {
-        const files = await fetchList(e2eContext, project!.id);
+        const files = await list(e2eContext, project!.id);
         const created = files.find((f) => f.filename === filename);
         expect(created).toBeDefined();
       },

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -3,12 +3,12 @@ import { e2eContext } from "./context.ts";
 import { list } from "../files/list.ts";
 import { create } from "../files/create.ts";
 import { upload } from "../files/upload.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Files API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 

--- a/e2e/groups.test.ts
+++ b/e2e/groups.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../groups/list.ts";
+import { list } from "../groups/list.ts";
 import { show } from "../groups/show.ts";
 import { create } from "../groups/create.ts";
 import { update } from "../groups/update.ts";
@@ -38,7 +38,7 @@ Deno.test({
 
     let groupId: number | undefined;
     await t.step("GET /groups.json should list the created group", async () => {
-      const groups = await fetchList(e2eContext);
+      const groups = await list(e2eContext);
       const created = groups.find((g) => g.name === groupName);
       expect(created).toBeDefined();
       groupId = created!.id;

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -5,12 +5,12 @@ import { show } from "../issue-categories/show.ts";
 import { create } from "../issue-categories/create.ts";
 import { update } from "../issue-categories/update.ts";
 import { deleteIssueCategory } from "../issue-categories/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Categories API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../issue-categories/list.ts";
+import { list } from "../issue-categories/list.ts";
 import { show } from "../issue-categories/show.ts";
 import { create } from "../issue-categories/create.ts";
 import { update } from "../issue-categories/update.ts";
 import { deleteIssueCategory } from "../issue-categories/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Categories API",
@@ -26,7 +26,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/issue_categories.json should return issue categories",
       async () => {
-        const categories = await fetchList(e2eContext, project!.id);
+        const categories = await list(e2eContext, project!.id);
         expect(categories.length).toBeGreaterThan(0);
         const created = categories.find((c) =>
           c.name === "E2E Created Category"
@@ -38,7 +38,7 @@ Deno.test({
     await t.step(
       "GET /issue_categories/:id.json should return an issue category",
       async () => {
-        const categories = await fetchList(e2eContext, project!.id);
+        const categories = await list(e2eContext, project!.id);
         const category = categories.find((c) =>
           c.name === "E2E Created Category"
         );
@@ -56,7 +56,7 @@ Deno.test({
     await t.step(
       "PUT /issue_categories/:id.json should update an issue category",
       async () => {
-        const categories = await fetchList(e2eContext, project!.id);
+        const categories = await list(e2eContext, project!.id);
         const category = categories.find((c) =>
           c.name === "E2E Created Category"
         );
@@ -76,7 +76,7 @@ Deno.test({
     await t.step(
       "DELETE /issue_categories/:id.json should delete an issue category",
       async () => {
-        const categories = await fetchList(e2eContext, project!.id);
+        const categories = await list(e2eContext, project!.id);
         const category = categories.find((c) =>
           c.name === "E2E Updated Category"
         );

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../issue-relations/list.ts";
+import { list } from "../issue-relations/list.ts";
 import { show } from "../issue-relations/show.ts";
 import { create } from "../issue-relations/create.ts";
 import { deleteRelation } from "../issue-relations/delete.ts";
-import { listIssues } from "../issues/list.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchIssues } from "../issues/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Relations API",
@@ -14,7 +14,7 @@ Deno.test({
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await listIssues(e2eContext, {
+    const issues = await fetchIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issues.length).toBeGreaterThan(0);
@@ -63,7 +63,7 @@ Deno.test({
     await t.step(
       "GET /issues/:issue_id/relations.json should return relations",
       async () => {
-        const relations = await fetchList(e2eContext, firstIssue.id);
+        const relations = await list(e2eContext, firstIssue.id);
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
@@ -75,7 +75,7 @@ Deno.test({
     await t.step(
       "GET /relations/:id.json should return a relation",
       async () => {
-        const relations = await fetchList(e2eContext, firstIssue.id);
+        const relations = await list(e2eContext, firstIssue.id);
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
@@ -92,7 +92,7 @@ Deno.test({
     await t.step(
       "DELETE /relations/:id.json should delete a relation",
       async () => {
-        const relations = await fetchList(e2eContext, firstIssue.id);
+        const relations = await list(e2eContext, firstIssue.id);
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -4,17 +4,17 @@ import { list } from "../issue-relations/list.ts";
 import { show } from "../issue-relations/show.ts";
 import { create } from "../issue-relations/create.ts";
 import { deleteRelation } from "../issue-relations/delete.ts";
-import { list as fetchIssues } from "../issues/list.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listIssues } from "../issues/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issue Relations API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await fetchIssues(e2eContext, {
+    const issues = await listIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issues.length).toBeGreaterThan(0);

--- a/e2e/issue-statuses.test.ts
+++ b/e2e/issue-statuses.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../issue-statuses/list.ts";
+import { list } from "../issue-statuses/list.ts";
 
 Deno.test("E2E: Issue Statuses API", async (t) => {
   await t.step(
     "GET /issue_statuses.json should return default issue statuses",
     async () => {
-      const statuses = await fetchList(e2eContext);
+      const statuses = await list(e2eContext);
       expect(
         statuses.length,
         "Redmine should have default issue statuses",

--- a/e2e/issue-watchers.test.ts
+++ b/e2e/issue-watchers.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { listIssues } from "../issues/list.ts";
+import { list } from "../issues/list.ts";
 import { addWatcher } from "../issues/add-watcher.ts";
 import { removeWatcher } from "../issues/remove-watcher.ts";
 
@@ -22,7 +22,7 @@ async function fetchCurrentUserId(): Promise<number | undefined> {
 Deno.test({
   name: "E2E: Issue watchers API",
   fn: async (t) => {
-    const issues = await listIssues(e2eContext, { limit: 1 });
+    const issues = await list(e2eContext, { limit: 1 });
     const issue = issues[0];
     if (issue === undefined) {
       // Nothing to watch when the seeded project holds no issues.

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -5,7 +5,7 @@ import { show } from "../issues/show.ts";
 import { createIssue } from "../issues/create.ts";
 import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issues API",
@@ -29,7 +29,7 @@ Deno.test({
     });
 
     await t.step("POST /issues.json should create an issue", async () => {
-      const projects = await fetchProjects(e2eContext);
+      const projects = await listProjects(e2eContext);
       const project = projects.find((p) => p.identifier === "e2e-test-project");
       expect(project).toBeDefined();
 
@@ -67,7 +67,7 @@ Deno.test({
         );
         expect(customField).toBeDefined();
 
-        const projects = await fetchProjects(e2eContext);
+        const projects = await listProjects(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );
@@ -129,7 +129,7 @@ Deno.test({
     await t.step(
       "GET /issues.json with limit: 1 should return exactly one issue",
       async () => {
-        const projects = await fetchProjects(e2eContext);
+        const projects = await listProjects(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -1,22 +1,22 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { listIssues } from "../issues/list.ts";
+import { list } from "../issues/list.ts";
 import { show } from "../issues/show.ts";
 import { createIssue } from "../issues/create.ts";
 import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Issues API",
   fn: async (t) => {
     await t.step("GET /issues.json should return issues", async () => {
-      const issues = await listIssues(e2eContext, {});
+      const issues = await list(e2eContext, {});
       expect(issues.length).toBeGreaterThan(0);
     });
 
     await t.step("GET /issues/:id.json should return an issue", async () => {
-      const issues = await listIssues(e2eContext, {});
+      const issues = await list(e2eContext, {});
       expect(issues.length).toBeGreaterThan(0);
       const issueId = issues[0].id;
 
@@ -33,7 +33,7 @@ Deno.test({
       const project = projects.find((p) => p.identifier === "e2e-test-project");
       expect(project).toBeDefined();
 
-      const issues = await listIssues(e2eContext, {
+      const issues = await list(e2eContext, {
         projectId: project!.id,
       });
       expect(issues.length).toBeGreaterThan(0);
@@ -73,7 +73,7 @@ Deno.test({
         );
         expect(project).toBeDefined();
 
-        const issues = await listIssues(e2eContext, {
+        const issues = await list(e2eContext, {
           projectId: project!.id,
         });
         expect(issues.length).toBeGreaterThan(0);
@@ -88,7 +88,7 @@ Deno.test({
           customFields: [{ id: customField!.id, value: "e2e custom value" }],
         });
 
-        const listAfter = await listIssues(e2eContext, {
+        const listAfter = await list(e2eContext, {
           projectId: project!.id,
         });
         const created = listAfter.find((i) => i.subject === subject);
@@ -104,7 +104,7 @@ Deno.test({
     );
 
     await t.step("PUT /issues/:id.json should update an issue", async () => {
-      const issues = await listIssues(e2eContext, {});
+      const issues = await list(e2eContext, {});
       const issue = issues.find((i) => i.subject === "E2E Created Issue");
       expect(issue).toBeDefined();
 
@@ -135,7 +135,7 @@ Deno.test({
         );
         expect(project).toBeDefined();
 
-        const issues = await listIssues(e2eContext, {
+        const issues = await list(e2eContext, {
           projectId: project!.id,
         });
         expect(issues.length).toBeGreaterThan(0);
@@ -150,16 +150,16 @@ Deno.test({
           statusId: issues[0].status.id,
           priorityId: issues[0].priority.id,
           subject,
-          description: "Created by E2E test to exercise listIssues limit",
+          description: "Created by E2E test to exercise list limit",
         });
 
         // Cleanup looks the issue up by subject because createIssue does
         // not return the created id.
         try {
-          const limited = await listIssues(e2eContext, { limit: 1 });
+          const limited = await list(e2eContext, { limit: 1 });
           expect(limited.length).toStrictEqual(1);
         } finally {
-          const cleanupList = await listIssues(e2eContext, {
+          const cleanupList = await list(e2eContext, {
             projectId: project!.id,
           });
           // Delete every match, not just one: runs that predate this
@@ -173,7 +173,7 @@ Deno.test({
     );
 
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
-      const issues = await listIssues(e2eContext, {});
+      const issues = await list(e2eContext, {});
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");
       expect(issue).toBeDefined();
 

--- a/e2e/journals.test.ts
+++ b/e2e/journals.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { listIssues } from "../issues/list.ts";
+import { list } from "../issues/list.ts";
 import { show } from "../issues/show.ts";
 import { createIssue } from "../issues/create.ts";
 import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 import { update as updateJournal } from "../journals/update.ts";
 
 Deno.test({
@@ -24,7 +24,7 @@ Deno.test({
         );
         expect(project).toBeDefined();
 
-        const issues = await listIssues(e2eContext, {
+        const issues = await list(e2eContext, {
           projectId: project!.id,
         });
         expect(issues.length).toBeGreaterThan(0);
@@ -39,7 +39,7 @@ Deno.test({
 
         // createIssue does not return the created id, so it is looked up
         // by subject, mirroring the pattern in e2e/issues.test.ts.
-        const listAfter = await listIssues(e2eContext, {
+        const listAfter = await list(e2eContext, {
           projectId: project!.id,
         });
         const createdIssue = listAfter.find((i) => i.subject === subject);

--- a/e2e/journals.test.ts
+++ b/e2e/journals.test.ts
@@ -5,7 +5,7 @@ import { show } from "../issues/show.ts";
 import { createIssue } from "../issues/create.ts";
 import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 import { update as updateJournal } from "../journals/update.ts";
 
 Deno.test({
@@ -18,7 +18,7 @@ Deno.test({
     await t.step(
       "POST /issues.json should create an issue to attach a journal to",
       async () => {
-        const projects = await fetchProjects(e2eContext);
+        const projects = await listProjects(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../memberships/list.ts";
+import { list } from "../memberships/list.ts";
 import { show } from "../memberships/show.ts";
 import { create } from "../memberships/create.ts";
 import { update } from "../memberships/update.ts";
 import { deleteMembership } from "../memberships/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 // The library has no `users`/`roles` resources yet, so these are fetched
 // directly against the raw REST API, mirroring e2e/setup.ts's seeding
@@ -73,7 +73,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/memberships.json should return memberships",
       async () => {
-        const memberships = await fetchList(e2eContext, project!.id);
+        const memberships = await list(e2eContext, project!.id);
         expect(memberships.length).toBeGreaterThan(0);
         const created = memberships.find((m) => m.user?.id === userId);
         expect(created).toBeDefined();

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -5,7 +5,7 @@ import { show } from "../memberships/show.ts";
 import { create } from "../memberships/create.ts";
 import { update } from "../memberships/update.ts";
 import { deleteMembership } from "../memberships/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 // The library has no `users`/`roles` resources yet, so these are fetched
 // directly against the raw REST API, mirroring e2e/setup.ts's seeding
@@ -43,7 +43,7 @@ async function fetchFirstRoleId(): Promise<number | undefined> {
 Deno.test({
   name: "E2E: Memberships API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../news/list.ts";
-import { fetchListByProject } from "../news/list-by-project.ts";
+import { list } from "../news/list.ts";
+import { listByProject } from "../news/list-by-project.ts";
 import { show } from "../news/show.ts";
 import { create } from "../news/create.ts";
 import { update } from "../news/update.ts";
 import { deleteNews } from "../news/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: News API",
@@ -16,7 +16,7 @@ Deno.test({
     expect(project).toBeDefined();
 
     await t.step("GET /news.json should return the seeded news", async () => {
-      const news = await fetchList(e2eContext);
+      const news = await list(e2eContext);
       const seeded = news.find((n) => n.title === "E2E News");
       expect(seeded).toBeDefined();
       expect(seeded!.summary).toStrictEqual("E2E news summary");
@@ -29,7 +29,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/news.json should return the project news",
       async () => {
-        const news = await fetchListByProject(e2eContext, project!.id);
+        const news = await listByProject(e2eContext, project!.id);
         const seeded = news.find((n) => n.title === "E2E News");
         expect(seeded).toBeDefined();
         // A news created without a summary is rendered as an empty string
@@ -54,7 +54,7 @@ Deno.test({
     );
 
     const findByTitle = async (title: string) => {
-      const news = await fetchListByProject(e2eContext, project!.id);
+      const news = await listByProject(e2eContext, project!.id);
       return news.find((n) => n.title === title);
     };
 

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -6,12 +6,12 @@ import { show } from "../news/show.ts";
 import { create } from "../news/create.ts";
 import { update } from "../news/update.ts";
 import { deleteNews } from "../news/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: News API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../projects/list.ts";
+import { list } from "../projects/list.ts";
 import { show } from "../projects/show.ts";
 import { create } from "../projects/create.ts";
 import { update } from "../projects/update.ts";
@@ -12,12 +12,12 @@ Deno.test({
   name: "E2E: Projects API",
   fn: async (t) => {
     await t.step("GET /projects.json should return projects", async () => {
-      const projects = await fetchList(e2eContext);
+      const projects = await list(e2eContext);
       expect(projects.length).toBeGreaterThan(0);
     });
 
     await t.step("GET /projects/:id.json should return a project", async () => {
-      const projects = await fetchList(e2eContext);
+      const projects = await list(e2eContext);
       expect(projects.length).toBeGreaterThan(0);
       const projectId = projects[0].id;
 
@@ -33,7 +33,7 @@ Deno.test({
     });
 
     await t.step("PUT /projects/:id.json should update a project", async () => {
-      const projects = await fetchList(e2eContext);
+      const projects = await list(e2eContext);
       const project = projects.find((p) =>
         p.identifier === "e2e-created-project"
       );
@@ -63,7 +63,7 @@ Deno.test({
         // an id from the try block: that id is unavailable exactly when the
         // lookup is the step that failed.
         try {
-          const projects = await fetchList(e2eContext);
+          const projects = await list(e2eContext);
           const created = projects.find((p) => p.identifier === identifier);
           expect(created).toBeDefined();
 
@@ -84,7 +84,7 @@ Deno.test({
           ).toStrictEqual(true);
         } finally {
           try {
-            const cleanupList = await fetchList(e2eContext);
+            const cleanupList = await list(e2eContext);
             const leftover = cleanupList.find((p) =>
               p.identifier === identifier
             );
@@ -102,7 +102,7 @@ Deno.test({
     await t.step(
       "PUT /projects/:id/archive.json should archive and unarchive",
       async () => {
-        const projects = await fetchList(e2eContext);
+        const projects = await list(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );
@@ -116,7 +116,7 @@ Deno.test({
     await t.step(
       "PUT /projects/:id/close.json should close and reopen",
       async () => {
-        const projects = await fetchList(e2eContext);
+        const projects = await list(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );
@@ -130,7 +130,7 @@ Deno.test({
     await t.step(
       "DELETE /projects/:id.json should delete a project",
       async () => {
-        const projects = await fetchList(e2eContext);
+        const projects = await list(e2eContext);
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );

--- a/e2e/queries.test.ts
+++ b/e2e/queries.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../queries/list.ts";
+import { list } from "../queries/list.ts";
 
 Deno.test("E2E: Queries API", async (t) => {
   await t.step(
     "GET /queries.json should return the list of queries",
     async () => {
-      const queries = await fetchList(e2eContext);
+      const queries = await list(e2eContext);
       // Saved queries are user-created, so a freshly provisioned Redmine has
       // none; a successful parse already proves the response matches the
       // schema regardless of length.

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../roles/list.ts";
+import { list } from "../roles/list.ts";
 import { show } from "../roles/show.ts";
 
 Deno.test({
@@ -9,7 +9,7 @@ Deno.test({
     await t.step(
       "GET /roles.json should return a list of roles",
       async () => {
-        const roles = await fetchList(e2eContext);
+        const roles = await list(e2eContext);
         expect(Array.isArray(roles)).toBe(true);
       },
     );
@@ -17,7 +17,7 @@ Deno.test({
     await t.step(
       "GET /roles/:id.json should return a role",
       async () => {
-        const roles = await fetchList(e2eContext);
+        const roles = await list(e2eContext);
         const role = roles[0];
         // e2e/setup.ts seeds a role so this normally runs. A freshly
         // provisioned Redmine loads no default roles, so guard the listing

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -5,17 +5,17 @@ import { show } from "../time-entries/show.ts";
 import { create } from "../time-entries/create.ts";
 import { update } from "../time-entries/update.ts";
 import { deleteTimeEntry } from "../time-entries/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
-import { list as fetchIssues } from "../issues/list.ts";
+import { list as listProjects } from "../projects/list.ts";
+import { list as listIssues } from "../issues/list.ts";
 
 Deno.test({
   name: "E2E: Time Entries API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await fetchIssues(e2eContext, {
+    const issues = await listIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issues.length).toBeGreaterThan(0);

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../time-entries/list.ts";
+import { list } from "../time-entries/list.ts";
 import { show } from "../time-entries/show.ts";
 import { create } from "../time-entries/create.ts";
 import { update } from "../time-entries/update.ts";
 import { deleteTimeEntry } from "../time-entries/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
-import { listIssues } from "../issues/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
+import { list as fetchIssues } from "../issues/list.ts";
 
 Deno.test({
   name: "E2E: Time Entries API",
@@ -15,7 +15,7 @@ Deno.test({
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await listIssues(e2eContext, {
+    const issues = await fetchIssues(e2eContext, {
       projectId: project!.id,
     });
     expect(issues.length).toBeGreaterThan(0);
@@ -56,7 +56,7 @@ Deno.test({
     await t.step(
       "GET /time_entries.json?project_id=... should return time entries",
       async () => {
-        const timeEntries = await fetchList(e2eContext, {
+        const timeEntries = await list(e2eContext, {
           projectId: project!.id,
         });
         expect(timeEntries.length).toBeGreaterThan(0);
@@ -70,7 +70,7 @@ Deno.test({
     await t.step(
       "GET /time_entries/:id.json should return a time entry",
       async () => {
-        const timeEntries = await fetchList(e2eContext, {
+        const timeEntries = await list(e2eContext, {
           projectId: project!.id,
         });
         const timeEntry = timeEntries.find((e) =>
@@ -90,7 +90,7 @@ Deno.test({
     await t.step(
       "PUT /time_entries/:id.json should update a time entry",
       async () => {
-        const timeEntries = await fetchList(e2eContext, {
+        const timeEntries = await list(e2eContext, {
           projectId: project!.id,
         });
         const timeEntry = timeEntries.find((e) =>
@@ -114,7 +114,7 @@ Deno.test({
     await t.step(
       "DELETE /time_entries/:id.json should delete a time entry",
       async () => {
-        const timeEntries = await fetchList(e2eContext, {
+        const timeEntries = await list(e2eContext, {
           projectId: project!.id,
         });
         const timeEntry = timeEntries.find((e) =>

--- a/e2e/trackers.test.ts
+++ b/e2e/trackers.test.ts
@@ -1,12 +1,12 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../trackers/list.ts";
+import { list } from "../trackers/list.ts";
 
 Deno.test("E2E: Trackers API", async (t) => {
   await t.step(
     "GET /trackers.json should return default trackers",
     async () => {
-      const trackers = await fetchList(e2eContext);
+      const trackers = await list(e2eContext);
       expect(
         trackers.length,
         "Redmine should have default trackers",

--- a/e2e/users.test.ts
+++ b/e2e/users.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../users/list.ts";
+import { list } from "../users/list.ts";
 import { show } from "../users/show.ts";
 import { create } from "../users/create.ts";
 import { update } from "../users/update.ts";
@@ -31,7 +31,7 @@ Deno.test({
     await t.step(
       "GET /users.json should return users",
       async () => {
-        const users = await fetchList(e2eContext);
+        const users = await list(e2eContext);
         expect(users.length).toBeGreaterThan(0);
         const created = users.find((u) => u.login === login);
         expect(created).toBeDefined();
@@ -39,7 +39,7 @@ Deno.test({
     );
 
     await t.step("GET /users/:id.json should return a user", async () => {
-      const users = await fetchList(e2eContext);
+      const users = await list(e2eContext);
       const user = users.find((u) => u.login === login);
       expect(user).toBeDefined();
 
@@ -52,7 +52,7 @@ Deno.test({
     });
 
     await t.step("PUT /users/:id.json should update a user", async () => {
-      const users = await fetchList(e2eContext);
+      const users = await list(e2eContext);
       const user = users.find((u) => u.login === login);
       expect(user).toBeDefined();
 
@@ -68,7 +68,7 @@ Deno.test({
     await t.step(
       "DELETE /users/:id.json should delete a user",
       async () => {
-        const users = await fetchList(e2eContext);
+        const users = await list(e2eContext);
         const user = users.find((u) => u.login === login);
         expect(user).toBeDefined();
 

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../versions/list.ts";
+import { list } from "../versions/list.ts";
 import { show } from "../versions/show.ts";
 import { create } from "../versions/create.ts";
 import { update } from "../versions/update.ts";
 import { deleteVersion } from "../versions/delete.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Versions API",
@@ -30,7 +30,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/versions.json should return versions",
       async () => {
-        const versions = await fetchList(e2eContext, project!.id);
+        const versions = await list(e2eContext, project!.id);
         expect(versions.length).toBeGreaterThan(0);
         const created = versions.find((v) => v.name === "E2E Created Version");
         expect(created).toBeDefined();
@@ -38,7 +38,7 @@ Deno.test({
     );
 
     await t.step("GET /versions/:id.json should return a version", async () => {
-      const versions = await fetchList(e2eContext, project!.id);
+      const versions = await list(e2eContext, project!.id);
       const version = versions.find((v) => v.name === "E2E Created Version");
       expect(version).toBeDefined();
 
@@ -50,7 +50,7 @@ Deno.test({
     });
 
     await t.step("PUT /versions/:id.json should update a version", async () => {
-      const versions = await fetchList(e2eContext, project!.id);
+      const versions = await list(e2eContext, project!.id);
       const version = versions.find((v) => v.name === "E2E Created Version");
       expect(version).toBeDefined();
 
@@ -67,7 +67,7 @@ Deno.test({
     await t.step(
       "DELETE /versions/:id.json should delete a version",
       async () => {
-        const versions = await fetchList(e2eContext, project!.id);
+        const versions = await list(e2eContext, project!.id);
         const version = versions.find((v) => v.name === "E2E Updated Version");
         expect(version).toBeDefined();
 

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -5,12 +5,12 @@ import { show } from "../versions/show.ts";
 import { create } from "../versions/create.ts";
 import { update } from "../versions/update.ts";
 import { deleteVersion } from "../versions/delete.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Versions API",
   fn: async (t) => {
-    const projects = await fetchProjects(e2eContext);
+    const projects = await listProjects(e2eContext);
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -5,7 +5,7 @@ import { show } from "../wiki-pages/show.ts";
 import { create } from "../wiki-pages/create.ts";
 import { deleteWiki } from "../wiki-pages/delete.ts";
 import { upload } from "../files/upload.ts";
-import { list as fetchProjects } from "../projects/list.ts";
+import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Wiki Pages API",
@@ -13,7 +13,7 @@ Deno.test({
     let projectId: number;
 
     await t.step("resolve test project", async () => {
-      const projects = await fetchProjects(e2eContext);
+      const projects = await listProjects(e2eContext);
       const project = projects.find((p) => p.identifier === "e2e-test-project");
       expect(project).toBeDefined();
       projectId = project!.id;

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "jsr:@std/expect@1.0.20";
 import { e2eContext } from "./context.ts";
-import { fetchList } from "../wiki-pages/list.ts";
+import { list } from "../wiki-pages/list.ts";
 import { show } from "../wiki-pages/show.ts";
 import { create } from "../wiki-pages/create.ts";
 import { deleteWiki } from "../wiki-pages/delete.ts";
 import { upload } from "../files/upload.ts";
-import { fetchList as fetchProjects } from "../projects/list.ts";
+import { list as fetchProjects } from "../projects/list.ts";
 
 Deno.test({
   name: "E2E: Wiki Pages API",
@@ -22,7 +22,7 @@ Deno.test({
     await t.step(
       "GET /projects/:id/wiki/index.json should return wiki pages",
       async () => {
-        const pages = await fetchList(e2eContext, projectId);
+        const pages = await list(e2eContext, projectId);
         expect(pages.length).toBeGreaterThan(0);
       },
     );

--- a/files/list.test.ts
+++ b/files/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/files.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const files = await fetchList(context, 1);
+    const files = await list(context, 1);
     expect(files).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     "if got 200, should return files with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const files = await fetchList(context, 1);
+      const files = await list(context, 1);
       expect(files.length).toStrictEqual(2);
       expect(files[0].contentType).toStrictEqual("application/zip");
       expect(files[0].contentUrl).toStrictEqual(
@@ -36,12 +36,12 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context, 422)).rejects.toThrow();
+      await expect(list(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
-    await expect(fetchList(context, 404)).rejects.toThrow();
+    await expect(list(context, 404)).rejects.toThrow();
   });
 });

--- a/files/list.ts
+++ b/files/list.ts
@@ -17,7 +17,7 @@ const responseSchema = object({
  * @param projectId Project identifier
  * @returns Files
  */
-export async function fetchList(
+export async function list(
   context: Context,
   projectId: number,
 ): Promise<ProjectFile[]> {

--- a/files/mod.ts
+++ b/files/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { create } from "./create.ts";
 import { upload } from "./upload.ts";
 import type { CreateFileQuery } from "./type.ts";
@@ -16,8 +16,8 @@ export class Client {
    *
    * @param projectId Project identifier
    */
-  list(projectId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, projectId);
+  list(projectId: number): ReturnType<typeof list> {
+    return list(this.#context, projectId);
   }
 
   /**

--- a/groups/list.test.ts
+++ b/groups/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /groups.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const r = await fetchList(context);
+    const r = await list(context);
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /groups.json", async (t) => {
     "if got 200, should return groups as id/name pairs",
     async () => {
       server.resetHandlers(...validHandlers);
-      const groups = await fetchList(context);
+      const groups = await list(context);
       expect(groups.length).toStrictEqual(2);
       expect(groups[0]).toStrictEqual({ id: 53, name: "Managers" });
       expect(groups[1]).toStrictEqual({
@@ -31,7 +31,7 @@ Deno.test("GET /groups.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/groups/list.ts
+++ b/groups/list.ts
@@ -16,7 +16,7 @@ const responseSchema = object({
  * @param context REST endpoint context
  * @returns Groups as id/name pairs
  */
-export async function fetchList(context: Context): Promise<IdName[]> {
+export async function list(context: Context): Promise<IdName[]> {
   const url = buildUrl(context.endpoint, "groups.json");
   const response = await fetch(url, {
     method: "GET",

--- a/groups/mod.ts
+++ b/groups/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { CreateGroupQuery, UpdateGroupQuery } from "./type.ts";
@@ -18,8 +18,8 @@ export class Client {
   /**
    * Returns all groups.
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 
   /**

--- a/issue-categories/list.test.ts
+++ b/issue-categories/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await fetchList(context, 1);
+    const r = await list(context, 1);
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     "if got 200, should return issue categories with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const categories = await fetchList(context, 1);
+      const categories = await list(context, 1);
       expect(categories[0].assignedTo).toStrictEqual({
         id: 5,
         name: "Alice",
@@ -30,12 +30,12 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(fetchList(context, 422)).rejects.toThrow();
+      await expect(list(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(fetchList(context, 404)).rejects.toThrow();
+    await expect(list(context, 404)).rejects.toThrow();
   });
 });

--- a/issue-categories/list.ts
+++ b/issue-categories/list.ts
@@ -17,7 +17,7 @@ const responseSchema = object({
  * @param projectId Project identifier
  * @returns Issue categories
  */
-export async function fetchList(
+export async function list(
   context: Context,
   projectId: number,
 ): Promise<IssueCategory[]> {

--- a/issue-categories/mod.ts
+++ b/issue-categories/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type {
@@ -21,8 +21,8 @@ export class Client {
    *
    * @param projectId Project identifier
    */
-  list(projectId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, projectId);
+  list(projectId: number): ReturnType<typeof list> {
+    return list(this.#context, projectId);
   }
 
   /**

--- a/issue-relations/list.test.ts
+++ b/issue-relations/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await fetchList(context, 1);
+    const r = await list(context, 1);
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     "if got 200, should return relations with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const relations = await fetchList(context, 1);
+      const relations = await list(context, 1);
       expect(relations[0]).toStrictEqual({
         id: 1,
         issueId: 1,
@@ -34,12 +34,12 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(fetchList(context, 422)).rejects.toThrow();
+      await expect(list(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(fetchList(context, 404)).rejects.toThrow();
+    await expect(list(context, 404)).rejects.toThrow();
   });
 });

--- a/issue-relations/list.ts
+++ b/issue-relations/list.ts
@@ -17,7 +17,7 @@ const responseSchema = object({
  * @param issueId Issue identifier
  * @returns Relations
  */
-export async function fetchList(
+export async function list(
   context: Context,
   issueId: number,
 ): Promise<Relation[]> {

--- a/issue-relations/mod.ts
+++ b/issue-relations/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { CreateRelationQuery } from "./type.ts";
@@ -17,8 +17,8 @@ export class Client {
    *
    * @param issueId Issue identifier
    */
-  list(issueId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, issueId);
+  list(issueId: number): ReturnType<typeof list> {
+    return list(this.#context, issueId);
   }
 
   /**

--- a/issue-statuses/list.test.ts
+++ b/issue-statuses/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /issue_statuses.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const issueStatuses = await fetchList(context);
+    const issueStatuses = await list(context);
     expect(issueStatuses).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     "if got 200, should return issue statuses with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const issueStatuses = await fetchList(context);
+      const issueStatuses = await list(context);
       expect(issueStatuses.length).toStrictEqual(3);
       expect(issueStatuses[0]).toStrictEqual({
         id: 1,
@@ -37,7 +37,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/issue-statuses/list.ts
+++ b/issue-statuses/list.ts
@@ -11,7 +11,7 @@ import { listIssueStatusResponse } from "./validator.ts";
  * @param context REST endpoint context
  * @return Array of IssueStatus
  */
-export async function fetchList(context: Context): Promise<IssueStatus[]> {
+export async function list(context: Context): Promise<IssueStatus[]> {
   const endpoint = buildUrl(context.endpoint, "issue_statuses.json");
   const response = await fetch(
     endpoint,

--- a/issue-statuses/mod.ts
+++ b/issue-statuses/mod.ts
@@ -1,5 +1,5 @@
 import { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 
 export class Client {
   readonly #context: Context;
@@ -11,7 +11,7 @@ export class Client {
   /**
    * Return the list of issue statuses
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 }

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -1,4 +1,4 @@
-import { listIssues } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
@@ -11,7 +11,7 @@ server.listen();
 Deno.test("GET /issues.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const issues = await listIssues(context);
+    const issues = await list(context);
     expect(issues).toBeDefined();
   });
 
@@ -19,7 +19,7 @@ Deno.test("GET /issues.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(listIssues(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });
@@ -78,14 +78,14 @@ function pagingHandler(
   });
 }
 
-Deno.test("listIssues limit option", async (t) => {
+Deno.test("list limit option", async (t) => {
   await t.step(
     "returns at most `limit` issues with a single page request when limit <= page size",
     async () => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      const issues = await listIssues(context, { limit: 1 });
+      const issues = await list(context, { limit: 1 });
 
       expect(issues.length).toStrictEqual(1);
       expect(requests.length).toStrictEqual(1);
@@ -99,7 +99,7 @@ Deno.test("listIssues limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(300, requests));
 
-      const issues = await listIssues(context, { limit: 150 });
+      const issues = await list(context, { limit: 150 });
 
       expect(issues.length).toStrictEqual(150);
       expect(requests).toStrictEqual([
@@ -115,7 +115,7 @@ Deno.test("listIssues limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(150, requests));
 
-      const issues = await listIssues(context, {});
+      const issues = await list(context, {});
 
       expect(issues.length).toStrictEqual(150);
       expect(requests).toStrictEqual([
@@ -131,7 +131,7 @@ Deno.test("listIssues limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(listIssues(context, { limit: 1.5 })).rejects.toThrow();
+      await expect(list(context, { limit: 1.5 })).rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );
@@ -142,7 +142,7 @@ Deno.test("listIssues limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(listIssues(context, { limit: -1 })).rejects.toThrow();
+      await expect(list(context, { limit: -1 })).rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );
@@ -153,7 +153,7 @@ Deno.test("listIssues limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(listIssues(context, { limit: 0 })).rejects.toThrow();
+      await expect(list(context, { limit: 0 })).rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );

--- a/issues/list.ts
+++ b/issues/list.ts
@@ -8,7 +8,7 @@ import { listResponse, toListOption } from "./validator.ts";
 
 const pageSize = 100;
 
-export async function listIssues(
+export async function list(
   context: Context,
   option: Partial<ListIssueQuery> = {},
 ): Promise<Issue[]> {

--- a/issues/mod.ts
+++ b/issues/mod.ts
@@ -4,7 +4,7 @@ import type {
   ListIssueQuery,
   UpdateIssueQuery,
 } from "./type.ts";
-import { listIssues } from "./list.ts";
+import { list } from "./list.ts";
 import { type Include, show } from "./show.ts";
 import { update } from "./update.ts";
 import { createIssue } from "./create.ts";
@@ -24,8 +24,8 @@ export class Client {
    *
    * @param option The query option
    */
-  list(option: Partial<ListIssueQuery>): ReturnType<typeof listIssues> {
-    return listIssues(this.#context, option);
+  list(option: Partial<ListIssueQuery>): ReturnType<typeof list> {
+    return list(this.#context, option);
   }
 
   /**

--- a/memberships/list.test.ts
+++ b/memberships/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const memberships = await fetchList(context, 1);
+    const memberships = await list(context, 1);
     expect(memberships).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     "if got 200, should return memberships with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const memberships = await fetchList(context, 1);
+      const memberships = await list(context, 1);
       expect(memberships[0].user).toStrictEqual({
         id: 17,
         name: "David Robert",
@@ -35,13 +35,13 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(fetchList(context, 422)).rejects.toThrow();
+      await expect(list(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(fetchList(context, 404)).rejects.toThrow();
+    await expect(list(context, 404)).rejects.toThrow();
   });
 
   await t.step(
@@ -68,7 +68,7 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
           },
         ),
       );
-      const memberships = await fetchList(context, 1);
+      const memberships = await list(context, 1);
       expect(memberships.length).toStrictEqual(total);
       expect(memberships[0].id).toStrictEqual(1);
       expect(memberships[total - 1].id).toStrictEqual(total);

--- a/memberships/list.ts
+++ b/memberships/list.ts
@@ -22,7 +22,7 @@ const pageSize = 100;
  * @param projectId Project identifier
  * @returns Memberships
  */
-export async function fetchList(
+export async function list(
   context: Context,
   projectId: number,
 ): Promise<Membership[]> {

--- a/memberships/mod.ts
+++ b/memberships/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { CreateMembershipQuery, UpdateMembershipQuery } from "./type.ts";
@@ -18,8 +18,8 @@ export class Client {
    *
    * @param projectId Project identifier
    */
-  list(projectId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, projectId);
+  list(projectId: number): ReturnType<typeof list> {
+    return list(this.#context, projectId);
   }
 
   /**

--- a/news/list-by-project.test.ts
+++ b/news/list-by-project.test.ts
@@ -1,4 +1,4 @@
-import { fetchListByProject } from "./list-by-project.ts";
+import { listByProject } from "./list-by-project.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/news.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const news = await fetchListByProject(context, 1);
+    const news = await listByProject(context, 1);
     expect(news).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     "if got 200, should return news with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const news = await fetchListByProject(context, 1);
+      const news = await listByProject(context, 1);
       expect(news.length).toStrictEqual(2);
       expect(news[0]).toStrictEqual({
         id: 1,
@@ -35,12 +35,12 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(fetchListByProject(context, 422)).rejects.toThrow();
+      await expect(listByProject(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(fetchListByProject(context, 404)).rejects.toThrow();
+    await expect(listByProject(context, 404)).rejects.toThrow();
   });
 });

--- a/news/list-by-project.ts
+++ b/news/list-by-project.ts
@@ -12,7 +12,7 @@ import { listNewsResponse } from "./validator.ts";
  * @param projectId Project identifier
  * @return Array of News
  */
-export async function fetchListByProject(
+export async function listByProject(
   context: Context,
   projectId: number,
 ): Promise<News[]> {

--- a/news/list.test.ts
+++ b/news/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /news.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const news = await fetchList(context);
+    const news = await list(context);
     expect(news).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /news.json", async (t) => {
     "if got 200, should return news with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const news = await fetchList(context);
+      const news = await list(context);
       expect(news.length).toStrictEqual(2);
       expect(news[0]).toStrictEqual({
         id: 1,
@@ -36,7 +36,7 @@ Deno.test("GET /news.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/news/list.ts
+++ b/news/list.ts
@@ -11,7 +11,7 @@ import { listNewsResponse } from "./validator.ts";
  * @param context REST endpoint context
  * @return Array of News
  */
-export async function fetchList(context: Context): Promise<News[]> {
+export async function list(context: Context): Promise<News[]> {
   const endpoint = buildUrl(context.endpoint, "news.json");
   const response = await fetch(
     endpoint,

--- a/news/mod.ts
+++ b/news/mod.ts
@@ -1,6 +1,6 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
-import { fetchListByProject } from "./list-by-project.ts";
+import { list } from "./list.ts";
+import { listByProject } from "./list-by-project.ts";
 import { type Include, show } from "./show.ts";
 import { create } from "./create.ts";
 import { update } from "./update.ts";
@@ -17,8 +17,8 @@ export class Client {
   /**
    * Return the list of news across all projects
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 
   /**
@@ -26,8 +26,8 @@ export class Client {
    *
    * @param projectId Project identifier
    */
-  listByProject(projectId: number): ReturnType<typeof fetchListByProject> {
-    return fetchListByProject(this.#context, projectId);
+  listByProject(projectId: number): ReturnType<typeof listByProject> {
+    return listByProject(this.#context, projectId);
   }
 
   /**

--- a/projects/list.test.ts
+++ b/projects/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await fetchList(context);
+    const r = await list(context);
     expect(r).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /projects.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(fetchList(c)).rejects.toThrow();
+      await expect(list(c)).rejects.toThrow();
     },
   );
 });

--- a/projects/list.ts
+++ b/projects/list.ts
@@ -13,7 +13,7 @@ const responseSchema = object({
   limit: number(),
 });
 
-export async function fetchList(context: Context): Promise<Project[]> {
+export async function list(context: Context): Promise<Project[]> {
   return await fetchAllPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "projects.json");
     endpoint.search = new URLSearchParams({

--- a/projects/mod.ts
+++ b/projects/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { ProjectQuery } from "./type.ts";
@@ -19,8 +19,8 @@ export class Client {
    * Returns all projects
    * This includes all public projects and private projects where user have access to.
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 
   /**

--- a/queries/list.test.ts
+++ b/queries/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /queries.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const queries = await fetchList(context);
+    const queries = await list(context);
     expect(queries).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /queries.json", async (t) => {
     "if got 200, should return queries with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const queries = await fetchList(context);
+      const queries = await list(context);
       expect(queries.length).toStrictEqual(3);
       expect(queries[0]).toStrictEqual({
         id: 1,
@@ -39,7 +39,7 @@ Deno.test("GET /queries.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/queries/list.ts
+++ b/queries/list.ts
@@ -11,7 +11,7 @@ import { listQueryResponse } from "./validator.ts";
  * @param context REST endpoint context
  * @return Array of Query
  */
-export async function fetchList(context: Context): Promise<Query[]> {
+export async function list(context: Context): Promise<Query[]> {
   const endpoint = buildUrl(context.endpoint, "queries.json");
   const response = await fetch(
     endpoint,

--- a/queries/mod.ts
+++ b/queries/mod.ts
@@ -1,5 +1,5 @@
 import { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 
 export class Client {
   readonly #context: Context;
@@ -11,7 +11,7 @@ export class Client {
   /**
    * Return the list of queries
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 }

--- a/roles/list.test.ts
+++ b/roles/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /roles.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const roles = await fetchList(context);
+    const roles = await list(context);
     expect(roles).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /roles.json", async (t) => {
     "if got 200, should return roles with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const roles = await fetchList(context);
+      const roles = await list(context);
       expect(roles.length).toStrictEqual(2);
       expect(roles[0]).toStrictEqual({ id: 1, name: "Manager" });
       expect(roles[1]).toStrictEqual({ id: 2, name: "Developer" });
@@ -28,7 +28,7 @@ Deno.test("GET /roles.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(fetchList(context)).rejects.toThrow();
+      await expect(list(context)).rejects.toThrow();
     },
   );
 });

--- a/roles/list.ts
+++ b/roles/list.ts
@@ -12,7 +12,7 @@ import { assertResponse } from "../error.ts";
  * @param context REST endpoint context
  * @returns Array of role id/name pairs
  */
-export async function fetchList(context: Context): Promise<IdName[]> {
+export async function list(context: Context): Promise<IdName[]> {
   const url = buildUrl(context.endpoint, "roles.json");
   const response = await fetch(url, {
     method: "GET",

--- a/roles/mod.ts
+++ b/roles/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 
 export class Client {
@@ -12,8 +12,8 @@ export class Client {
   /**
    * Returns all roles.
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 
   /**

--- a/time-entries/list.test.ts
+++ b/time-entries/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { http, HttpResponse } from "npm:msw@2.15.0";
 import { setupServer } from "npm:msw@2.15.0/node";
@@ -10,8 +10,8 @@ server.listen();
 Deno.test("GET /time_entries.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const list = await fetchList(context);
-    expect(list).toBeDefined();
+    const entries = await list(context);
+    expect(entries).toBeDefined();
   });
 
   await t.step(
@@ -19,19 +19,19 @@ Deno.test("GET /time_entries.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(fetchList(c)).rejects.toThrow();
+      await expect(list(c)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
-    await expect(fetchList(c)).rejects.toThrow();
+    await expect(list(c)).rejects.toThrow();
   });
 
   await t.step("should map camelCase fields from the response", async () => {
     server.use(...validHandlers);
-    const entries = await fetchList(context);
+    const entries = await list(context);
     const entry = entries.find((timeEntry) => timeEntry.id === 3);
     expect(entry).toBeDefined();
     expect(entry!.project).toStrictEqual({ id: 1, name: "Demo" });
@@ -60,7 +60,7 @@ Deno.test("GET /time_entries.json", async (t) => {
           });
         }),
       );
-      await fetchList(context, {
+      await list(context, {
         projectId: 1,
         userId: 2,
         spentOn: new Date("2026-07-01"),
@@ -90,7 +90,7 @@ Deno.test("GET /time_entries.json", async (t) => {
           });
         }),
       );
-      await fetchList(context, { projectId: undefined });
+      await list(context, { projectId: undefined });
       expect(captured?.has("project_id")).toStrictEqual(false);
       expect(!captured?.toString().includes("undefined")).toBe(true);
     },

--- a/time-entries/list.ts
+++ b/time-entries/list.ts
@@ -21,7 +21,7 @@ const responseSchema = object({
  * @param filter Optional filters (projectId, spentOn, userId, from, to)
  * @returns Time entries
  */
-export async function fetchList(
+export async function list(
   context: Context,
   filter: Partial<ListTimeEntryQuery> = {},
 ): Promise<TimeEntry[]> {

--- a/time-entries/mod.ts
+++ b/time-entries/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type {
@@ -22,8 +22,8 @@ export class Client {
    *
    * @param filter Optional filters (projectId, spentOn, userId, from, to)
    */
-  list(filter?: Partial<ListTimeEntryQuery>): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, filter);
+  list(filter?: Partial<ListTimeEntryQuery>): ReturnType<typeof list> {
+    return list(this.#context, filter);
   }
 
   /**

--- a/time-entries/validator.ts
+++ b/time-entries/validator.ts
@@ -69,7 +69,7 @@ export const toUpdateTimeEntryQuery = pipe(
 );
 
 // The filter values are serialized to strings here (rather than left as
-// number/Date) because URLSearchParams only accepts strings, and fetchList
+// number/Date) because URLSearchParams only accepts strings, and list
 // spreads this object directly into the query string alongside limit/offset.
 export const toListTimeEntryQuery = pipe(
   partial(object({

--- a/trackers/list.ts
+++ b/trackers/list.ts
@@ -11,7 +11,7 @@ import { listTrackerResponse } from "./validator.ts";
  * @param context REST endpoint context
  * @return Array of Tracker
  */
-export async function fetchList(context: Context): Promise<Tracker[]> {
+export async function list(context: Context): Promise<Tracker[]> {
   const endpoint = buildUrl(context.endpoint, "trackers.json");
   const response = await fetch(
     endpoint,

--- a/trackers/mod.ts
+++ b/trackers/mod.ts
@@ -1,5 +1,5 @@
 import { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 
 export class Client {
   readonly #context: Context;
@@ -11,7 +11,7 @@ export class Client {
   /**
    * Return the list of trackers
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 }

--- a/users/list.test.ts
+++ b/users/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /users.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const users = await fetchList(context);
+    const users = await list(context);
     expect(users).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /users.json", async (t) => {
     "if got 200, should return users with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const users = await fetchList(context);
+      const users = await list(context);
       expect(users.length).toStrictEqual(2);
       expect(users[1].login).toStrictEqual("admin");
       expect(users[1].admin).toStrictEqual(true);
@@ -33,13 +33,13 @@ Deno.test("GET /users.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(fetchList(c)).rejects.toThrow();
+      await expect(list(c)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
-    await expect(fetchList(c)).rejects.toThrow();
+    await expect(list(c)).rejects.toThrow();
   });
 });

--- a/users/list.ts
+++ b/users/list.ts
@@ -20,7 +20,7 @@ const responseSchema = object({
  * @param context REST endpoint context
  * @returns Users
  */
-export async function fetchList(context: Context): Promise<User[]> {
+export async function list(context: Context): Promise<User[]> {
   return await fetchAllPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "users.json");
     endpoint.search = new URLSearchParams({

--- a/users/mod.ts
+++ b/users/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { CreateUserQuery, UpdateUserQuery } from "./type.ts";
@@ -16,8 +16,8 @@ export class Client {
   /**
    * Returns all users.
    */
-  list(): ReturnType<typeof fetchList> {
-    return fetchList(this.#context);
+  list(): ReturnType<typeof list> {
+    return list(this.#context);
   }
 
   /**

--- a/versions/list.test.ts
+++ b/versions/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { context, invalidHandlers, validHandlers } from "./_mock.ts";
 import { setupServer } from "npm:msw@2.15.0/node";
 import { expect } from "jsr:@std/expect@1.0.20";
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/versions.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const versions = await fetchList(context, 1);
+    const versions = await list(context, 1);
     expect(versions).toBeDefined();
   });
 
@@ -17,12 +17,12 @@ Deno.test("GET /projects/:project_id/versions.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(fetchList(context, 422)).rejects.toThrow();
+      await expect(list(context, 422)).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(fetchList(context, 404)).rejects.toThrow();
+    await expect(list(context, 404)).rejects.toThrow();
   });
 });

--- a/versions/list.ts
+++ b/versions/list.ts
@@ -17,7 +17,7 @@ const responseSchema = object({
  * @param projectId Project identifier
  * @returns Versions
  */
-export async function fetchList(
+export async function list(
   context: Context,
   projectId: number,
 ): Promise<Version[]> {

--- a/versions/mod.ts
+++ b/versions/mod.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show } from "./show.ts";
 import { create } from "./create.ts";
 import type { CreateVersionQuery, UpdateVersionQuery } from "./type.ts";
@@ -18,8 +18,8 @@ export class Client {
    *
    * @param projectId Project identifier
    */
-  list(projectId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, projectId);
+  list(projectId: number): ReturnType<typeof list> {
+    return list(this.#context, projectId);
   }
 
   /**

--- a/wiki-pages/list.test.ts
+++ b/wiki-pages/list.test.ts
@@ -1,4 +1,4 @@
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { expect } from "jsr:@std/expect@1.0.20";
 
 import {
@@ -14,12 +14,12 @@ server.listen();
 Deno.test("GET /projects/:id/wiki/index.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validResponseHandlers);
-    const wikis = await fetchList(context, 1);
+    const wikis = await list(context, 1);
     expect(wikis.length).toBe(2);
   });
   await t.step("If got 422, should throw", async () => {
     server.resetHandlers(...invalidResponseHandlers);
-    await expect(fetchList(context, 2)).rejects.toThrow(
+    await expect(list(context, 2)).rejects.toThrow(
       "Unprocessable Entity",
     );
   });

--- a/wiki-pages/list.ts
+++ b/wiki-pages/list.ts
@@ -13,7 +13,7 @@ import { wikis } from "./validator.ts";
  * @param projectId Project identifier
  * @returns Wiki pages
  */
-export async function fetchList(
+export async function list(
   context: Context,
   projectId: number,
 ): Promise<Wiki[]> {

--- a/wiki-pages/mod.ts
+++ b/wiki-pages/mod.ts
@@ -1,6 +1,6 @@
 import type { Context } from "../context.ts";
 import type { WikiContent } from "./type.ts";
-import { fetchList } from "./list.ts";
+import { list } from "./list.ts";
 import { show, type ShowWikiPageParams } from "./show.ts";
 import { update } from "./update.ts";
 import { create } from "./create.ts";
@@ -18,8 +18,8 @@ export class Client {
    * @param projectId The project ID
    * @returns Wiki pages
    */
-  list(projectId: number): ReturnType<typeof fetchList> {
-    return fetchList(this.#context, projectId);
+  list(projectId: number): ReturnType<typeof list> {
+    return list(this.#context, projectId);
   }
 
   /**


### PR DESCRIPTION
## Summary

Rename the exported list functions to `list`, and news' `fetchListByProject` to `listByProject`.

## Details

The free functions were split between `fetchList`, `listIssues`, and `list` while the Client methods already exposed them uniformly as `list`, so aligning them removes the naming seam before their return type changes shape in the next PR.

## Confirmation

Ran `nix run .#check-deno`; format, lint, type check, and 109 tests passed with 0 failures.

## Limitation

The enumerations functions keep their per-resource names because they are three distinct resources in one module, and `search` keeps its name.

The e2e suite was not executed; its call sites are covered by the type check only.

BREAKING CHANGE: `fetchList` and `listIssues` are renamed to `list`, and `fetchListByProject` to `listByProject`. Update imports accordingly, e.g. `import { list } from "@omochice/redmine/issues/list"`.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85