### PR TITLE
fix: return attachments and relations from issue list include

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -255,18 +255,12 @@ Deno.test({
             return;
           }
 
-          // The Issue type does not (yet) carry attachments, so the cast
-          // below stands in for the fix's widened return type: it lets this
-          // test observe the actual response-stripping bug at runtime
-          // instead of failing to compile before ever hitting the server.
           const listed = await Array.fromAsync(
             list(e2eContext, {
               projectId: project!.id,
               include: "attachments",
             }),
-          ) as unknown as (
-            { subject: string; attachments?: { filename: string }[] }
-          )[];
+          );
           const listedIssue = listed.find((i) => i.subject === subject);
           expect(listedIssue).toBeDefined();
           expect(listedIssue!.attachments).toBeDefined();
@@ -326,18 +320,12 @@ Deno.test({
             relationType: "relates",
           });
 
-          // The Issue type does not (yet) carry relations, so the cast
-          // below stands in for the fix's widened return type: it lets this
-          // test observe the actual response-stripping bug at runtime
-          // instead of failing to compile before ever hitting the server.
           const listed = await Array.fromAsync(
             list(e2eContext, {
               projectId: project!.id,
               include: "relations",
             }),
-          ) as unknown as (
-            { subject: string; relations?: { issueToId?: number }[] }
-          )[];
+          );
           const listedIssue = listed.find((i) => i.subject === sourceSubject);
           expect(listedIssue).toBeDefined();
           expect(listedIssue!.relations).toBeDefined();

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -5,6 +5,7 @@ import { show } from "../issues/show.ts";
 import { createIssue } from "../issues/create.ts";
 import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
+import { create as createRelation } from "../issue-relations/create.ts";
 import { list as listProjects } from "../projects/list.ts";
 
 Deno.test({
@@ -277,6 +278,79 @@ Deno.test({
             projectId: project!.id,
           }));
           const leftovers = cleanupList.filter((i) => i.subject === subject);
+          for (const leftover of leftovers) {
+            await deleteIssue(e2eContext, leftover.id);
+          }
+        }
+      },
+    );
+
+    await t.step(
+      "GET /issues.json with include: relations should return relations",
+      async () => {
+        const projects = await Array.fromAsync(listProjects(e2eContext));
+        const project = projects.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        expect(project).toBeDefined();
+
+        const issues = await Array.fromAsync(list(e2eContext, {
+          projectId: project!.id,
+        }));
+        expect(issues.length).toBeGreaterThan(0);
+
+        const sourceSubject = "E2E Include Relations Source";
+        const targetSubject = "E2E Include Relations Target";
+        for (const subject of [sourceSubject, targetSubject]) {
+          await createIssue(e2eContext, {
+            projectId: project!.id,
+            trackerId: issues[0].tracker.id,
+            statusId: issues[0].status.id,
+            priorityId: issues[0].priority.id,
+            subject,
+            description: "Created by E2E test to exercise list include",
+          });
+        }
+
+        try {
+          const created = await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }));
+          const source = created.find((i) => i.subject === sourceSubject);
+          const target = created.find((i) => i.subject === targetSubject);
+          expect(source).toBeDefined();
+          expect(target).toBeDefined();
+
+          await createRelation(e2eContext, source!.id, {
+            issueToId: target!.id,
+            relationType: "relates",
+          });
+
+          // The Issue type does not (yet) carry relations, so the cast
+          // below stands in for the fix's widened return type: it lets this
+          // test observe the actual response-stripping bug at runtime
+          // instead of failing to compile before ever hitting the server.
+          const listed = await Array.fromAsync(
+            list(e2eContext, {
+              projectId: project!.id,
+              include: "relations",
+            }),
+          ) as unknown as (
+            { subject: string; relations?: { issueToId?: number }[] }
+          )[];
+          const listedIssue = listed.find((i) => i.subject === sourceSubject);
+          expect(listedIssue).toBeDefined();
+          expect(listedIssue!.relations).toBeDefined();
+          expect(
+            listedIssue!.relations?.some((r) => r.issueToId === target!.id),
+          ).toBe(true);
+        } finally {
+          const cleanupList = await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }));
+          const leftovers = cleanupList.filter((i) =>
+            i.subject === sourceSubject || i.subject === targetSubject
+          );
           for (const leftover of leftovers) {
             await deleteIssue(e2eContext, leftover.id);
           }

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -174,6 +174,116 @@ Deno.test({
       },
     );
 
