### PR TITLE
feat: filter issue list by priority, category, fixed version, and author

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -520,27 +520,40 @@ Deno.test({
           }))).find((i) => i.subject === subject);
           expect(created).toBeDefined();
 
+          // The version and category are provisioned for this test alone, so
+          // filtering by them must narrow the listing to exactly this issue.
           const byVersion = await Array.fromAsync(
             list(e2eContext, { fixedVersionId: version!.id }),
           );
-          expect(byVersion.some((i) => i.subject === subject)).toBe(true);
+          expect(byVersion.map((i) => i.id)).toStrictEqual([created!.id]);
 
+          // categoryId is only honored alongside projectId: Redmine scopes the
+          // category filter to a project and ignores it otherwise.
           const byCategory = await Array.fromAsync(
-            list(e2eContext, { categoryId: category!.id }),
+            list(e2eContext, {
+              projectId: project!.id,
+              categoryId: category!.id,
+            }),
           );
-          expect(byCategory.some((i) => i.subject === subject)).toBe(true);
+          expect(byCategory.map((i) => i.id)).toStrictEqual([created!.id]);
 
-          // priorityId is not unique to this issue, so this only checks
-          // inclusion rather than an exact match like the version/category
-          // filters above.
+          // priority and author are shared with other issues, so rather than an
+          // exact match assert the filter is honored: every result carries the
+          // requested value, and the target issue is among them.
           const byPriority = await Array.fromAsync(
             list(e2eContext, { priorityId: issues[0].priority.id }),
           );
+          expect(
+            byPriority.every((i) => i.priority.id === issues[0].priority.id),
+          )
+            .toBe(true);
           expect(byPriority.some((i) => i.subject === subject)).toBe(true);
 
           const byAuthor = await Array.fromAsync(
             list(e2eContext, { authorId: "me" }),
           );
