### PR TITLE
feat!: return AsyncGenerator from list functions

### DIFF
--- a/custom-fields/list.test.ts
+++ b/custom-fields/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /custom_fields.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const customFields = await list(context);
+    const customFields = await Array.fromAsync(list(context));
     expect(customFields).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
     "if got 200, should return custom fields with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const customFields = await list(context);
+      const customFields = await Array.fromAsync(list(context));
       expect(customFields.length).toStrictEqual(3);
       expect(customFields[0]).toStrictEqual({
         id: 1,
@@ -67,7 +67,7 @@ Deno.test("GET /custom_fields.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/custom-fields/list.ts
+++ b/custom-fields/list.ts
@@ -11,9 +11,9 @@ import { listCustomFieldResponse } from "./validator.ts";
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @return Array of CustomField
+ * @return Yields each CustomField
  */
-export async function list(context: Context): Promise<CustomField[]> {
+export async function* list(context: Context): AsyncGenerator<CustomField> {
   const endpoint = buildUrl(context.endpoint, "custom_fields.json");
   const response = await fetch(
     endpoint,
@@ -26,5 +26,5 @@ export async function list(context: Context): Promise<CustomField[]> {
     },
   );
   await assertResponse(response);
-  return parse(listCustomFieldResponse, await response.json()).custom_fields;
+  yield* parse(listCustomFieldResponse, await response.json()).custom_fields;
 }

--- a/e2e/custom-fields.test.ts
+++ b/e2e/custom-fields.test.ts
@@ -6,7 +6,7 @@ Deno.test("E2E: Custom Fields API", async (t) => {
   await t.step(
     "GET /custom_fields.json should return an array of custom fields",
     async () => {
-      const customFields = await list(e2eContext);
+      const customFields = await Array.fromAsync(list(e2eContext));
       expect(Array.isArray(customFields)).toBe(true);
       // e2e/setup.ts seeds an "E2E CF" issue custom field, so the list is
       // non-empty and contains it.

--- a/e2e/enumerations.test.ts
+++ b/e2e/enumerations.test.ts
@@ -13,7 +13,9 @@ Deno.test("E2E: Enumerations API", async (t) => {
   await t.step(
     "GET /enumerations/issue_priorities.json should return an array",
     async () => {
-      const priorities = await listIssuePriorities(e2eContext);
+      const priorities = await Array.fromAsync(
+        listIssuePriorities(e2eContext),
+      );
       expect(Array.isArray(priorities)).toBe(true);
     },
   );
@@ -21,7 +23,9 @@ Deno.test("E2E: Enumerations API", async (t) => {
   await t.step(
     "GET /enumerations/time_entry_activities.json should return an array",
     async () => {
-      const activities = await listTimeEntryActivities(e2eContext);
+      const activities = await Array.fromAsync(
+        listTimeEntryActivities(e2eContext),
+      );
       expect(Array.isArray(activities)).toBe(true);
     },
   );
@@ -29,7 +33,9 @@ Deno.test("E2E: Enumerations API", async (t) => {
   await t.step(
     "GET /enumerations/document_categories.json should return an array",
     async () => {
-      const categories = await listDocumentCategories(e2eContext);
+      const categories = await Array.fromAsync(
+        listDocumentCategories(e2eContext),
+      );
       expect(Array.isArray(categories)).toBe(true);
     },
   );

--- a/e2e/files.test.ts
+++ b/e2e/files.test.ts
@@ -8,7 +8,7 @@ import { list as listProjects } from "../projects/list.ts";
 Deno.test({
   name: "E2E: Files API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
@@ -41,7 +41,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/files.json should return files",
       async () => {
-        const files = await list(e2eContext, project!.id);
+        const files = await Array.fromAsync(list(e2eContext, project!.id));
         const created = files.find((f) => f.filename === filename);
         expect(created).toBeDefined();
       },

--- a/e2e/groups.test.ts
+++ b/e2e/groups.test.ts
@@ -38,7 +38,7 @@ Deno.test({
 
     let groupId: number | undefined;
     await t.step("GET /groups.json should list the created group", async () => {
-      const groups = await list(e2eContext);
+      const groups = await Array.fromAsync(list(e2eContext));
       const created = groups.find((g) => g.name === groupName);
       expect(created).toBeDefined();
       groupId = created!.id;

--- a/e2e/issue-categories.test.ts
+++ b/e2e/issue-categories.test.ts
@@ -10,7 +10,7 @@ import { list as listProjects } from "../projects/list.ts";
 Deno.test({
   name: "E2E: Issue Categories API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
@@ -26,7 +26,9 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/issue_categories.json should return issue categories",
       async () => {
-        const categories = await list(e2eContext, project!.id);
+        const categories = await Array.fromAsync(
+          list(e2eContext, project!.id),
+        );
         expect(categories.length).toBeGreaterThan(0);
         const created = categories.find((c) =>
           c.name === "E2E Created Category"
@@ -38,7 +40,9 @@ Deno.test({
     await t.step(
       "GET /issue_categories/:id.json should return an issue category",
       async () => {
-        const categories = await list(e2eContext, project!.id);
+        const categories = await Array.fromAsync(
+          list(e2eContext, project!.id),
+        );
         const category = categories.find((c) =>
           c.name === "E2E Created Category"
         );
@@ -56,7 +60,9 @@ Deno.test({
     await t.step(
       "PUT /issue_categories/:id.json should update an issue category",
       async () => {
-        const categories = await list(e2eContext, project!.id);
+        const categories = await Array.fromAsync(
+          list(e2eContext, project!.id),
+        );
         const category = categories.find((c) =>
           c.name === "E2E Created Category"
         );
@@ -76,7 +82,9 @@ Deno.test({
     await t.step(
       "DELETE /issue_categories/:id.json should delete an issue category",
       async () => {
-        const categories = await list(e2eContext, project!.id);
+        const categories = await Array.fromAsync(
+          list(e2eContext, project!.id),
+        );
         const category = categories.find((c) =>
           c.name === "E2E Updated Category"
         );

--- a/e2e/issue-relations.test.ts
+++ b/e2e/issue-relations.test.ts
@@ -10,13 +10,13 @@ import { list as listProjects } from "../projects/list.ts";
 Deno.test({
   name: "E2E: Issue Relations API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await listIssues(e2eContext, {
+    const issues = await Array.fromAsync(listIssues(e2eContext, {
       projectId: project!.id,
-    });
+    }));
     expect(issues.length).toBeGreaterThan(0);
     const firstIssue = issues[0];
 
@@ -63,7 +63,9 @@ Deno.test({
     await t.step(
       "GET /issues/:issue_id/relations.json should return relations",
       async () => {
-        const relations = await list(e2eContext, firstIssue.id);
+        const relations = await Array.fromAsync(
+          list(e2eContext, firstIssue.id),
+        );
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
@@ -75,7 +77,9 @@ Deno.test({
     await t.step(
       "GET /relations/:id.json should return a relation",
       async () => {
-        const relations = await list(e2eContext, firstIssue.id);
+        const relations = await Array.fromAsync(
+          list(e2eContext, firstIssue.id),
+        );
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );
@@ -92,7 +96,9 @@ Deno.test({
     await t.step(
       "DELETE /relations/:id.json should delete a relation",
       async () => {
-        const relations = await list(e2eContext, firstIssue.id);
+        const relations = await Array.fromAsync(
+          list(e2eContext, firstIssue.id),
+        );
         const relation = relations.find((r) =>
           r.issueToId === targetIssueId && r.relationType === "relates"
         );

--- a/e2e/issue-statuses.test.ts
+++ b/e2e/issue-statuses.test.ts
@@ -6,7 +6,7 @@ Deno.test("E2E: Issue Statuses API", async (t) => {
   await t.step(
     "GET /issue_statuses.json should return default issue statuses",
     async () => {
-      const statuses = await list(e2eContext);
+      const statuses = await Array.fromAsync(list(e2eContext));
       expect(
         statuses.length,
         "Redmine should have default issue statuses",

--- a/e2e/issue-watchers.test.ts
+++ b/e2e/issue-watchers.test.ts
@@ -22,7 +22,7 @@ async function fetchCurrentUserId(): Promise<number | undefined> {
 Deno.test({
   name: "E2E: Issue watchers API",
   fn: async (t) => {
-    const issues = await list(e2eContext, { limit: 1 });
+    const issues = await Array.fromAsync(list(e2eContext, { limit: 1 }));
     const issue = issues[0];
     if (issue === undefined) {
       // Nothing to watch when the seeded project holds no issues.

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -11,12 +11,12 @@ Deno.test({
   name: "E2E: Issues API",
   fn: async (t) => {
     await t.step("GET /issues.json should return issues", async () => {
-      const issues = await list(e2eContext, {});
+      const issues = await Array.fromAsync(list(e2eContext, {}));
       expect(issues.length).toBeGreaterThan(0);
     });
 
     await t.step("GET /issues/:id.json should return an issue", async () => {
-      const issues = await list(e2eContext, {});
+      const issues = await Array.fromAsync(list(e2eContext, {}));
       expect(issues.length).toBeGreaterThan(0);
       const issueId = issues[0].id;
 
@@ -29,13 +29,13 @@ Deno.test({
     });
 
     await t.step("POST /issues.json should create an issue", async () => {
-      const projects = await listProjects(e2eContext);
+      const projects = await Array.fromAsync(listProjects(e2eContext));
       const project = projects.find((p) => p.identifier === "e2e-test-project");
       expect(project).toBeDefined();
 
-      const issues = await list(e2eContext, {
+      const issues = await Array.fromAsync(list(e2eContext, {
         projectId: project!.id,
-      });
+      }));
       expect(issues.length).toBeGreaterThan(0);
 
       await createIssue(e2eContext, {
@@ -67,15 +67,15 @@ Deno.test({
         );
         expect(customField).toBeDefined();
 
-        const projects = await listProjects(e2eContext);
+        const projects = await Array.fromAsync(listProjects(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );
         expect(project).toBeDefined();
 
-        const issues = await list(e2eContext, {
+        const issues = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         expect(issues.length).toBeGreaterThan(0);
 
         const subject = "E2E Issue With Custom Field";
@@ -88,9 +88,9 @@ Deno.test({
           customFields: [{ id: customField!.id, value: "e2e custom value" }],
         });
 
-        const listAfter = await list(e2eContext, {
+        const listAfter = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         const created = listAfter.find((i) => i.subject === subject);
         expect(created).toBeDefined();
 
@@ -104,7 +104,7 @@ Deno.test({
     );
 
     await t.step("PUT /issues/:id.json should update an issue", async () => {
-      const issues = await list(e2eContext, {});
+      const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Created Issue");
       expect(issue).toBeDefined();
 
@@ -129,15 +129,15 @@ Deno.test({
     await t.step(
       "GET /issues.json with limit: 1 should return exactly one issue",
       async () => {
-        const projects = await listProjects(e2eContext);
+        const projects = await Array.fromAsync(listProjects(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );
         expect(project).toBeDefined();
 
-        const issues = await list(e2eContext, {
+        const issues = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         expect(issues.length).toBeGreaterThan(0);
 
         // Ensure at least two issues exist on the server so that a
@@ -156,12 +156,14 @@ Deno.test({
         // Cleanup looks the issue up by subject because createIssue does
         // not return the created id.
         try {
-          const limited = await list(e2eContext, { limit: 1 });
+          const limited = await Array.fromAsync(
+            list(e2eContext, { limit: 1 }),
+          );
           expect(limited.length).toStrictEqual(1);
         } finally {
-          const cleanupList = await list(e2eContext, {
+          const cleanupList = await Array.fromAsync(list(e2eContext, {
             projectId: project!.id,
-          });
+          }));
           // Delete every match, not just one: runs that predate this
           // cleanup left issues with the same subject behind.
           const leftovers = cleanupList.filter((i) => i.subject === subject);
@@ -173,7 +175,7 @@ Deno.test({
     );
 
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
-      const issues = await list(e2eContext, {});
+      const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");
       expect(issue).toBeDefined();
 

--- a/e2e/journals.test.ts
+++ b/e2e/journals.test.ts
@@ -18,15 +18,15 @@ Deno.test({
     await t.step(
       "POST /issues.json should create an issue to attach a journal to",
       async () => {
-        const projects = await listProjects(e2eContext);
+        const projects = await Array.fromAsync(listProjects(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-test-project"
         );
         expect(project).toBeDefined();
 
-        const issues = await list(e2eContext, {
+        const issues = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         expect(issues.length).toBeGreaterThan(0);
 
         await createIssue(e2eContext, {
@@ -39,9 +39,9 @@ Deno.test({
 
         // createIssue does not return the created id, so it is looked up
         // by subject, mirroring the pattern in e2e/issues.test.ts.
-        const listAfter = await list(e2eContext, {
+        const listAfter = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         const createdIssue = listAfter.find((i) => i.subject === subject);
         expect(createdIssue).toBeDefined();
         issueId = createdIssue!.id;

--- a/e2e/memberships.test.ts
+++ b/e2e/memberships.test.ts
@@ -43,7 +43,7 @@ async function fetchFirstRoleId(): Promise<number | undefined> {
 Deno.test({
   name: "E2E: Memberships API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
@@ -73,7 +73,9 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/memberships.json should return memberships",
       async () => {
-        const memberships = await list(e2eContext, project!.id);
+        const memberships = await Array.fromAsync(
+          list(e2eContext, project!.id),
+        );
         expect(memberships.length).toBeGreaterThan(0);
         const created = memberships.find((m) => m.user?.id === userId);
         expect(created).toBeDefined();

--- a/e2e/news.test.ts
+++ b/e2e/news.test.ts
@@ -11,12 +11,12 @@ import { list as listProjects } from "../projects/list.ts";
 Deno.test({
   name: "E2E: News API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
     await t.step("GET /news.json should return the seeded news", async () => {
-      const news = await list(e2eContext);
+      const news = await Array.fromAsync(list(e2eContext));
       const seeded = news.find((n) => n.title === "E2E News");
       expect(seeded).toBeDefined();
       expect(seeded!.summary).toStrictEqual("E2E news summary");
@@ -29,7 +29,9 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/news.json should return the project news",
       async () => {
-        const news = await listByProject(e2eContext, project!.id);
+        const news = await Array.fromAsync(
+          listByProject(e2eContext, project!.id),
+        );
         const seeded = news.find((n) => n.title === "E2E News");
         expect(seeded).toBeDefined();
         // A news created without a summary is rendered as an empty string
@@ -54,7 +56,9 @@ Deno.test({
     );
 
     const findByTitle = async (title: string) => {
-      const news = await listByProject(e2eContext, project!.id);
+      const news = await Array.fromAsync(
+        listByProject(e2eContext, project!.id),
+      );
       return news.find((n) => n.title === title);
     };
 

--- a/e2e/projects.test.ts
+++ b/e2e/projects.test.ts
@@ -12,12 +12,12 @@ Deno.test({
   name: "E2E: Projects API",
   fn: async (t) => {
     await t.step("GET /projects.json should return projects", async () => {
-      const projects = await list(e2eContext);
+      const projects = await Array.fromAsync(list(e2eContext));
       expect(projects.length).toBeGreaterThan(0);
     });
 
     await t.step("GET /projects/:id.json should return a project", async () => {
-      const projects = await list(e2eContext);
+      const projects = await Array.fromAsync(list(e2eContext));
       expect(projects.length).toBeGreaterThan(0);
       const projectId = projects[0].id;
 
@@ -33,7 +33,7 @@ Deno.test({
     });
 
     await t.step("PUT /projects/:id.json should update a project", async () => {
-      const projects = await list(e2eContext);
+      const projects = await Array.fromAsync(list(e2eContext));
       const project = projects.find((p) =>
         p.identifier === "e2e-created-project"
       );
@@ -63,7 +63,7 @@ Deno.test({
         // an id from the try block: that id is unavailable exactly when the
         // lookup is the step that failed.
         try {
-          const projects = await list(e2eContext);
+          const projects = await Array.fromAsync(list(e2eContext));
           const created = projects.find((p) => p.identifier === identifier);
           expect(created).toBeDefined();
 
@@ -84,7 +84,7 @@ Deno.test({
           ).toStrictEqual(true);
         } finally {
           try {
-            const cleanupList = await list(e2eContext);
+            const cleanupList = await Array.fromAsync(list(e2eContext));
             const leftover = cleanupList.find((p) =>
               p.identifier === identifier
             );
@@ -102,7 +102,7 @@ Deno.test({
     await t.step(
       "PUT /projects/:id/archive.json should archive and unarchive",
       async () => {
-        const projects = await list(e2eContext);
+        const projects = await Array.fromAsync(list(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );
@@ -116,7 +116,7 @@ Deno.test({
     await t.step(
       "PUT /projects/:id/close.json should close and reopen",
       async () => {
-        const projects = await list(e2eContext);
+        const projects = await Array.fromAsync(list(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );
@@ -130,7 +130,7 @@ Deno.test({
     await t.step(
       "DELETE /projects/:id.json should delete a project",
       async () => {
-        const projects = await list(e2eContext);
+        const projects = await Array.fromAsync(list(e2eContext));
         const project = projects.find((p) =>
           p.identifier === "e2e-created-project"
         );

--- a/e2e/queries.test.ts
+++ b/e2e/queries.test.ts
@@ -6,7 +6,7 @@ Deno.test("E2E: Queries API", async (t) => {
   await t.step(
     "GET /queries.json should return the list of queries",
     async () => {
-      const queries = await list(e2eContext);
+      const queries = await Array.fromAsync(list(e2eContext));
       // Saved queries are user-created, so a freshly provisioned Redmine has
       // none; a successful parse already proves the response matches the
       // schema regardless of length.

--- a/e2e/roles.test.ts
+++ b/e2e/roles.test.ts
@@ -9,7 +9,7 @@ Deno.test({
     await t.step(
       "GET /roles.json should return a list of roles",
       async () => {
-        const roles = await list(e2eContext);
+        const roles = await Array.fromAsync(list(e2eContext));
         expect(Array.isArray(roles)).toBe(true);
       },
     );
@@ -17,7 +17,7 @@ Deno.test({
     await t.step(
       "GET /roles/:id.json should return a role",
       async () => {
-        const roles = await list(e2eContext);
+        const roles = await Array.fromAsync(list(e2eContext));
         const role = roles[0];
         // e2e/setup.ts seeds a role so this normally runs. A freshly
         // provisioned Redmine loads no default roles, so guard the listing

--- a/e2e/search.test.ts
+++ b/e2e/search.test.ts
@@ -10,7 +10,9 @@ Deno.test({
       async () => {
         // The result set may be empty depending on how far Redmine's indexing
         // has progressed, so only the response shape is asserted.
-        const results = await search(e2eContext, { q: "E2E" });
+        const results = await Array.fromAsync(
+          search(e2eContext, { q: "E2E" }),
+        );
         expect(Array.isArray(results)).toBe(true);
         for (const item of results) {
           expect(item.datetime).toBeInstanceOf(Date);

--- a/e2e/time-entries.test.ts
+++ b/e2e/time-entries.test.ts
@@ -11,13 +11,13 @@ import { list as listIssues } from "../issues/list.ts";
 Deno.test({
   name: "E2E: Time Entries API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
-    const issues = await listIssues(e2eContext, {
+    const issues = await Array.fromAsync(listIssues(e2eContext, {
       projectId: project!.id,
-    });
+    }));
     expect(issues.length).toBeGreaterThan(0);
     const issue = issues[0];
 
@@ -56,9 +56,9 @@ Deno.test({
     await t.step(
       "GET /time_entries.json?project_id=... should return time entries",
       async () => {
-        const timeEntries = await list(e2eContext, {
+        const timeEntries = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         expect(timeEntries.length).toBeGreaterThan(0);
         const created = timeEntries.find((e) =>
           e.comments === "E2E Created Time Entry"
@@ -70,9 +70,9 @@ Deno.test({
     await t.step(
       "GET /time_entries/:id.json should return a time entry",
       async () => {
-        const timeEntries = await list(e2eContext, {
+        const timeEntries = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         const timeEntry = timeEntries.find((e) =>
           e.comments === "E2E Created Time Entry"
         );
@@ -90,9 +90,9 @@ Deno.test({
     await t.step(
       "PUT /time_entries/:id.json should update a time entry",
       async () => {
-        const timeEntries = await list(e2eContext, {
+        const timeEntries = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         const timeEntry = timeEntries.find((e) =>
           e.comments === "E2E Created Time Entry"
         );
@@ -114,9 +114,9 @@ Deno.test({
     await t.step(
       "DELETE /time_entries/:id.json should delete a time entry",
       async () => {
-        const timeEntries = await list(e2eContext, {
+        const timeEntries = await Array.fromAsync(list(e2eContext, {
           projectId: project!.id,
-        });
+        }));
         const timeEntry = timeEntries.find((e) =>
           e.comments === "E2E Updated Time Entry"
         );

--- a/e2e/trackers.test.ts
+++ b/e2e/trackers.test.ts
@@ -6,7 +6,7 @@ Deno.test("E2E: Trackers API", async (t) => {
   await t.step(
     "GET /trackers.json should return default trackers",
     async () => {
-      const trackers = await list(e2eContext);
+      const trackers = await Array.fromAsync(list(e2eContext));
       expect(
         trackers.length,
         "Redmine should have default trackers",

--- a/e2e/users.test.ts
+++ b/e2e/users.test.ts
@@ -31,7 +31,7 @@ Deno.test({
     await t.step(
       "GET /users.json should return users",
       async () => {
-        const users = await list(e2eContext);
+        const users = await Array.fromAsync(list(e2eContext));
         expect(users.length).toBeGreaterThan(0);
         const created = users.find((u) => u.login === login);
         expect(created).toBeDefined();
@@ -39,7 +39,7 @@ Deno.test({
     );
 
     await t.step("GET /users/:id.json should return a user", async () => {
-      const users = await list(e2eContext);
+      const users = await Array.fromAsync(list(e2eContext));
       const user = users.find((u) => u.login === login);
       expect(user).toBeDefined();
 
@@ -52,7 +52,7 @@ Deno.test({
     });
 
     await t.step("PUT /users/:id.json should update a user", async () => {
-      const users = await list(e2eContext);
+      const users = await Array.fromAsync(list(e2eContext));
       const user = users.find((u) => u.login === login);
       expect(user).toBeDefined();
 
@@ -68,7 +68,7 @@ Deno.test({
     await t.step(
       "DELETE /users/:id.json should delete a user",
       async () => {
-        const users = await list(e2eContext);
+        const users = await Array.fromAsync(list(e2eContext));
         const user = users.find((u) => u.login === login);
         expect(user).toBeDefined();
 

--- a/e2e/versions.test.ts
+++ b/e2e/versions.test.ts
@@ -10,7 +10,7 @@ import { list as listProjects } from "../projects/list.ts";
 Deno.test({
   name: "E2E: Versions API",
   fn: async (t) => {
-    const projects = await listProjects(e2eContext);
+    const projects = await Array.fromAsync(listProjects(e2eContext));
     const project = projects.find((p) => p.identifier === "e2e-test-project");
     expect(project).toBeDefined();
 
@@ -30,7 +30,7 @@ Deno.test({
     await t.step(
       "GET /projects/:project_id/versions.json should return versions",
       async () => {
-        const versions = await list(e2eContext, project!.id);
+        const versions = await Array.fromAsync(list(e2eContext, project!.id));
         expect(versions.length).toBeGreaterThan(0);
         const created = versions.find((v) => v.name === "E2E Created Version");
         expect(created).toBeDefined();
@@ -38,7 +38,7 @@ Deno.test({
     );
 
     await t.step("GET /versions/:id.json should return a version", async () => {
-      const versions = await list(e2eContext, project!.id);
+      const versions = await Array.fromAsync(list(e2eContext, project!.id));
       const version = versions.find((v) => v.name === "E2E Created Version");
       expect(version).toBeDefined();
 
@@ -50,7 +50,7 @@ Deno.test({
     });
 
     await t.step("PUT /versions/:id.json should update a version", async () => {
-      const versions = await list(e2eContext, project!.id);
+      const versions = await Array.fromAsync(list(e2eContext, project!.id));
       const version = versions.find((v) => v.name === "E2E Created Version");
       expect(version).toBeDefined();
 
@@ -67,7 +67,7 @@ Deno.test({
     await t.step(
       "DELETE /versions/:id.json should delete a version",
       async () => {
-        const versions = await list(e2eContext, project!.id);
+        const versions = await Array.fromAsync(list(e2eContext, project!.id));
         const version = versions.find((v) => v.name === "E2E Updated Version");
         expect(version).toBeDefined();
 

--- a/e2e/wiki-pages.test.ts
+++ b/e2e/wiki-pages.test.ts
@@ -13,7 +13,7 @@ Deno.test({
     let projectId: number;
 
     await t.step("resolve test project", async () => {
-      const projects = await listProjects(e2eContext);
+      const projects = await Array.fromAsync(listProjects(e2eContext));
       const project = projects.find((p) => p.identifier === "e2e-test-project");
       expect(project).toBeDefined();
       projectId = project!.id;
@@ -22,7 +22,7 @@ Deno.test({
     await t.step(
       "GET /projects/:id/wiki/index.json should return wiki pages",
       async () => {
-        const pages = await list(e2eContext, projectId);
+        const pages = await Array.fromAsync(list(e2eContext, projectId));
         expect(pages.length).toBeGreaterThan(0);
       },
     );

--- a/enumerations/list-document-categories.test.ts
+++ b/enumerations/list-document-categories.test.ts
@@ -14,7 +14,7 @@ server.listen();
 Deno.test("GET /enumerations/document_categories.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const categories = await listDocumentCategories(context);
+    const categories = await Array.fromAsync(listDocumentCategories(context));
     expect(categories).toBeDefined();
   });
 
@@ -22,7 +22,9 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
     "if got 200, should return document categories with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const categories = await listDocumentCategories(context);
+      const categories = await Array.fromAsync(
+        listDocumentCategories(context),
+      );
       expect(categories.length).toStrictEqual(2);
       expect(categories[0]).toStrictEqual({
         id: 1,
@@ -37,12 +39,14 @@ Deno.test("GET /enumerations/document_categories.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(listDocumentCategories(context)).rejects.toThrow();
+      await expect(Array.fromAsync(listDocumentCategories(context))).rejects
+        .toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
-    await expect(listDocumentCategories(context)).rejects.toThrow();
+    await expect(Array.fromAsync(listDocumentCategories(context))).rejects
+      .toThrow();
   });
 });

--- a/enumerations/list-issue-priorities.test.ts
+++ b/enumerations/list-issue-priorities.test.ts
@@ -14,7 +14,7 @@ server.listen();
 Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const priorities = await listIssuePriorities(context);
+    const priorities = await Array.fromAsync(listIssuePriorities(context));
     expect(priorities).toBeDefined();
   });
 
@@ -22,7 +22,7 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
     "if got 200, should return issue priorities with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const priorities = await listIssuePriorities(context);
+      const priorities = await Array.fromAsync(listIssuePriorities(context));
       expect(priorities.length).toStrictEqual(3);
       expect(priorities[1]).toStrictEqual({
         id: 4,
@@ -37,12 +37,14 @@ Deno.test("GET /enumerations/issue_priorities.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(listIssuePriorities(context)).rejects.toThrow();
+      await expect(Array.fromAsync(listIssuePriorities(context))).rejects
+        .toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
-    await expect(listIssuePriorities(context)).rejects.toThrow();
+    await expect(Array.fromAsync(listIssuePriorities(context))).rejects
+      .toThrow();
   });
 });

--- a/enumerations/list-time-entry-activities.test.ts
+++ b/enumerations/list-time-entry-activities.test.ts
@@ -14,7 +14,9 @@ server.listen();
 Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const activities = await listTimeEntryActivities(context);
+    const activities = await Array.fromAsync(
+      listTimeEntryActivities(context),
+    );
     expect(activities).toBeDefined();
   });
 
@@ -22,7 +24,9 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
     "if got 200, should return time entry activities with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const activities = await listTimeEntryActivities(context);
+      const activities = await Array.fromAsync(
+        listTimeEntryActivities(context),
+      );
       expect(activities.length).toStrictEqual(2);
       expect(activities[1]).toStrictEqual({
         id: 9,
@@ -37,12 +41,14 @@ Deno.test("GET /enumerations/time_entry_activities.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(listTimeEntryActivities(context)).rejects.toThrow();
+      await expect(Array.fromAsync(listTimeEntryActivities(context))).rejects
+        .toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...notFoundHandlers);
-    await expect(listTimeEntryActivities(context)).rejects.toThrow();
+    await expect(Array.fromAsync(listTimeEntryActivities(context))).rejects
+      .toThrow();
   });
 });

--- a/enumerations/list.ts
+++ b/enumerations/list.ts
@@ -35,37 +35,37 @@ async function fetchEnumerations(
  * Fetch issue priorities
  *
  * @param context REST endpoint context
- * @return Array of Enumeration
+ * @return Yields each Enumeration
  */
-export async function listIssuePriorities(
+export async function* listIssuePriorities(
   context: Context,
-): Promise<Enumeration[]> {
+): AsyncGenerator<Enumeration> {
   const body = await fetchEnumerations(context, "issue_priorities.json");
-  return parse(listIssuePriorityResponse, body).issue_priorities;
+  yield* parse(listIssuePriorityResponse, body).issue_priorities;
 }
 
 /**
  * Fetch time entry activities
  *
  * @param context REST endpoint context
- * @return Array of Enumeration
+ * @return Yields each Enumeration
  */
-export async function listTimeEntryActivities(
+export async function* listTimeEntryActivities(
   context: Context,
-): Promise<Enumeration[]> {
+): AsyncGenerator<Enumeration> {
   const body = await fetchEnumerations(context, "time_entry_activities.json");
-  return parse(listTimeEntryActivityResponse, body).time_entry_activities;
+  yield* parse(listTimeEntryActivityResponse, body).time_entry_activities;
 }
 
 /**
  * Fetch document categories
  *
  * @param context REST endpoint context
- * @return Array of Enumeration
+ * @return Yields each Enumeration
  */
-export async function listDocumentCategories(
+export async function* listDocumentCategories(
   context: Context,
-): Promise<Enumeration[]> {
+): AsyncGenerator<Enumeration> {
   const body = await fetchEnumerations(context, "document_categories.json");
-  return parse(listDocumentCategoryResponse, body).document_categories;
+  yield* parse(listDocumentCategoryResponse, body).document_categories;
 }

--- a/files/list.test.ts
+++ b/files/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/files.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const files = await list(context, 1);
+    const files = await Array.fromAsync(list(context, 1));
     expect(files).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     "if got 200, should return files with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const files = await list(context, 1);
+      const files = await Array.fromAsync(list(context, 1));
       expect(files.length).toStrictEqual(2);
       expect(files[0].contentType).toStrictEqual("application/zip");
       expect(files[0].contentUrl).toStrictEqual(
@@ -36,12 +36,12 @@ Deno.test("GET /projects/:project_id/files.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, 422))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
-    await expect(list(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(list(context, 404))).rejects.toThrow();
   });
 });

--- a/files/list.ts
+++ b/files/list.ts
@@ -15,12 +15,12 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @returns Files
+ * @returns Yields each ProjectFile
  */
-export async function list(
+export async function* list(
   context: Context,
   projectId: number,
-): Promise<ProjectFile[]> {
+): AsyncGenerator<ProjectFile> {
   const url = buildUrl(
     context.endpoint,
     "projects",
@@ -35,5 +35,5 @@ export async function list(
     },
   });
   await assertResponse(response);
-  return parse(responseSchema, await response.json()).files;
+  yield* parse(responseSchema, await response.json()).files;
 }

--- a/groups/list.test.ts
+++ b/groups/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /groups.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const r = await list(context);
+    const r = await Array.fromAsync(list(context));
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /groups.json", async (t) => {
     "if got 200, should return groups as id/name pairs",
     async () => {
       server.resetHandlers(...validHandlers);
-      const groups = await list(context);
+      const groups = await Array.fromAsync(list(context));
       expect(groups.length).toStrictEqual(2);
       expect(groups[0]).toStrictEqual({ id: 53, name: "Managers" });
       expect(groups[1]).toStrictEqual({
@@ -31,7 +31,7 @@ Deno.test("GET /groups.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/groups/list.ts
+++ b/groups/list.ts
@@ -14,9 +14,9 @@ const responseSchema = object({
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @returns Groups as id/name pairs
+ * @returns Yields each group as an id/name pair
  */
-export async function list(context: Context): Promise<IdName[]> {
+export async function* list(context: Context): AsyncGenerator<IdName> {
   const url = buildUrl(context.endpoint, "groups.json");
   const response = await fetch(url, {
     method: "GET",
@@ -26,5 +26,5 @@ export async function list(context: Context): Promise<IdName[]> {
     },
   });
   await assertResponse(response);
-  return parse(responseSchema, await response.json()).groups;
+  yield* parse(responseSchema, await response.json()).groups;
 }

--- a/internal/paging.test.ts
+++ b/internal/paging.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "jsr:@std/expect@1.0.20";
-import { fetchAllPages, type Page, walkPages } from "./paging.ts";
+import { type Page, walkPages } from "./paging.ts";
 
 const nextTick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -21,42 +21,45 @@ function finiteSource(
     });
 }
 
-Deno.test("aggregates every page in ascending offset order", async () => {
-  const result = await fetchAllPages(finiteSource(23), { pageSize: 10 });
+Deno.test("yields every item in ascending offset order", async () => {
+  const result = await Array.fromAsync(
+    walkPages(finiteSource(23), { pageSize: 10 }),
+  );
   expect(result).toStrictEqual(range(0, 23));
 });
 
-Deno.test("returns an empty result without fetching data pages when the total is zero", async () => {
+Deno.test("yields nothing without fetching data pages when the total is zero", async () => {
   const offsets: number[] = [];
-  const result = await fetchAllPages(
+  const result = await Array.fromAsync(walkPages(
     (_limit, offset) => {
       offsets.push(offset);
       return Promise.resolve({ items: [] as number[], totalCount: 0 });
     },
     { pageSize: 10 },
-  );
+  ));
   expect(result).toStrictEqual([]);
   expect(offsets).toStrictEqual([0]);
 });
 
 Deno.test("keeps offset order even when later pages settle first", async () => {
-  const result = await fetchAllPages(
+  const result = await Array.fromAsync(walkPages(
     async (limit, offset) => {
-      // Earlier offsets resolve last, so a naive push-on-settle would reorder.
+      // Earlier offsets resolve last, so a naive yield-on-settle would
+      // reorder.
       await new Promise<void>((resolve) =>
         setTimeout(resolve, offset === 0 ? 5 : 1)
       );
       return { items: range(offset, offset + limit), totalCount: 30 };
     },
     { pageSize: 10, concurrency: 6 },
-  );
+  ));
   expect(result).toStrictEqual(range(0, 30));
 });
 
 Deno.test("never exceeds the concurrency bound for data pages", async () => {
   let inFlight = 0;
   let maxInFlight = 0;
-  const result = await fetchAllPages(
+  const result = await Array.fromAsync(walkPages(
     async (limit, offset) => {
       inFlight++;
       maxInFlight = Math.max(maxInFlight, inFlight);
@@ -68,14 +71,14 @@ Deno.test("never exceeds the concurrency bound for data pages", async () => {
       };
     },
     { pageSize: 10, concurrency: 3 },
-  );
+  ));
   expect(result).toStrictEqual(range(0, 100));
   expect(maxInFlight).toStrictEqual(3);
 });
 
 Deno.test("fetches a single page when the total fits within one page", async () => {
   const calls: Array<{ limit: number; offset: number }> = [];
-  const result = await fetchAllPages(
+  const result = await Array.fromAsync(walkPages(
     (limit, offset) => {
       calls.push({ limit, offset });
       return Promise.resolve({
@@ -84,34 +87,34 @@ Deno.test("fetches a single page when the total fits within one page", async () 
       });
     },
     { pageSize: 10 },
-  );
+  ));
   expect(result).toStrictEqual(range(0, 5));
   expect(calls).toStrictEqual([{ limit: 10, offset: 0 }]);
 });
 
-Deno.test("rejects a pageSize outside Redmine's 1-to-100 range", async () => {
+Deno.test("rejects a pageSize outside Redmine's 1-to-100 range on first iteration", async () => {
   // Above 100 Redmine clamps each page while the offset walk advances by the
   // full pageSize, which would silently skip records; at or below zero the walk
   // cannot advance.
   for (const pageSize of [0, -1, 101, 10.5]) {
-    await expect(fetchAllPages(finiteSource(50), { pageSize })).rejects
-      .toThrow(RangeError);
+    const pages = walkPages(finiteSource(50), { pageSize });
+    await expect(pages.next()).rejects.toThrow(RangeError);
   }
 });
 
 Deno.test("clamps a non-positive concurrency to at least one", async () => {
-  // Without clamping, zero workers would silently drop every page after the
-  // first, and a negative value would throw on `Array.from`.
-  const result = await fetchAllPages(finiteSource(30), {
+  // Without clamping, zero in-flight slots would make the walk await pages
+  // that were never requested.
+  const result = await Array.fromAsync(walkPages(finiteSource(30), {
     pageSize: 10,
     concurrency: 0,
-  });
+  }));
   expect(result).toStrictEqual(range(0, 30));
 });
 
-Deno.test("stops at the requested limit and slices off the over-fetch", async () => {
+Deno.test("stops at the requested limit without over-fetching", async () => {
   const calls: Array<{ limit: number; offset: number }> = [];
-  const result = await fetchAllPages(
+  const result = await Array.fromAsync(walkPages(
     (limit, offset) => {
       calls.push({ limit, offset });
       return Promise.resolve({
@@ -120,7 +123,7 @@ Deno.test("stops at the requested limit and slices off the over-fetch", async ()
       });
     },
     { pageSize: 100, limit: 250 },
-  );
+  ));
   expect(result).toStrictEqual(range(0, 250));
   // No count probe; the last page requests only the remaining 50 items.
   expect(calls).toStrictEqual([
@@ -130,14 +133,23 @@ Deno.test("stops at the requested limit and slices off the over-fetch", async ()
   ]);
 });
 
-Deno.test("walkPages yields every item in ascending offset order", async () => {
-  const result = await Array.fromAsync(walkPages(finiteSource(23), {
-    pageSize: 10,
-  }));
-  expect(result).toStrictEqual(range(0, 23));
+Deno.test("stops early when the source is exhausted before the limit", async () => {
+  const calls: Array<{ limit: number; offset: number }> = [];
+  const result = await Array.fromAsync(walkPages(
+    (limit, offset) => {
+      calls.push({ limit, offset });
+      return Promise.resolve({
+        items: range(offset, Math.min(offset + limit, 30)),
+        totalCount: 30,
+      });
+    },
+    { pageSize: 100, limit: 250 },
+  ));
+  expect(result).toStrictEqual(range(0, 30));
+  expect(calls).toStrictEqual([{ limit: 100, offset: 0 }]);
 });
 
-Deno.test("walkPages fetches nothing beyond the first page when the consumer breaks inside it", async () => {
+Deno.test("fetches nothing beyond the first page when the consumer breaks inside it", async () => {
   const calls: number[] = [];
   const source = finiteSource(100);
   const counted: typeof source = (limit, offset) => {
@@ -155,7 +167,7 @@ Deno.test("walkPages fetches nothing beyond the first page when the consumer bre
   expect(calls).toStrictEqual([0]);
 });
 
-Deno.test("walkPages wastes at most the read-ahead window when the consumer breaks later", async () => {
+Deno.test("wastes at most the read-ahead window when the consumer breaks later", async () => {
   const calls: number[] = [];
   const source = finiteSource(100);
   const counted: typeof source = (limit, offset) => {
@@ -177,7 +189,7 @@ Deno.test("walkPages wastes at most the read-ahead window when the consumer brea
   expect(calls).toStrictEqual([0, 10, 20, 30, 40]);
 });
 
-Deno.test("walkPages surfaces a page failure only after every earlier item is yielded", async () => {
+Deno.test("surfaces a page failure only after every earlier item is yielded", async () => {
   const collected: number[] = [];
   await expect((async () => {
     const pages = walkPages<number>(
@@ -202,7 +214,7 @@ Deno.test("walkPages surfaces a page failure only after every earlier item is yi
   expect(collected).toStrictEqual(range(0, 20));
 });
 
-Deno.test("walkPages surfaces a synchronously thrown page failure in order too", async () => {
+Deno.test("surfaces a synchronously thrown page failure in order too", async () => {
   const collected: number[] = [];
   await expect((async () => {
     const pages = walkPages<number>(
@@ -230,7 +242,7 @@ Deno.test("walkPages surfaces a synchronously thrown page failure in order too",
   expect(collected).toStrictEqual(range(0, 20));
 });
 
-Deno.test("walkPages leaves no unhandled rejection behind when the consumer stops early", async () => {
+Deno.test("leaves no unhandled rejection behind when the consumer stops early", async () => {
   // Read-ahead pages that reject after the consumer breaks would surface as
   // unhandled rejections and crash the test run if the generator did not
   // capture them.
@@ -258,25 +270,4 @@ Deno.test("walkPages leaves no unhandled rejection behind when the consumer stop
   }
   await new Promise<void>((resolve) => setTimeout(resolve, 10));
   expect(collected).toStrictEqual(range(0, 10));
-});
-
-Deno.test("walkPages rejects a pageSize outside Redmine's 1-to-100 range on first iteration", async () => {
-  const pages = walkPages(finiteSource(50), { pageSize: 101 });
-  await expect(pages.next()).rejects.toThrow(RangeError);
-});
-
-Deno.test("stops early when the source is exhausted before the limit", async () => {
-  const calls: Array<{ limit: number; offset: number }> = [];
-  const result = await fetchAllPages(
-    (limit, offset) => {
-      calls.push({ limit, offset });
-      return Promise.resolve({
-        items: range(offset, Math.min(offset + limit, 30)),
-        totalCount: 30,
-      });
-    },
-    { pageSize: 100, limit: 250 },
-  );
-  expect(result).toStrictEqual(range(0, 30));
-  expect(calls).toStrictEqual([{ limit: 100, offset: 0 }]);
 });

--- a/internal/paging.ts
+++ b/internal/paging.ts
@@ -86,25 +86,6 @@ export async function* walkPages<T>(
   );
 }
 
-/**
- * Walk every page of a Redmine list resource and return the aggregated items
- * in page order.
- *
- * Thin aggregation over {@link walkPages}; see there for the walking
- * strategy.
- *
- * @typeParam T Element type of the list
- * @param fetchPage Fetches and parses a single page
- * @param options Page size, optional item cap, and concurrency bound
- * @returns Every item across all pages, in ascending offset order
- */
-export async function fetchAllPages<T>(
-  fetchPage: FetchPage<T>,
-  options: PagingOptions,
-): Promise<T[]> {
-  return await Array.fromAsync(walkPages(fetchPage, options));
-}
-
 async function* walkUpToLimit<T>(
   fetchPage: FetchPage<T>,
   pageSize: number,

--- a/issue-categories/list.test.ts
+++ b/issue-categories/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await list(context, 1);
+    const r = await Array.fromAsync(list(context, 1));
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     "if got 200, should return issue categories with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const categories = await list(context, 1);
+      const categories = await Array.fromAsync(list(context, 1));
       expect(categories[0].assignedTo).toStrictEqual({
         id: 5,
         name: "Alice",
@@ -30,12 +30,12 @@ Deno.test("GET /projects/:project_id/issue_categories.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(list(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, 422))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(list(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(list(context, 404))).rejects.toThrow();
   });
 });

--- a/issue-categories/list.ts
+++ b/issue-categories/list.ts
@@ -15,12 +15,12 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @returns Issue categories
+ * @returns Yields each IssueCategory
  */
-export async function list(
+export async function* list(
   context: Context,
   projectId: number,
-): Promise<IssueCategory[]> {
+): AsyncGenerator<IssueCategory> {
   const url = buildUrl(
     context.endpoint,
     "projects",
@@ -40,5 +40,5 @@ export async function list(
     },
   });
   await assertResponse(response);
-  return parse(responseSchema, await response.json()).issue_categories;
+  yield* parse(responseSchema, await response.json()).issue_categories;
 }

--- a/issue-relations/list.test.ts
+++ b/issue-relations/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await list(context, 1);
+    const r = await Array.fromAsync(list(context, 1));
     expect(r).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     "if got 200, should return relations with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const relations = await list(context, 1);
+      const relations = await Array.fromAsync(list(context, 1));
       expect(relations[0]).toStrictEqual({
         id: 1,
         issueId: 1,
@@ -34,12 +34,12 @@ Deno.test("GET /issues/:issue_id/relations.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(list(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, 422))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(list(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(list(context, 404))).rejects.toThrow();
   });
 });

--- a/issue-relations/list.ts
+++ b/issue-relations/list.ts
@@ -15,12 +15,12 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param issueId Issue identifier
- * @returns Relations
+ * @returns Yields each Relation
  */
-export async function list(
+export async function* list(
   context: Context,
   issueId: number,
-): Promise<Relation[]> {
+): AsyncGenerator<Relation> {
   const url = buildUrl(
     context.endpoint,
     "issues",
@@ -35,5 +35,5 @@ export async function list(
     },
   });
   await assertResponse(response);
-  return parse(responseSchema, await response.json()).relations;
+  yield* parse(responseSchema, await response.json()).relations;
 }

--- a/issue-statuses/list.test.ts
+++ b/issue-statuses/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /issue_statuses.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const issueStatuses = await list(context);
+    const issueStatuses = await Array.fromAsync(list(context));
     expect(issueStatuses).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     "if got 200, should return issue statuses with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const issueStatuses = await list(context);
+      const issueStatuses = await Array.fromAsync(list(context));
       expect(issueStatuses.length).toStrictEqual(3);
       expect(issueStatuses[0]).toStrictEqual({
         id: 1,
@@ -37,7 +37,7 @@ Deno.test("GET /issue_statuses.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/issue-statuses/list.ts
+++ b/issue-statuses/list.ts
@@ -9,9 +9,9 @@ import { listIssueStatusResponse } from "./validator.ts";
  * Fetch issue statuses
  *
  * @param context REST endpoint context
- * @return Array of IssueStatus
+ * @return Yields each IssueStatus
  */
-export async function list(context: Context): Promise<IssueStatus[]> {
+export async function* list(context: Context): AsyncGenerator<IssueStatus> {
   const endpoint = buildUrl(context.endpoint, "issue_statuses.json");
   const response = await fetch(
     endpoint,
@@ -24,5 +24,5 @@ export async function list(context: Context): Promise<IssueStatus[]> {
     },
   );
   await assertResponse(response);
-  return parse(listIssueStatusResponse, await response.json()).issue_statuses;
+  yield* parse(listIssueStatusResponse, await response.json()).issue_statuses;
 }

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -11,7 +11,7 @@ server.listen();
 Deno.test("GET /issues.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const issues = await list(context);
+    const issues = await Array.fromAsync(list(context));
     expect(issues).toBeDefined();
   });
 
@@ -19,7 +19,7 @@ Deno.test("GET /issues.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });
@@ -85,7 +85,7 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      const issues = await list(context, { limit: 1 });
+      const issues = await Array.fromAsync(list(context, { limit: 1 }));
 
       expect(issues.length).toStrictEqual(1);
       expect(requests.length).toStrictEqual(1);
@@ -99,7 +99,7 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(300, requests));
 
-      const issues = await list(context, { limit: 150 });
+      const issues = await Array.fromAsync(list(context, { limit: 150 }));
 
       expect(issues.length).toStrictEqual(150);
       expect(requests).toStrictEqual([
@@ -115,7 +115,7 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(150, requests));
 
-      const issues = await list(context, {});
+      const issues = await Array.fromAsync(list(context, {}));
 
       expect(issues.length).toStrictEqual(150);
       expect(requests).toStrictEqual([
@@ -131,7 +131,8 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(list(context, { limit: 1.5 })).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, { limit: 1.5 })))
+        .rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );
@@ -142,7 +143,8 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(list(context, { limit: -1 })).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, { limit: -1 })))
+        .rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );
@@ -153,7 +155,8 @@ Deno.test("list limit option", async (t) => {
       const requests: RecordedRequest[] = [];
       server.resetHandlers(pagingHandler(5, requests));
 
-      await expect(list(context, { limit: 0 })).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, { limit: 0 })))
+        .rejects.toThrow();
       expect(requests.length).toStrictEqual(0);
     },
   );

--- a/issues/list.ts
+++ b/issues/list.ts
@@ -1,23 +1,23 @@
 import type { Context } from "../context.ts";
 import { parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import type { Issue, ListIssueQuery } from "./type.ts";
 import { assertResponse } from "../error.ts";
 import { listResponse, toListOption } from "./validator.ts";
 
 const pageSize = 100;
 
-export async function list(
+export async function* list(
   context: Context,
   option: Partial<ListIssueQuery> = {},
-): Promise<Issue[]> {
+): AsyncGenerator<Issue> {
   const convertedOption = parse(toListOption, option);
 
   // A requested limit selects the helper's over-fetch-avoiding path, which
   // walks sequentially and skips the total_count probe; without one the helper
   // probes the count and walks the remaining pages with bounded parallelism.
-  return await fetchAllPages(async (limit, offset) => {
+  yield* walkPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "issues.json");
     endpoint.search = new URLSearchParams({
       limit: `${limit}`,

--- a/memberships/list.test.ts
+++ b/memberships/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const memberships = await list(context, 1);
+    const memberships = await Array.fromAsync(list(context, 1));
     expect(memberships).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     "if got 200, should return memberships with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const memberships = await list(context, 1);
+      const memberships = await Array.fromAsync(list(context, 1));
       expect(memberships[0].user).toStrictEqual({
         id: 17,
         name: "David Robert",
@@ -35,13 +35,13 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(list(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, 422))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(list(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(list(context, 404))).rejects.toThrow();
   });
 
   await t.step(
@@ -68,7 +68,7 @@ Deno.test("GET /projects/:project_id/memberships.json", async (t) => {
           },
         ),
       );
-      const memberships = await list(context, 1);
+      const memberships = await Array.fromAsync(list(context, 1));
       expect(memberships.length).toStrictEqual(total);
       expect(memberships[0].id).toStrictEqual(1);
       expect(memberships[total - 1].id).toStrictEqual(total);

--- a/memberships/list.ts
+++ b/memberships/list.ts
@@ -1,6 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import type { Context } from "../context.ts";
 import type { Membership } from "./type.ts";
 import { membershipSchema } from "./validator.ts";
@@ -20,15 +20,15 @@ const pageSize = 100;
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @returns Memberships
+ * @returns Memberships, yielded one at a time across every page
  */
-export async function list(
+export async function* list(
   context: Context,
   projectId: number,
-): Promise<Membership[]> {
+): AsyncGenerator<Membership> {
   // The memberships listing is paginated (default limit 25), so walk every
   // page until each membership has been collected.
-  return await fetchAllPages(async (limit, offset) => {
+  yield* walkPages(async (limit, offset) => {
     const url = buildUrl(
       context.endpoint,
       "projects",

--- a/news/list-by-project.test.ts
+++ b/news/list-by-project.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/news.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const news = await listByProject(context, 1);
+    const news = await Array.fromAsync(listByProject(context, 1));
     expect(news).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     "if got 200, should return news with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const news = await listByProject(context, 1);
+      const news = await Array.fromAsync(listByProject(context, 1));
       expect(news.length).toStrictEqual(2);
       expect(news[0]).toStrictEqual({
         id: 1,
@@ -35,12 +35,14 @@ Deno.test("GET /projects/:project_id/news.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(listByProject(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(listByProject(context, 422))).rejects
+        .toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(listByProject(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(listByProject(context, 404))).rejects
+      .toThrow();
   });
 });

--- a/news/list-by-project.ts
+++ b/news/list-by-project.ts
@@ -10,12 +10,12 @@ import { listNewsResponse } from "./validator.ts";
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @return Array of News
+ * @return Yields each News
  */
-export async function listByProject(
+export async function* listByProject(
   context: Context,
   projectId: number,
-): Promise<News[]> {
+): AsyncGenerator<News> {
   const endpoint = buildUrl(
     context.endpoint,
     "projects",
@@ -33,5 +33,5 @@ export async function listByProject(
     },
   );
   await assertResponse(response);
-  return parse(listNewsResponse, await response.json()).news;
+  yield* parse(listNewsResponse, await response.json()).news;
 }

--- a/news/list.test.ts
+++ b/news/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /news.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const news = await list(context);
+    const news = await Array.fromAsync(list(context));
     expect(news).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /news.json", async (t) => {
     "if got 200, should return news with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const news = await list(context);
+      const news = await Array.fromAsync(list(context));
       expect(news.length).toStrictEqual(2);
       expect(news[0]).toStrictEqual({
         id: 1,
@@ -36,7 +36,7 @@ Deno.test("GET /news.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/news/list.ts
+++ b/news/list.ts
@@ -9,9 +9,9 @@ import { listNewsResponse } from "./validator.ts";
  * Fetch news across all projects
  *
  * @param context REST endpoint context
- * @return Array of News
+ * @return Yields each News
  */
-export async function list(context: Context): Promise<News[]> {
+export async function* list(context: Context): AsyncGenerator<News> {
   const endpoint = buildUrl(context.endpoint, "news.json");
   const response = await fetch(
     endpoint,
@@ -24,5 +24,5 @@ export async function list(context: Context): Promise<News[]> {
     },
   );
   await assertResponse(response);
-  return parse(listNewsResponse, await response.json()).news;
+  yield* parse(listNewsResponse, await response.json()).news;
 }

--- a/projects/list.test.ts
+++ b/projects/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const r = await list(context);
+    const r = await Array.fromAsync(list(context));
     expect(r).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /projects.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(list(c)).rejects.toThrow();
+      await expect(Array.fromAsync(list(c))).rejects.toThrow();
     },
   );
 });

--- a/projects/list.ts
+++ b/projects/list.ts
@@ -1,6 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import { type Project } from "./type.ts";
 import { projectSchema } from "./validator.ts";
 import type { Context } from "../context.ts";
@@ -13,8 +13,8 @@ const responseSchema = object({
   limit: number(),
 });
 
-export async function list(context: Context): Promise<Project[]> {
-  return await fetchAllPages(async (limit, offset) => {
+export async function* list(context: Context): AsyncGenerator<Project> {
+  yield* walkPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "projects.json");
     endpoint.search = new URLSearchParams({
       limit: `${limit}`,

--- a/queries/list.test.ts
+++ b/queries/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /queries.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const queries = await list(context);
+    const queries = await Array.fromAsync(list(context));
     expect(queries).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /queries.json", async (t) => {
     "if got 200, should return queries with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const queries = await list(context);
+      const queries = await Array.fromAsync(list(context));
       expect(queries.length).toStrictEqual(3);
       expect(queries[0]).toStrictEqual({
         id: 1,
@@ -39,7 +39,7 @@ Deno.test("GET /queries.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/queries/list.ts
+++ b/queries/list.ts
@@ -9,9 +9,9 @@ import { listQueryResponse } from "./validator.ts";
  * Fetch queries
  *
  * @param context REST endpoint context
- * @return Array of Query
+ * @return Yields each Query
  */
-export async function list(context: Context): Promise<Query[]> {
+export async function* list(context: Context): AsyncGenerator<Query> {
   const endpoint = buildUrl(context.endpoint, "queries.json");
   const response = await fetch(
     endpoint,
@@ -24,5 +24,5 @@ export async function list(context: Context): Promise<Query[]> {
     },
   );
   await assertResponse(response);
-  return parse(listQueryResponse, await response.json()).queries;
+  yield* parse(listQueryResponse, await response.json()).queries;
 }

--- a/roles/list.test.ts
+++ b/roles/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /roles.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const roles = await list(context);
+    const roles = await Array.fromAsync(list(context));
     expect(roles).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /roles.json", async (t) => {
     "if got 200, should return roles with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const roles = await list(context);
+      const roles = await Array.fromAsync(list(context));
       expect(roles.length).toStrictEqual(2);
       expect(roles[0]).toStrictEqual({ id: 1, name: "Manager" });
       expect(roles[1]).toStrictEqual({ id: 2, name: "Developer" });
@@ -28,7 +28,7 @@ Deno.test("GET /roles.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(list(context)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context))).rejects.toThrow();
     },
   );
 });

--- a/roles/list.ts
+++ b/roles/list.ts
@@ -10,9 +10,9 @@ import { assertResponse } from "../error.ts";
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @returns Array of role id/name pairs
+ * @returns Yields each role as an id/name pair
  */
-export async function list(context: Context): Promise<IdName[]> {
+export async function* list(context: Context): AsyncGenerator<IdName> {
   const url = buildUrl(context.endpoint, "roles.json");
   const response = await fetch(url, {
     method: "GET",
@@ -22,5 +22,5 @@ export async function list(context: Context): Promise<IdName[]> {
     },
   });
   await assertResponse(response);
-  return parse(roleListResponse, await response.json()).roles;
+  yield* parse(roleListResponse, await response.json()).roles;
 }

--- a/search/search.test.ts
+++ b/search/search.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /search.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validHandlers);
-    const items = await search(context, { q: "E2E" });
+    const items = await Array.fromAsync(search(context, { q: "E2E" }));
     expect(items).toBeDefined();
   });
 
@@ -18,7 +18,7 @@ Deno.test("GET /search.json", async (t) => {
     "if got 200, should return results with camelCase fields",
     async () => {
       server.resetHandlers(...validHandlers);
-      const items = await search(context, { q: "E2E" });
+      const items = await Array.fromAsync(search(context, { q: "E2E" }));
       expect(items.length).toStrictEqual(3);
       expect(items[0].id).toStrictEqual(1);
       expect(items[0].type).toStrictEqual("issue");
@@ -44,14 +44,14 @@ Deno.test("GET /search.json", async (t) => {
           });
         }),
       );
-      await search(context, {
+      await Array.fromAsync(search(context, {
         q: "E2E",
         allWords: true,
         wikiPages: true,
         openIssues: false,
         scope: "all",
         attachments: true,
-      });
+      }));
       expect(capturedUrl).toBeDefined();
       expect(capturedUrl!.searchParams.get("q")).toStrictEqual("E2E");
       expect(capturedUrl!.searchParams.get("all_words")).toStrictEqual("1");
@@ -68,13 +68,15 @@ Deno.test("GET /search.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.resetHandlers(...invalidHandlers);
-      await expect(search(context, { q: "422" })).rejects.toThrow();
+      await expect(Array.fromAsync(search(context, { q: "422" })))
+        .rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.resetHandlers(...invalidHandlers);
-    await expect(search(context, { q: "404" })).rejects.toThrow();
+    await expect(Array.fromAsync(search(context, { q: "404" })))
+      .rejects.toThrow();
   });
 
   await t.step(
@@ -102,7 +104,7 @@ Deno.test("GET /search.json", async (t) => {
           });
         }),
       );
-      const items = await search(context, { q: "E2E" });
+      const items = await Array.fromAsync(search(context, { q: "E2E" }));
       expect(items.length).toStrictEqual(total);
       expect(items[0].id).toStrictEqual(1);
       expect(items[total - 1].id).toStrictEqual(total);

--- a/search/search.ts
+++ b/search/search.ts
@@ -1,6 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import type { Context } from "../context.ts";
 import type { SearchQuery, SearchResult } from "./type.ts";
 import { searchResultSchema, toSearchParams } from "./validator.ts";
@@ -19,14 +19,14 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param query The search query, whose only required field is `q`
- * @returns Search results across every page
+ * @returns Search results, yielded one at a time across every page
  */
-export async function search(
+export async function* search(
   context: Context,
   query: SearchQuery,
-): Promise<SearchResult[]> {
+): AsyncGenerator<SearchResult> {
   const base = toSearchParams(query);
-  return await fetchAllPages(async (limit, offset) => {
+  yield* walkPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "search.json");
     const params = new URLSearchParams(base);
     params.set("limit", `${limit}`);

--- a/time-entries/list.test.ts
+++ b/time-entries/list.test.ts
@@ -10,7 +10,7 @@ server.listen();
 Deno.test("GET /time_entries.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const entries = await list(context);
+    const entries = await Array.fromAsync(list(context));
     expect(entries).toBeDefined();
   });
 
@@ -19,19 +19,19 @@ Deno.test("GET /time_entries.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(list(c)).rejects.toThrow();
+      await expect(Array.fromAsync(list(c))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
-    await expect(list(c)).rejects.toThrow();
+    await expect(Array.fromAsync(list(c))).rejects.toThrow();
   });
 
   await t.step("should map camelCase fields from the response", async () => {
     server.use(...validHandlers);
-    const entries = await list(context);
+    const entries = await Array.fromAsync(list(context));
     const entry = entries.find((timeEntry) => timeEntry.id === 3);
     expect(entry).toBeDefined();
     expect(entry!.project).toStrictEqual({ id: 1, name: "Demo" });
@@ -60,13 +60,13 @@ Deno.test("GET /time_entries.json", async (t) => {
           });
         }),
       );
-      await list(context, {
+      await Array.fromAsync(list(context, {
         projectId: 1,
         userId: 2,
         spentOn: new Date("2026-07-01"),
         from: new Date("2026-07-01"),
         to: new Date("2026-07-31"),
-      });
+      }));
       expect(captured?.get("project_id")).toStrictEqual("1");
       expect(captured?.get("user_id")).toStrictEqual("2");
       expect(captured?.get("spent_on")).toStrictEqual("2026-07-01");
@@ -90,7 +90,7 @@ Deno.test("GET /time_entries.json", async (t) => {
           });
         }),
       );
-      await list(context, { projectId: undefined });
+      await Array.fromAsync(list(context, { projectId: undefined }));
       expect(captured?.has("project_id")).toStrictEqual(false);
       expect(!captured?.toString().includes("undefined")).toBe(true);
     },

--- a/time-entries/list.ts
+++ b/time-entries/list.ts
@@ -1,6 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import type { Context } from "../context.ts";
 import type { ListTimeEntryQuery, TimeEntry } from "./type.ts";
 import { timeEntrySchema, toListTimeEntryQuery } from "./validator.ts";
@@ -19,14 +19,14 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param filter Optional filters (projectId, spentOn, userId, from, to)
- * @returns Time entries
+ * @returns Time entries, yielded one at a time across every page
  */
-export async function list(
+export async function* list(
   context: Context,
   filter: Partial<ListTimeEntryQuery> = {},
-): Promise<TimeEntry[]> {
+): AsyncGenerator<TimeEntry> {
   const query = parse(toListTimeEntryQuery, filter);
-  return await fetchAllPages(async (limit, offset) => {
+  yield* walkPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "time_entries.json");
     endpoint.search = new URLSearchParams({
       limit: `${limit}`,

--- a/trackers/list.ts
+++ b/trackers/list.ts
@@ -9,9 +9,9 @@ import { listTrackerResponse } from "./validator.ts";
  * Fetch trackers
  *
  * @param context REST endpoint context
- * @return Array of Tracker
+ * @return Yields each Tracker
  */
-export async function list(context: Context): Promise<Tracker[]> {
+export async function* list(context: Context): AsyncGenerator<Tracker> {
   const endpoint = buildUrl(context.endpoint, "trackers.json");
   const response = await fetch(
     endpoint,
@@ -24,5 +24,5 @@ export async function list(context: Context): Promise<Tracker[]> {
     },
   );
   await assertResponse(response);
-  return parse(listTrackerResponse, await response.json()).trackers;
+  yield* parse(listTrackerResponse, await response.json()).trackers;
 }

--- a/users/list.test.ts
+++ b/users/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /users.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const users = await list(context);
+    const users = await Array.fromAsync(list(context));
     expect(users).toBeDefined();
   });
 
@@ -17,7 +17,7 @@ Deno.test("GET /users.json", async (t) => {
     "if got 200, should return users with camelCase fields",
     async () => {
       server.use(...validHandlers);
-      const users = await list(context);
+      const users = await Array.fromAsync(list(context));
       expect(users.length).toStrictEqual(2);
       expect(users[1].login).toStrictEqual("admin");
       expect(users[1].admin).toStrictEqual(true);
@@ -33,13 +33,13 @@ Deno.test("GET /users.json", async (t) => {
     async () => {
       server.use(...invalidHandlers);
       const c = { ...context, endpoint: `${context.endpoint}/422` };
-      await expect(list(c)).rejects.toThrow();
+      await expect(Array.fromAsync(list(c))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
     const c = { ...context, endpoint: `${context.endpoint}/404` };
-    await expect(list(c)).rejects.toThrow();
+    await expect(Array.fromAsync(list(c))).rejects.toThrow();
   });
 });

--- a/users/list.ts
+++ b/users/list.ts
@@ -1,6 +1,6 @@
 import { array, number, object, parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
-import { fetchAllPages } from "../internal/paging.ts";
+import { walkPages } from "../internal/paging.ts";
 import type { Context } from "../context.ts";
 import type { User } from "./type.ts";
 import { userSchema } from "./validator.ts";
@@ -18,10 +18,10 @@ const responseSchema = object({
  * This may throw `Error`
  *
  * @param context REST endpoint context
- * @returns Users
+ * @returns Users, yielded one at a time across every page
  */
-export async function list(context: Context): Promise<User[]> {
-  return await fetchAllPages(async (limit, offset) => {
+export async function* list(context: Context): AsyncGenerator<User> {
+  yield* walkPages(async (limit, offset) => {
     const endpoint = buildUrl(context.endpoint, "users.json");
     endpoint.search = new URLSearchParams({
       limit: `${limit}`,

--- a/versions/list.test.ts
+++ b/versions/list.test.ts
@@ -9,7 +9,7 @@ server.listen();
 Deno.test("GET /projects/:project_id/versions.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.use(...validHandlers);
-    const versions = await list(context, 1);
+    const versions = await Array.fromAsync(list(context, 1));
     expect(versions).toBeDefined();
   });
 
@@ -17,12 +17,12 @@ Deno.test("GET /projects/:project_id/versions.json", async (t) => {
     "if get invalid response with error object, should throw",
     async () => {
       server.use(...invalidHandlers);
-      await expect(list(context, 422)).rejects.toThrow();
+      await expect(Array.fromAsync(list(context, 422))).rejects.toThrow();
     },
   );
 
   await t.step("if get invalid response with unexpected format", async () => {
     server.use(...invalidHandlers);
-    await expect(list(context, 404)).rejects.toThrow();
+    await expect(Array.fromAsync(list(context, 404))).rejects.toThrow();
   });
 });

--- a/versions/list.ts
+++ b/versions/list.ts
@@ -15,12 +15,12 @@ const responseSchema = object({
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @returns Versions
+ * @returns Yields each Version
  */
-export async function list(
+export async function* list(
   context: Context,
   projectId: number,
-): Promise<Version[]> {
+): AsyncGenerator<Version> {
   const url = buildUrl(
     context.endpoint,
     "projects",
@@ -39,5 +39,5 @@ export async function list(
     },
   });
   await assertResponse(response);
-  return parse(responseSchema, await response.json()).versions;
+  yield* parse(responseSchema, await response.json()).versions;
 }

--- a/wiki-pages/list.test.ts
+++ b/wiki-pages/list.test.ts
@@ -14,12 +14,12 @@ server.listen();
 Deno.test("GET /projects/:id/wiki/index.json", async (t) => {
   await t.step("if got 200, should resolve", async () => {
     server.resetHandlers(...validResponseHandlers);
-    const wikis = await list(context, 1);
+    const wikis = await Array.fromAsync(list(context, 1));
     expect(wikis.length).toBe(2);
   });
   await t.step("If got 422, should throw", async () => {
     server.resetHandlers(...invalidResponseHandlers);
-    await expect(list(context, 2)).rejects.toThrow(
+    await expect(Array.fromAsync(list(context, 2))).rejects.toThrow(
       "Unprocessable Entity",
     );
   });

--- a/wiki-pages/list.ts
+++ b/wiki-pages/list.ts
@@ -11,12 +11,12 @@ import { wikis } from "./validator.ts";
  *
  * @param context REST endpoint context
  * @param projectId Project identifier
- * @returns Wiki pages
+ * @returns Yields each Wiki page
  */
-export async function list(
+export async function* list(
   context: Context,
   projectId: number,
-): Promise<Wiki[]> {
+): AsyncGenerator<Wiki> {
   const opts = {
     method: "GET",
     headers: {
@@ -34,5 +34,5 @@ export async function list(
 
   const r = await fetch(url, opts);
   await assertResponse(r);
-  return parse(wikis, await r.json());
+  yield* parse(wikis, await r.json());
 }


### PR DESCRIPTION
## Summary

List functions return `AsyncGenerator<T>` instead of `Promise<T[]>`.

## Details

Lazy paging lets consumers break out of iteration without paying for the remaining pages, and single-response resources share the same iterator shape so whether a resource paginates stays a transport detail that can change without breaking the API.

The paged walk reads ahead with bounded parallelism, keeping full-consumption wall clock on par with the previous aggregated fetch, and `fetchAllPages` is removed because `walkPages` subsumes its only callers.

## Confirmation

Ran `nix run .#check-deno`; format, lint, type check, and 107 tests passed with 0 failures (the count drop comes from consolidating the paging tests).

## Limitation

issue-templates' `list` keeps returning an object because its response carries three differently classified template arrays, not a single list.

The e2e suite was not executed; its call sites are covered by the type check only.

BREAKING CHANGE: `list`, `listByProject`, `search`, and the enumerations list functions return `AsyncGenerator<T>` instead of `Promise<T[]>`. Iterate with `for await` or collect with `await Array.fromAsync(list(context))`.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85