+    await t.step(
+      "GET /issues.json with include: attachments should return attachments",
+      async () => {
+        const projects = await Array.fromAsync(listProjects(e2eContext));
+        const project = projects.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        expect(project).toBeDefined();
+
+        const issues = await Array.fromAsync(list(e2eContext, {
+          projectId: project!.id,
+        }));
+        expect(issues.length).toBeGreaterThan(0);
+
+        const subject = "E2E Include Attachments Issue";
+        await createIssue(e2eContext, {
+          projectId: project!.id,
+          trackerId: issues[0].tracker.id,
+          statusId: issues[0].status.id,
+          priorityId: issues[0].priority.id,
+          subject,
+          description: "Created by E2E test to exercise list include",
+        });
+
+        try {
+          const created = (await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }))).find((i) => i.subject === subject);
+          expect(created).toBeDefined();
+
+          const headers = {
+            "Content-Type": "application/json",
+            "X-Redmine-API-Key": e2eContext.apiKey,
+          };
+          const filename = "e2e-include-attachment.txt";
+
+          const uploadResponse = await fetch(
+            `${e2eContext.endpoint}/uploads.json`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/octet-stream",
+                "X-Redmine-API-Key": e2eContext.apiKey,
+              },
+              body: new TextEncoder().encode("E2E include attachment content"),
+            },
+          );
+          if (!uploadResponse.ok) {
+            await uploadResponse.body?.cancel();
+            console.warn("Skipping: file upload is restricted on this Redmine");
+            return;
+          }
+          const uploadData = await uploadResponse.json();
+          const token = uploadData.upload?.token;
+          if (token === undefined) {
+            console.warn("Skipping: upload did not return a token");
+            return;
+          }
+
+          const attachResponse = await fetch(
+            `${e2eContext.endpoint}/issues/${created!.id}.json`,
+            {
+              method: "PUT",
+              headers,
+              body: JSON.stringify({
+                issue: {
+                  uploads: [
+                    { token, filename, content_type: "text/plain" },
+                  ],
+                },
+              }),
+            },
+          );
+          const attached = attachResponse.ok;
+          await attachResponse.body?.cancel();
+          if (!attached) {
+            console.warn("Skipping: could not attach upload to issue");
+            return;
+          }
+
+          // The Issue type does not (yet) carry attachments, so the cast
+          // below stands in for the fix's widened return type: it lets this
+          // test observe the actual response-stripping bug at runtime
+          // instead of failing to compile before ever hitting the server.
+          const listed = await Array.fromAsync(
+            list(e2eContext, {
+              projectId: project!.id,
+              include: "attachments",
+            }),
+          ) as unknown as (
+            { subject: string; attachments?: { filename: string }[] }
+          )[];
+          const listedIssue = listed.find((i) => i.subject === subject);
+          expect(listedIssue).toBeDefined();
+          expect(listedIssue!.attachments).toBeDefined();
+          expect(
+            listedIssue!.attachments?.some((a) => a.filename === filename),
+          ).toBe(true);
+        } finally {
+          const cleanupList = await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }));
+          const leftovers = cleanupList.filter((i) => i.subject === subject);
+          for (const leftover of leftovers) {
+            await deleteIssue(e2eContext, leftover.id);
+          }
+        }
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");

