### PR TITLE
feat: require projectId when filtering issues by subproject

### DIFF
--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -618,8 +618,7 @@ Deno.test({
           );
           expect(included.some((i) => i.subject === subject)).toBe(true);
 
-          // subprojectId="!*" excludes subprojects, so every result is in the
-          // parent project itself and the subproject issue is gone.
+          // subprojectId="!*" excludes subprojects.
           const excluded = await Array.fromAsync(
             list(e2eContext, { projectId: parent!.id, subprojectId: "!*" }),
           );

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -7,6 +7,8 @@ import { update } from "../issues/update.ts";
 import { deleteIssue } from "../issues/delete.ts";
 import { create as createRelation } from "../issue-relations/create.ts";
 import { list as listProjects } from "../projects/list.ts";
+import { create as createProject } from "../projects/create.ts";
+import { deleteProject } from "../projects/delete.ts";
 import { create as createVersion } from "../versions/create.ts";
 import { list as listVersions } from "../versions/list.ts";
 import { deleteVersion } from "../versions/delete.ts";
@@ -568,6 +570,70 @@ Deno.test({
           }
           if (category !== undefined) {
             await deleteIssueCategory(e2eContext, category.id);
+          }
+        }
+      },
+    );
+
+    await t.step(
+      "GET /issues.json with subprojectId excludes subproject issues",
+      async () => {
+        const projects = await Array.fromAsync(listProjects(e2eContext));
+        const parent = projects.find((p) =>
+          p.identifier === "e2e-test-project"
+        );
+        expect(parent).toBeDefined();
+
+        const parentIssues = await Array.fromAsync(list(e2eContext, {
+          projectId: parent!.id,
+        }));
+        expect(parentIssues.length).toBeGreaterThan(0);
+
+        const childIdentifier = "e2e-subproject-filter";
+        await createProject(e2eContext, {
+          name: "E2E Subproject Filter",
+          identifier: childIdentifier,
+          isPublic: true,
+          parentId: parent!.id,
+          enableModuleNames: ["issue_tracking"],
+        });
+        const child = (await Array.fromAsync(listProjects(e2eContext))).find((
+          p,
+        ) => p.identifier === childIdentifier);
+        expect(child).toBeDefined();
+
+        const subject = "E2E Subproject Issue";
+        await createIssue(e2eContext, {
+          projectId: child!.id,
+          trackerId: parentIssues[0].tracker.id,
+          statusId: parentIssues[0].status.id,
+          priorityId: parentIssues[0].priority.id,
+          subject,
+        });
+
+        try {
+          // Listing the parent includes subproject issues by default.
+          const included = await Array.fromAsync(
+            list(e2eContext, { projectId: parent!.id }),
+          );
+          expect(included.some((i) => i.subject === subject)).toBe(true);
+
+          // subprojectId="!*" excludes subprojects, so every result is in the
+          // parent project itself and the subproject issue is gone.
+          const excluded = await Array.fromAsync(
+            list(e2eContext, { projectId: parent!.id, subprojectId: "!*" }),
+          );
+          expect(excluded.every((i) => i.project.id === parent!.id)).toBe(true);
+          expect(excluded.some((i) => i.subject === subject)).toBe(false);
+        } finally {
+          const leftovers = (await Array.fromAsync(list(e2eContext, {
+            projectId: child!.id,
+          }))).filter((i) => i.subject === subject);
+          for (const leftover of leftovers) {
+            await deleteIssue(e2eContext, leftover.id);
+          }
+          if (child !== undefined) {
+            await deleteProject(e2eContext, child.id);
           }
         }
       },

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -247,6 +247,15 @@ Deno.test("categoryId requires projectId at the type level", () => {
   };
 });
 
+Deno.test("subprojectId requires projectId at the type level", () => {
+  // @ts-expect-error subprojectId without projectId is not honored by Redmine
+  const _missingProject: Parameters<typeof list>[1] = { subprojectId: "1" };
+  const _withProject: Parameters<typeof list>[1] = {
+    subprojectId: "1",
+    projectId: 2,
+  };
+});
+
 function queryHandler(recorded: URLSearchParams[]) {
   return http.get(`${context.endpoint}/issues.json`, ({ request }) => {
     recorded.push(new URL(request.url).searchParams);

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -135,7 +135,6 @@ export type ListIssueQuery =
     include?: ListIncludeValue | [ListIncludeValue, ...ListIncludeValue[]];
     issueId?: number[] | number;
     projectId?: number;
-    subprojectId?: string;
     trackerId?: number;
     statusId?: "open" | "closed" | "*" | number;
     priorityId?: number;
@@ -154,4 +153,11 @@ export type ListIssueQuery =
     // silently-ignored filter from type-checking.
     | { categoryId?: never }
     | { categoryId: number; projectId: number }
+  )
+  & (
+    // subproject_id is only an available filter when a project is in scope
+    // (and that project is not a leaf); without projectId Redmine ignores it
+    // and returns every issue, so require projectId alongside it.
+    | { subprojectId?: never }
+    | { subprojectId: string; projectId: number }
   );

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -148,16 +148,12 @@ export type ListIssueQuery =
     }[];
   }
   & (
-    // Redmine scopes the category filter to a project and ignores category_id
-    // otherwise, so requiring projectId whenever categoryId is present keeps a
-    // silently-ignored filter from type-checking.
+    // Redmine ignores category_id without a project scope.
     | { categoryId?: never }
     | { categoryId: number; projectId: number }
   )
   & (
-    // subproject_id is only an available filter when a project is in scope
-    // (and that project is not a leaf); without projectId Redmine ignores it
-    // and returns every issue, so require projectId alongside it.
+    // Likewise, subproject_id is ignored without a project scope.
     | { subprojectId?: never }
     | { subprojectId: string; projectId: number }
   );


### PR DESCRIPTION
## Summary

Encode `subprojectId ⇒ projectId` in `ListIssueQuery` so the subproject filter cannot be requested without a project scope.

## Details

Redmine only exposes the `subproject_id` filter when a project is in scope (and that project is not a leaf); without `projectId` it silently ignores the parameter and returns every issue.

Confirmed against the Redmine source (`IssueQuery#build_from_params` / `available_filters` add the filter only `if project`) and empirically. This mirrors the `categoryId ⇒ projectId` constraint added in #454.

## Confirmation

`nix run .#check-deno` (115 tests, incl. a type-level `@ts-expect-error` proving `subprojectId` alone is rejected), and the full e2e suite against a live Redmine 5.1 (24 tests / 96 steps), including a new step asserting `subprojectId="!*"` with `projectId` excludes subproject issues.

## Limitation

The type cannot express that the parent project must be non-leaf (a runtime data condition); a `subprojectId` filter against a leaf project still compiles but is ignored by Redmine.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue filtering so subproject issues are excluded when using `subprojectId="!*"` together with a project filter.
  * Strengthened filter validation to ensure `subprojectId` can only be used when `projectId` is provided.
* **Tests**
  * Added end-to-end coverage for parent vs. subproject issue listing and `subprojectId="!*"` behavior.
  * Added type-level tests to verify valid and invalid filter combinations at compile time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->