+          expect(byAuthor.every((i) => i.author.id === created!.author.id))
+            .toBe(true);
           expect(byAuthor.some((i) => i.subject === subject)).toBe(true);
         } finally {
           const cleanupList = await Array.fromAsync(list(e2eContext, {

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -7,6 +7,12 @@ import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
 import { create as createRelation } from "../issue-relations/create.ts";
 import { list as listProjects } from "../projects/list.ts";
+import { create as createVersion } from "../versions/create.ts";
+import { list as listVersions } from "../versions/list.ts";
+import { deleteVersion } from "../versions/delete.ts";
+import { create as createCategory } from "../issue-categories/create.ts";
+import { list as listCategories } from "../issue-categories/list.ts";
+import { deleteIssueCategory } from "../issue-categories/delete.ts";
 
 Deno.test({
   name: "E2E: Issues API",
@@ -464,6 +470,91 @@ Deno.test({
           );
           for (const leftover of leftovers) {
             await deleteIssue(e2eContext, leftover.id);
+          }
+        }
+      },
+    );
+
+    await t.step(
+      "GET /issues.json with id-based filters should narrow the listing",
+      async () => {
+        const projects = await Array.fromAsync(listProjects(e2eContext));
+        const project = projects.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        expect(project).toBeDefined();
+
+        const issues = await Array.fromAsync(list(e2eContext, {
+          projectId: project!.id,
+        }));
+        expect(issues.length).toBeGreaterThan(0);
+
+        const versionName = "E2E Filter Version";
+        await createVersion(e2eContext, project!.id, { name: versionName });
+        const version =
+          (await Array.fromAsync(listVersions(e2eContext, project!.id)))
+            .find((v) => v.name === versionName);
+        expect(version).toBeDefined();
+
+        const categoryName = "E2E Filter Category";
+        await createCategory(e2eContext, project!.id, { name: categoryName });
+        const category =
+          (await Array.fromAsync(listCategories(e2eContext, project!.id)))
+            .find((c) => c.name === categoryName);
+        expect(category).toBeDefined();
+
+        const subject = "E2E Filter Target Issue";
+        await createIssue(e2eContext, {
+          projectId: project!.id,
+          trackerId: issues[0].tracker.id,
+          statusId: issues[0].status.id,
+          priorityId: issues[0].priority.id,
+          fixedVersionId: version!.id,
+          categoryId: category!.id,
+          subject,
+        });
+
+        try {
+          const created = (await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }))).find((i) => i.subject === subject);
+          expect(created).toBeDefined();
+
+          const byVersion = await Array.fromAsync(
+            list(e2eContext, { fixedVersionId: version!.id }),
+          );
+          expect(byVersion.some((i) => i.subject === subject)).toBe(true);
+
+          const byCategory = await Array.fromAsync(
+            list(e2eContext, { categoryId: category!.id }),
+          );
+          expect(byCategory.some((i) => i.subject === subject)).toBe(true);
+
+          // priorityId is not unique to this issue, so this only checks
+          // inclusion rather than an exact match like the version/category
+          // filters above.
+          const byPriority = await Array.fromAsync(
+            list(e2eContext, { priorityId: issues[0].priority.id }),
+          );
+          expect(byPriority.some((i) => i.subject === subject)).toBe(true);
+
+          const byAuthor = await Array.fromAsync(
+            list(e2eContext, { authorId: "me" }),
+          );
+          expect(byAuthor.some((i) => i.subject === subject)).toBe(true);
+        } finally {
+          const cleanupList = await Array.fromAsync(list(e2eContext, {
+            projectId: project!.id,
+          }));
+          const leftovers = cleanupList.filter((i) => i.subject === subject);
+          for (const leftover of leftovers) {
+            await deleteIssue(e2eContext, leftover.id);
+          }
+          if (version !== undefined) {
+            await deleteVersion(e2eContext, version.id);
+          }
+          if (category !== undefined) {
+            await deleteIssueCategory(e2eContext, category.id);
           }
         }
       },

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -238,6 +238,15 @@ Deno.test("an empty include array is rejected by the type", () => {
   const _option: Parameters<typeof list>[1] = { include: [] };
 });
 
+Deno.test("categoryId requires projectId at the type level", () => {
+  // @ts-expect-error categoryId without projectId is not honored by Redmine
+  const _missingProject: Parameters<typeof list>[1] = { categoryId: 1 };
+  const _withProject: Parameters<typeof list>[1] = {
+    categoryId: 1,
+    projectId: 2,
+  };
+});
+
 function queryHandler(recorded: URLSearchParams[]) {
   return http.get(`${context.endpoint}/issues.json`, ({ request }) => {
     recorded.push(new URL(request.url).searchParams);
@@ -265,7 +274,7 @@ Deno.test("list id-based filters", async (t) => {
     },
     {
       name: "categoryId is sent as category_id",
-      option: { categoryId: 7 },
+      option: { categoryId: 7, projectId: 1 },
       param: "category_id",
       expected: "7",
     },

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -237,3 +237,67 @@ Deno.test("an empty include array is rejected by the type", () => {
   // @ts-expect-error include must name at least one value
   const _option: Parameters<typeof list>[1] = { include: [] };
 });
+
+function queryHandler(recorded: URLSearchParams[]) {
+  return http.get(`${context.endpoint}/issues.json`, ({ request }) => {
+    recorded.push(new URL(request.url).searchParams);
+    return HttpResponse.json({
+      issues: [],
+      total_count: 0,
+      offset: 0,
+      limit: 100,
+    });
+  });
+}
+
+Deno.test("list id-based filters", async (t) => {
+  const cases: {
+    name: string;
+    option: Parameters<typeof list>[1];
+    param: string;
+    expected: string;
+  }[] = [
+    {
+      name: "priorityId is sent as priority_id",
+      option: { priorityId: 3 },
+      param: "priority_id",
+      expected: "3",
+    },
+    {
+      name: "categoryId is sent as category_id",
+      option: { categoryId: 7 },
+      param: "category_id",
+      expected: "7",
+    },
+    {
+      name: "fixedVersionId is sent as fixed_version_id",
+      option: { fixedVersionId: 12 },
+      param: "fixed_version_id",
+      expected: "12",
+    },
+    {
+      name: "authorId accepts a numeric id",
+      option: { authorId: 5 },
+      param: "author_id",
+      expected: "5",
+    },
+    {
+      name: "authorId accepts the me literal",
+      option: { authorId: "me" },
+      param: "author_id",
+      expected: "me",
+    },
+  ];
+
+  for (const { name, option, param, expected } of cases) {
+    await t.step(name, async () => {
+      const recorded: URLSearchParams[] = [];
+      server.resetHandlers(queryHandler(recorded));
+
+      await Array.fromAsync(list(context, option));
+
+      expect(recorded.length).toStrictEqual(1);
+      expect(recorded[0].get(param)).toStrictEqual(expected);
+    });
+  }
+});

--- a/issues/list.ts
+++ b/issues/list.ts
@@ -10,7 +10,7 @@ const pageSize = 100;
 
 export async function* list(
   context: Context,
-  option: Partial<ListIssueQuery> = {},
+  option: ListIssueQuery = {},
 ): AsyncGenerator<ListIssue> {
   const convertedOption = parse(toListOption, option);
 

--- a/issues/mod.ts
+++ b/issues/mod.ts
@@ -24,7 +24,7 @@ export class Client {
    *
    * @param option The query option
    */
-  list(option: Partial<ListIssueQuery>): ReturnType<typeof list> {
+  list(option: ListIssueQuery): ReturnType<typeof list> {
     return list(this.#context, option);
   }
 

--- a/issues/mod.ts
+++ b/issues/mod.ts
@@ -24,7 +24,7 @@ export class Client {
    *
    * @param option The query option
    */
-  list(option: ListIssueQuery): ReturnType<typeof list> {
+  list(option: ListIssueQuery = {}): ReturnType<typeof list> {
     return list(this.#context, option);
   }
 

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -137,7 +137,11 @@ export type ListIssueQuery = {
   subprojectId: string;
   trackerId: number;
   statusId: "open" | "closed" | "*" | number;
+  priorityId: number;
+  categoryId: number;
+  fixedVersionId: number;
   assignedToId: number | "me";
+  authorId: number | "me";
   parentId: string;
   customField: {
     id: number;

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -130,20 +130,20 @@ export type CreateIssueQuery = {
 export type ListIncludeValue = "attachments" | "relations";
 
 export type ListIssueQuery = {
-  limit: number;
-  include: ListIncludeValue | [ListIncludeValue, ...ListIncludeValue[]];
-  issueId: number[] | number;
-  projectId: number;
-  subprojectId: string;
-  trackerId: number;
-  statusId: "open" | "closed" | "*" | number;
-  priorityId: number;
-  categoryId: number;
-  fixedVersionId: number;
-  assignedToId: number | "me";
-  authorId: number | "me";
-  parentId: string;
-  customField: {
+  limit?: number;
+  include?: ListIncludeValue | [ListIncludeValue, ...ListIncludeValue[]];
+  issueId?: number[] | number;
+  projectId?: number;
+  subprojectId?: string;
+  trackerId?: number;
+  statusId?: "open" | "closed" | "*" | number;
+  priorityId?: number;
+  categoryId?: number;
+  fixedVersionId?: number;
+  assignedToId?: number | "me";
+  authorId?: number | "me";
+  parentId?: string;
+  customField?: {
     id: number;
     value: string;
   }[];

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -129,22 +129,29 @@ export type CreateIssueQuery = {
 
 export type ListIncludeValue = "attachments" | "relations";
 
-export type ListIssueQuery = {
-  limit?: number;
-  include?: ListIncludeValue | [ListIncludeValue, ...ListIncludeValue[]];
-  issueId?: number[] | number;
-  projectId?: number;
-  subprojectId?: string;
-  trackerId?: number;
-  statusId?: "open" | "closed" | "*" | number;
-  priorityId?: number;
-  categoryId?: number;
-  fixedVersionId?: number;
-  assignedToId?: number | "me";
-  authorId?: number | "me";
-  parentId?: string;
-  customField?: {
-    id: number;
-    value: string;
-  }[];
-};
+export type ListIssueQuery =
+  & {
+    limit?: number;
+    include?: ListIncludeValue | [ListIncludeValue, ...ListIncludeValue[]];
+    issueId?: number[] | number;
+    projectId?: number;
+    subprojectId?: string;
+    trackerId?: number;
+    statusId?: "open" | "closed" | "*" | number;
+    priorityId?: number;
+    fixedVersionId?: number;
+    assignedToId?: number | "me";
+    authorId?: number | "me";
+    parentId?: string;
+    customField?: {
+      id: number;
+      value: string;
+    }[];
+  }
+  & (
+    // Redmine scopes the category filter to a project and ignores category_id
+    // otherwise, so requiring projectId whenever categoryId is present keeps a
+    // silently-ignored filter from type-checking.
+    | { categoryId?: never }
+    | { categoryId: number; projectId: number }
+  );

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -327,7 +327,11 @@ const listIssueQuery = partial(
     subprojectId: string(),
     trackerId: number(),
     statusId: union([picklist(["open", "closed", "*"]), number()]),
+    priorityId: number(),
+    categoryId: number(),
+    fixedVersionId: number(),
     assignedToId: union([number(), literal("me")]),
+    authorId: union([number(), literal("me")]),
     parentId: string(),
     customField: array(object({
       id: number(),


### PR DESCRIPTION
## Summary

Add priority_id, category_id, fixed_version_id, and author_id filters to the issue list endpoint.

## Details

Redmine's issue list accepts these fields as short-filter query params, but the client only exposed status, tracker, and assignee filtering, so callers could not narrow a listing by common fields such as a target version without hand-building the request.

The additions ride the existing snake_case/stringify path, and author_id mirrors assigned_to_id in also accepting the "me" literal.

## Confirmation

Ran the unit suite via `nix run .#check-deno` (113 passed), and the full e2e suite against a live Redmine 5.1 (24 tests / 95 steps passed), including a new step asserting each filter narrows the listing.

## Limitation

Date-range filters (created_on / updated_on), sort, and the general operator-based filter syntax (f[]/op[]/v[][]) remain unsupported and are out of scope here.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional issue list filters: priority, fixed version, category, and author.
  * Author and assignee filters now support the `"me"` value.
  * When using `categoryId`, `projectId` is required to ensure valid requests.
* **Tests**
  * Added end-to-end coverage verifying `fixedVersionId`, `categoryId`, `priorityId`, and `authorId` narrow results correctly.
  * Added unit/type coverage confirming ID-based query parameters serialize as expected (including `"me"` handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->