--- a/issues/list.ts
+++ b/issues/list.ts
@@ -2,7 +2,7 @@ import type { Context } from "../context.ts";
 import { parse } from "jsr:@valibot/valibot@1.4.2";
 import { buildUrl } from "../internal/url.ts";
 import { walkPages } from "../internal/paging.ts";
-import type { Issue, ListIssueQuery } from "./type.ts";
+import type { ListIssue, ListIssueQuery } from "./type.ts";
 import { assertResponse } from "../error.ts";
 import { listResponse, toListOption } from "./validator.ts";
 
@@ -11,7 +11,7 @@ const pageSize = 100;
 export async function* list(
   context: Context,
   option: Partial<ListIssueQuery> = {},
-): AsyncGenerator<Issue> {
+): AsyncGenerator<ListIssue> {
   const convertedOption = parse(toListOption, option);
 
   // A requested limit selects the helper's over-fetch-avoiding path, which

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -124,7 +124,7 @@ export type CreateIssueQuery = {
 
 export type ListIssueQuery = {
   limit: number;
-  include: "attachment" | "relations";
+  include: "attachments" | "relations";
   issueId: number[] | number;
   projectId: number;
   subprojectId: string;

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -90,6 +90,11 @@ export type Include = {
 
 export type ShowIssue = Issue & Include;
 
+// The list endpoint only supports include=attachments/relations (unlike
+// show, which supports the full Include set), so the list result widens
+// Issue with just those two associations rather than the whole Include type.
+export type ListIssue = Issue & Pick<Include, "attachments" | "relations">;
+
 export type UpdateOption = {
   notes?: string;
   privateNotes?: boolean;

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -27,6 +27,7 @@ import type {
   Issue,
   IssueStatus,
   Journal,
+  ListIssue,
   ListIssueQuery,
   Relation,
 } from "./type.ts";
@@ -220,6 +221,19 @@ export const showIssueSchema = object({
   issue: showIssue,
 });
 
+// Only attachments/relations are spread here, not the full include.entries,
+// because the list endpoint only supports include=attachments/relations.
+const listIssueSchema = pipe(
+  object({
+    ...issueSchema.entries,
+    attachments: optional(array(attachments)),
+    relations: optional(array(relation)),
+  }),
+  transform((input) => {
+    return objectToCamel(input) satisfies ListIssue;
+  }),
+);
+
 // Redmine expects dates as YYYY-MM-DD strings. The UTC date part is used
 // rather than the local calendar fields because dateLikeString parses
 // Redmine's date-only strings as UTC midnight, so only UTC keeps a
@@ -287,7 +301,7 @@ export const toCreateRequest = pipe(
 
 export const listResponse = pipe(
   object({
-    issues: array(issueSchema),
+    issues: array(listIssueSchema),
     total_count: number(),
     offset: number(),
     limit: number(),

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -300,7 +300,7 @@ export const listResponse = pipe(
 const listIssueQuery = partial(
   object({
     limit: pipe(number(), integer(), minValue(1)),
-    include: picklist(["attachment", "relations"]),
+    include: picklist(["attachments", "relations"]),
     issueId: union([array(number()), number()]),
     projectId: number(),
     subprojectId: string(),


### PR DESCRIPTION
## Summary

The issue list `include` option now returns the requested `attachments` and `relations` instead of silently dropping them.

## Details

The list response was parsed with a schema that carried no attachments/relations keys, so valibot stripped the associations Redmine returned, and the result type could not expose them; the option only ever sent the query param. The list response is now parsed with a schema that keeps them, and the result type is widened to `ListIssue`. This branch also corrects the option value from the singular `attachment` to `attachments`, which Redmine had been silently ignoring.

## Confirmation

Added e2e steps against a real Redmine for both `include: attachments` and `include: relations`; both fail before the fix and pass after (24 passed / 0 failed). `nix run .#check-deno` passes (108 passed, 0 failed).

## Limitation

The `include` option is single-valued, so attachments and relations cannot be requested together in one list call even though Redmine accepts comma-separated includes.