### PR TITLE
chore: exclude .direnv from deno file resolution

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,6 +9,10 @@
     "test:e2e": "deno test --allow-net --allow-env e2e/"
   },
   "lock": false,
+  // .direnv holds nix-direnv's copies of flake inputs (including a stale copy
+  // of this repo's own source); globbing them into deno's file resolution
+  // makes local check/lint/fmt/test diverge from CI, which runs without it.
+  "exclude": [".direnv", "coverage"],
   "fmt": {
     "exclude": ["CHANGELOG.md"]
   },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,9 +9,6 @@
     "test:e2e": "deno test --allow-net --allow-env e2e/"
   },
   "lock": false,
-  // .direnv holds nix-direnv's copies of flake inputs (including a stale copy
-  // of this repo's own source); globbing them into deno's file resolution
-  // makes local check/lint/fmt/test diverge from CI, which runs without it.
   "exclude": [".direnv", "coverage"],
   "fmt": {
     "exclude": ["CHANGELOG.md"]


### PR DESCRIPTION
## Summary

Exclude `.direnv` and `coverage` from deno's file resolution so local tooling checks the same files as CI.

## Details

deno's fmt/lint/check/test tasks glob `./**/*.ts`, which pulled in the flake-input copies nix-direnv writes under `.direnv`, making the pre-push `deno check` hook fail with spurious TS2578 while CI, running without `.direnv`, stayed green.

A top-level exclude keeps local runs aligned with the CI sandbox.

## Confirmation

Ran `nix run .#check-deno` with `.direnv` populated and it passed (108 passed, 0 failed), and the pre-push `deno check` hook now passes.

## Limitation

No known limitations.