### PR TITLE
ci: run e2e tests against Redmine 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine-version: ["5.1", "6.0", "6.1"]
+        redmine-version: ["5.1", "6.0", "6.1", "7.0"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Add Redmine 7.0 to the e2e test matrix so the client is verified against the latest major release.

## Details

Redmine 7.0 was released, and the e2e matrix only covered 5.1 / 6.0 / 6.1.

Adding it as a matrix entry (rather than replacing an existing one) keeps coverage of the older supported versions while catching any 7.0 API incompatibilities.

## Confirmation

Ran the full e2e suite locally against `redmine:7.0` (built via `e2e/compose.yaml`, host port remapped to avoid a conflict) and all 24 tests / 96 steps passed.

The `e2e/setup.ts` bootstrap, including the `redmine_issue_templates` plugin migration and seeding, completed successfully, so the bundled plugin is compatible with Redmine 7.

Also ran `nix run .#check-actions` (zizmor) successfully against the updated workflow.

## Limitation

No known limitations.

Generated with: Claude

https://claude.ai/code/session_01LkzNJYEfNjN3taqifA5e85