### PR TITLE
feat: filter issue list by date

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Redmine's short filter operator for "tomorrow" (see issues/validator.ts),
+# not a typo of "and".
+nd = "nd"

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -653,6 +653,41 @@ Deno.test({
       },
     );
 
+    await t.step(
+      "GET /issues.json with relative date filters resolves",
+      async () => {
+        // assertResponse throws on Redmine's 422, so a resolved promise is
+        // enough to prove each relative wire form (t-, >t-, <t-, ><t-, t+,
+        // >t+, <t+, ><t+) round-trips.
+        await Array.fromAsync(list(e2eContext, { createdOn: { daysAgo: 3 } }));
+        await Array.fromAsync(
+          list(e2eContext, { createdOn: { from: { daysAgo: 3 } } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { createdOn: { to: { daysAgo: 3 } } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, {
+            createdOn: { from: { daysAgo: 3 }, to: "today" },
+          }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { dueDate: { daysFromNow: 5 } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { dueDate: { from: { daysFromNow: 5 } } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { dueDate: { to: { daysFromNow: 5 } } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, {
+            dueDate: { from: "today", to: { daysFromNow: 5 } },
+          }),
+        );
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -638,6 +638,21 @@ Deno.test({
       },
     );
 
+    await t.step(
+      "GET /issues.json with absolute date filters resolves",
+      async () => {
+        const from = new Date("2026-07-01T00:00:00Z");
+        const to = new Date("2026-07-31T00:00:00Z");
+
+        // assertResponse throws on Redmine's 422, so a resolved promise is
+        // enough to prove each wire form (=, >=, <=, ><) round-trips.
+        await Array.fromAsync(list(e2eContext, { createdOn: from }));
+        await Array.fromAsync(list(e2eContext, { updatedOn: { from } }));
+        await Array.fromAsync(list(e2eContext, { closedOn: { to } }));
+        await Array.fromAsync(list(e2eContext, { startDate: { from, to } }));
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -688,6 +688,30 @@ Deno.test({
       },
     );
 
+    await t.step(
+      "GET /issues.json with named period and presence date filters resolves",
+      async () => {
+        // assertResponse throws on Redmine's 422, so a resolved promise is
+        // enough to prove each literal's wire form (t, ld, w, lw, l2w, m,
+        // lm, y, *, !*, and, nw, nm) round-trips.
+        await Array.fromAsync(list(e2eContext, { createdOn: "today" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "yesterday" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "thisWeek" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "lastWeek" }));
+        await Array.fromAsync(
+          list(e2eContext, { createdOn: "lastTwoWeeks" }),
+        );
+        await Array.fromAsync(list(e2eContext, { createdOn: "thisMonth" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "lastMonth" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "thisYear" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "any" }));
+        await Array.fromAsync(list(e2eContext, { createdOn: "none" }));
+        await Array.fromAsync(list(e2eContext, { dueDate: "tomorrow" }));
+        await Array.fromAsync(list(e2eContext, { dueDate: "nextWeek" }));
+        await Array.fromAsync(list(e2eContext, { dueDate: "nextMonth" }));
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -693,7 +693,7 @@ Deno.test({
       async () => {
         // assertResponse throws on Redmine's 422, so a resolved promise is
         // enough to prove each literal's wire form (t, ld, w, lw, l2w, m,
-        // lm, y, *, !*, and, nw, nm) round-trips.
+        // lm, y, *, !*, nd, nw, nm) round-trips.
         await Array.fromAsync(list(e2eContext, { createdOn: "today" }));
         await Array.fromAsync(list(e2eContext, { createdOn: "yesterday" }));
         await Array.fromAsync(list(e2eContext, { createdOn: "thisWeek" }));

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -712,6 +712,51 @@ Deno.test({
       },
     );
 
+    await t.step(
+      "GET /issues.json applies from as the lower bound and to as the upper",
+      async () => {
+        const epoch = new Date("2000-01-01T00:00:00Z");
+
+        const upToEpoch = await Array.fromAsync(
+          list(e2eContext, { createdOn: { to: epoch } }),
+        );
+        const sinceEpoch = await Array.fromAsync(
+          list(e2eContext, { createdOn: { from: epoch } }),
+        );
+
+        expect(upToEpoch).toStrictEqual([]);
+        expect(sinceEpoch.length).toBeGreaterThan(0);
+      },
+    );
+
+    await t.step(
+      "GET /issues.json resolves today against the server's calendar day",
+      async () => {
+        const createdToday = await Array.fromAsync(
+          list(e2eContext, { createdOn: "today" }),
+        );
+
+        expect(createdToday.length).toBeGreaterThan(0);
+      },
+    );
+
+    await t.step(
+      "GET /issues.json partitions issues between any and none",
+      async () => {
+        const all = await Array.fromAsync(list(e2eContext, {}));
+        const withDueDate = await Array.fromAsync(
+          list(e2eContext, { dueDate: "any" }),
+        );
+        const withoutDueDate = await Array.fromAsync(
+          list(e2eContext, { dueDate: "none" }),
+        );
+
+        expect(withDueDate.length + withoutDueDate.length).toStrictEqual(
+          all.length,
+        );
+      },
+    );
+
     await t.step("DELETE /issues/:id.json should delete an issue", async () => {
       const issues = await Array.fromAsync(list(e2eContext, {}));
       const issue = issues.find((i) => i.subject === "E2E Updated Issue");

--- a/e2e/issues.test.ts
+++ b/e2e/issues.test.ts
@@ -645,11 +645,18 @@ Deno.test({
         const to = new Date("2026-07-31T00:00:00Z");
 
         // assertResponse throws on Redmine's 422, so a resolved promise is
-        // enough to prove each wire form (=, >=, <=, ><) round-trips.
-        await Array.fromAsync(list(e2eContext, { createdOn: from }));
-        await Array.fromAsync(list(e2eContext, { updatedOn: { from } }));
-        await Array.fromAsync(list(e2eContext, { closedOn: { to } }));
-        await Array.fromAsync(list(e2eContext, { startDate: { from, to } }));
+        // enough to prove each wire form (=, >=, <=, ><) round-trips. limit
+        // caps each probe at one request, since the matched issues are not
+        // being inspected and walking every page would slow down as fixture
+        // data accumulates.
+        await Array.fromAsync(list(e2eContext, { limit: 1, createdOn: from }));
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, updatedOn: { from } }),
+        );
+        await Array.fromAsync(list(e2eContext, { limit: 1, closedOn: { to } }));
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, startDate: { from, to } }),
+        );
       },
     );
 
@@ -658,30 +665,35 @@ Deno.test({
       async () => {
         // assertResponse throws on Redmine's 422, so a resolved promise is
         // enough to prove each relative wire form (t-, >t-, <t-, ><t-, t+,
-        // >t+, <t+, ><t+) round-trips.
-        await Array.fromAsync(list(e2eContext, { createdOn: { daysAgo: 3 } }));
+        // >t+, <t+, ><t+) round-trips. limit caps each probe at one request,
+        // as above.
         await Array.fromAsync(
-          list(e2eContext, { createdOn: { from: { daysAgo: 3 } } }),
+          list(e2eContext, { limit: 1, createdOn: { daysAgo: 3 } }),
         );
         await Array.fromAsync(
-          list(e2eContext, { createdOn: { to: { daysAgo: 3 } } }),
+          list(e2eContext, { limit: 1, createdOn: { from: { daysAgo: 3 } } }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: { to: { daysAgo: 3 } } }),
         );
         await Array.fromAsync(
           list(e2eContext, {
+            limit: 1,
             createdOn: { from: { daysAgo: 3 }, to: "today" },
           }),
         );
         await Array.fromAsync(
-          list(e2eContext, { dueDate: { daysFromNow: 5 } }),
+          list(e2eContext, { limit: 1, dueDate: { daysFromNow: 5 } }),
         );
         await Array.fromAsync(
-          list(e2eContext, { dueDate: { from: { daysFromNow: 5 } } }),
+          list(e2eContext, { limit: 1, dueDate: { from: { daysFromNow: 5 } } }),
         );
         await Array.fromAsync(
-          list(e2eContext, { dueDate: { to: { daysFromNow: 5 } } }),
+          list(e2eContext, { limit: 1, dueDate: { to: { daysFromNow: 5 } } }),
         );
         await Array.fromAsync(
           list(e2eContext, {
+            limit: 1,
             dueDate: { from: "today", to: { daysFromNow: 5 } },
           }),
         );
@@ -693,22 +705,45 @@ Deno.test({
       async () => {
         // assertResponse throws on Redmine's 422, so a resolved promise is
         // enough to prove each literal's wire form (t, ld, w, lw, l2w, m,
-        // lm, y, *, !*, nd, nw, nm) round-trips.
-        await Array.fromAsync(list(e2eContext, { createdOn: "today" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "yesterday" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "thisWeek" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "lastWeek" }));
+        // lm, y, *, !*, nd, nw, nm) round-trips. limit caps each probe at one
+        // request, as above; "any" would otherwise walk the whole table.
         await Array.fromAsync(
-          list(e2eContext, { createdOn: "lastTwoWeeks" }),
+          list(e2eContext, { limit: 1, createdOn: "today" }),
         );
-        await Array.fromAsync(list(e2eContext, { createdOn: "thisMonth" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "lastMonth" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "thisYear" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "any" }));
-        await Array.fromAsync(list(e2eContext, { createdOn: "none" }));
-        await Array.fromAsync(list(e2eContext, { dueDate: "tomorrow" }));
-        await Array.fromAsync(list(e2eContext, { dueDate: "nextWeek" }));
-        await Array.fromAsync(list(e2eContext, { dueDate: "nextMonth" }));
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "yesterday" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "thisWeek" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "lastWeek" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "lastTwoWeeks" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "thisMonth" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "lastMonth" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "thisYear" }),
+        );
+        await Array.fromAsync(list(e2eContext, { limit: 1, createdOn: "any" }));
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, createdOn: "none" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, dueDate: "tomorrow" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, dueDate: "nextWeek" }),
+        );
+        await Array.fromAsync(
+          list(e2eContext, { limit: 1, dueDate: "nextMonth" }),
+        );
       },
     );
 

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -502,7 +502,7 @@ Deno.test("list date filters", async (t) => {
       name: '"tomorrow" sends a named-period filter',
       option: { dueDate: "tomorrow" },
       param: "due_date",
-      expected: "and",
+      expected: "nd",
     },
     {
       name: '"nextWeek" sends a named-period filter',

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -438,6 +438,84 @@ Deno.test("list date filters", async (t) => {
       param: "due_date",
       expected: "><t+|5",
     },
+    {
+      name: '"today" sends a named-period filter',
+      option: { createdOn: "today" },
+      param: "created_on",
+      expected: "t",
+    },
+    {
+      name: '"yesterday" sends a named-period filter',
+      option: { createdOn: "yesterday" },
+      param: "created_on",
+      expected: "ld",
+    },
+    {
+      name: '"thisWeek" sends a named-period filter',
+      option: { createdOn: "thisWeek" },
+      param: "created_on",
+      expected: "w",
+    },
+    {
+      name: '"lastWeek" sends a named-period filter',
+      option: { createdOn: "lastWeek" },
+      param: "created_on",
+      expected: "lw",
+    },
+    {
+      name: '"lastTwoWeeks" sends a named-period filter',
+      option: { createdOn: "lastTwoWeeks" },
+      param: "created_on",
+      expected: "l2w",
+    },
+    {
+      name: '"thisMonth" sends a named-period filter',
+      option: { createdOn: "thisMonth" },
+      param: "created_on",
+      expected: "m",
+    },
+    {
+      name: '"lastMonth" sends a named-period filter',
+      option: { createdOn: "lastMonth" },
+      param: "created_on",
+      expected: "lm",
+    },
+    {
+      name: '"thisYear" sends a named-period filter',
+      option: { createdOn: "thisYear" },
+      param: "created_on",
+      expected: "y",
+    },
+    {
+      name: '"any" sends a value-presence filter',
+      option: { createdOn: "any" },
+      param: "created_on",
+      expected: "*",
+    },
+    {
+      name: '"none" sends a value-presence filter',
+      option: { createdOn: "none" },
+      param: "created_on",
+      expected: "!*",
+    },
+    {
+      name: '"tomorrow" sends a named-period filter',
+      option: { dueDate: "tomorrow" },
+      param: "due_date",
+      expected: "and",
+    },
+    {
+      name: '"nextWeek" sends a named-period filter',
+      option: { dueDate: "nextWeek" },
+      param: "due_date",
+      expected: "nw",
+    },
+    {
+      name: '"nextMonth" sends a named-period filter',
+      option: { dueDate: "nextMonth" },
+      param: "due_date",
+      expected: "nm",
+    },
   ];
 
   for (const { name, option, param, expected } of cases) {
@@ -533,6 +611,32 @@ Deno.test(
       // @ts-expect-error createdOn is PastDateFilter; :date_past rejects daysFromNow with a 422
       createdOn: { daysFromNow: 3 },
     };
+  },
+);
+
+Deno.test(
+  "a future-looking named period on createdOn is rejected by the type",
+  async (t) => {
+    await t.step('"tomorrow"', () => {
+      const _option: Parameters<typeof list>[1] = {
+        // @ts-expect-error createdOn is PastDateFilter; :date_past rejects "tomorrow" with a 422
+        createdOn: "tomorrow",
+      };
+    });
+
+    await t.step('"nextWeek"', () => {
+      const _option: Parameters<typeof list>[1] = {
+        // @ts-expect-error createdOn is PastDateFilter; :date_past rejects "nextWeek" with a 422
+        createdOn: "nextWeek",
+      };
+    });
+
+    await t.step('"nextMonth"', () => {
+      const _option: Parameters<typeof list>[1] = {
+        // @ts-expect-error createdOn is PastDateFilter; :date_past rejects "nextMonth" with a 422
+        createdOn: "nextMonth",
+      };
+    });
   },
 );
 

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -598,7 +598,7 @@ Deno.test(
   () => {
     const someDate = new Date("2026-07-01T00:00:00Z");
     const _option: Parameters<typeof list>[1] = {
-      // @ts-expect-error "today" is not an absolute bound in this increment
+      // @ts-expect-error no union member pairs a Date bound with "today"
       createdOn: { from: someDate, to: "today" },
     };
   },

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -319,3 +319,158 @@ Deno.test("list id-based filters", async (t) => {
     });
   }
 });
+
+Deno.test("list date filters", async (t) => {
+  const cases: {
+    name: string;
+    option: Parameters<typeof list>[1];
+    param: string;
+    expected: string;
+  }[] = [
+    {
+      name: "a bare Date sends an exact-match filter",
+      option: { createdOn: new Date("2026-07-01T00:00:00Z") },
+      param: "created_on",
+      expected: "=2026-07-01",
+    },
+    {
+      name: "{ from } alone sends a lower-bound filter",
+      option: { createdOn: { from: new Date("2026-07-01T00:00:00Z") } },
+      param: "created_on",
+      expected: ">=2026-07-01",
+    },
+    {
+      name: "{ to } alone sends an upper-bound filter",
+      option: { createdOn: { to: new Date("2026-07-31T00:00:00Z") } },
+      param: "created_on",
+      expected: "<=2026-07-31",
+    },
+    {
+      name: "{ from, to } sends a range filter",
+      option: {
+        createdOn: {
+          from: new Date("2026-07-01T00:00:00Z"),
+          to: new Date("2026-07-31T00:00:00Z"),
+        },
+      },
+      param: "created_on",
+      expected: "><2026-07-01|2026-07-31",
+    },
+    {
+      name:
+        "the time part of a Date is dropped and the UTC calendar day is sent",
+      option: { createdOn: new Date("2026-07-01T23:59:59Z") },
+      param: "created_on",
+      expected: "=2026-07-01",
+    },
+    {
+      name: "startDate is sent as start_date",
+      option: { startDate: new Date("2026-07-01T00:00:00Z") },
+      param: "start_date",
+      expected: "=2026-07-01",
+    },
+    {
+      name: "dueDate is sent as due_date",
+      option: { dueDate: new Date("2026-07-01T00:00:00Z") },
+      param: "due_date",
+      expected: "=2026-07-01",
+    },
+    {
+      name: "updatedOn is sent as updated_on",
+      option: { updatedOn: new Date("2026-07-01T00:00:00Z") },
+      param: "updated_on",
+      expected: "=2026-07-01",
+    },
+    {
+      name: "closedOn is sent as closed_on",
+      option: { closedOn: new Date("2026-07-01T00:00:00Z") },
+      param: "closed_on",
+      expected: "=2026-07-01",
+    },
+  ];
+
+  for (const { name, option, param, expected } of cases) {
+    await t.step(name, async () => {
+      const recorded: URLSearchParams[] = [];
+      server.resetHandlers(queryHandler(recorded));
+
+      await Array.fromAsync(list(context, option));
+
+      expect(recorded.length).toStrictEqual(1);
+      expect(recorded[0].get(param)).toStrictEqual(expected);
+    });
+  }
+
+  await t.step(
+    "omitting every date filter sends no date parameter",
+    async () => {
+      const recorded: URLSearchParams[] = [];
+      server.resetHandlers(queryHandler(recorded));
+
+      await Array.fromAsync(list(context, {}));
+
+      expect(recorded.length).toStrictEqual(1);
+      for (
+        const param of [
+          "start_date",
+          "due_date",
+          "created_on",
+          "updated_on",
+          "closed_on",
+        ]
+      ) {
+        expect(recorded[0].get(param)).toBeNull();
+      }
+    },
+  );
+
+  await t.step(
+    "createdOn and dueDate given together are both sent",
+    async () => {
+      const recorded: URLSearchParams[] = [];
+      server.resetHandlers(queryHandler(recorded));
+
+      await Array.fromAsync(list(context, {
+        createdOn: new Date("2026-07-01T00:00:00Z"),
+        dueDate: { from: new Date("2026-07-10T00:00:00Z") },
+      }));
+
+      expect(recorded.length).toStrictEqual(1);
+      expect(recorded[0].get("created_on")).toStrictEqual("=2026-07-01");
+      expect(recorded[0].get("due_date")).toStrictEqual(">=2026-07-10");
+    },
+  );
+
+  await t.step(
+    "a date filter given alongside customField does not drop either parameter",
+    async () => {
+      const recorded: URLSearchParams[] = [];
+      server.resetHandlers(queryHandler(recorded));
+
+      await Array.fromAsync(list(context, {
+        createdOn: new Date("2026-07-01T00:00:00Z"),
+        customField: [{ id: 1, value: "hi" }],
+      }));
+
+      expect(recorded.length).toStrictEqual(1);
+      expect(recorded[0].get("created_on")).toStrictEqual("=2026-07-01");
+      expect(recorded[0].get("cf_1")).toStrictEqual("hi");
+    },
+  );
+});
+
+Deno.test("an empty date filter object is rejected by the type", () => {
+  // @ts-expect-error a date filter must set at least one of from/to
+  const _option: Parameters<typeof list>[1] = { createdOn: {} };
+});
+
+Deno.test(
+  "mixing an absolute bound with a relative bound is rejected by the type",
+  () => {
+    const someDate = new Date("2026-07-01T00:00:00Z");
+    // @ts-expect-error "today" is not an absolute bound in this increment
+    const _option: Parameters<typeof list>[1] = {
+      createdOn: { from: someDate, to: "today" },
+    };
+  },
+);

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -387,6 +387,57 @@ Deno.test("list date filters", async (t) => {
       param: "closed_on",
       expected: "=2026-07-01",
     },
+    {
+      name: "{ daysAgo } sends a relative exact-match filter",
+      option: { createdOn: { daysAgo: 3 } },
+      param: "created_on",
+      expected: "t-|3",
+    },
+    {
+      name:
+        "{ from: { daysAgo } } sends a lower-bound filter with no upper bound",
+      option: { createdOn: { from: { daysAgo: 3 } } },
+      param: "created_on",
+      expected: ">t-|3",
+    },
+    {
+      name: "{ to: { daysAgo } } sends an upper-bound filter",
+      option: { createdOn: { to: { daysAgo: 3 } } },
+      param: "created_on",
+      expected: "<t-|3",
+    },
+    {
+      name: '{ from: { daysAgo }, to: "today" } sends a bounded range filter',
+      option: { createdOn: { from: { daysAgo: 3 }, to: "today" } },
+      param: "created_on",
+      expected: "><t-|3",
+    },
+    {
+      name: "{ daysFromNow } sends a relative exact-match filter",
+      option: { dueDate: { daysFromNow: 5 } },
+      param: "due_date",
+      expected: "t+|5",
+    },
+    {
+      name: "{ from: { daysFromNow } } sends a lower-bound filter",
+      option: { dueDate: { from: { daysFromNow: 5 } } },
+      param: "due_date",
+      expected: ">t+|5",
+    },
+    {
+      name:
+        "{ to: { daysFromNow } } sends an upper-bound filter with no lower bound",
+      option: { dueDate: { to: { daysFromNow: 5 } } },
+      param: "due_date",
+      expected: "<t+|5",
+    },
+    {
+      name:
+        '{ from: "today", to: { daysFromNow } } sends a bounded range filter',
+      option: { dueDate: { from: "today", to: { daysFromNow: 5 } } },
+      param: "due_date",
+      expected: "><t+|5",
+    },
   ];
 
   for (const { name, option, param, expected } of cases) {
@@ -472,5 +523,40 @@ Deno.test(
       // @ts-expect-error "today" is not an absolute bound in this increment
       createdOn: { from: someDate, to: "today" },
     };
+  },
+);
+
+Deno.test(
+  "a future-looking filter on createdOn is rejected by the type",
+  () => {
+    const _option: Parameters<typeof list>[1] = {
+      // @ts-expect-error createdOn is PastDateFilter; :date_past rejects daysFromNow with a 422
+      createdOn: { daysFromNow: 3 },
+    };
+  },
+);
+
+Deno.test(
+  "a negative day count is rejected at parse time",
+  async () => {
+    const recorded: URLSearchParams[] = [];
+    server.resetHandlers(queryHandler(recorded));
+
+    await expect(Array.fromAsync(list(context, { createdOn: { daysAgo: -1 } })))
+      .rejects.toThrow();
+    expect(recorded.length).toStrictEqual(0);
+  },
+);
+
+Deno.test(
+  "a fractional day count is rejected at parse time",
+  async () => {
+    const recorded: URLSearchParams[] = [];
+    server.resetHandlers(queryHandler(recorded));
+
+    await expect(
+      Array.fromAsync(list(context, { createdOn: { daysAgo: 1.5 } })),
+    ).rejects.toThrow();
+    expect(recorded.length).toStrictEqual(0);
   },
 );

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -468,8 +468,8 @@ Deno.test(
   "mixing an absolute bound with a relative bound is rejected by the type",
   () => {
     const someDate = new Date("2026-07-01T00:00:00Z");
-    // @ts-expect-error "today" is not an absolute bound in this increment
     const _option: Parameters<typeof list>[1] = {
+      // @ts-expect-error "today" is not an absolute bound in this increment
       createdOn: { from: someDate, to: "today" },
     };
   },

--- a/issues/list.test.ts
+++ b/issues/list.test.ts
@@ -391,52 +391,52 @@ Deno.test("list date filters", async (t) => {
       name: "{ daysAgo } sends a relative exact-match filter",
       option: { createdOn: { daysAgo: 3 } },
       param: "created_on",
-      expected: "t-|3",
+      expected: "t-3",
     },
     {
       name:
         "{ from: { daysAgo } } sends a lower-bound filter with no upper bound",
       option: { createdOn: { from: { daysAgo: 3 } } },
       param: "created_on",
-      expected: ">t-|3",
+      expected: ">t-3",
     },
     {
       name: "{ to: { daysAgo } } sends an upper-bound filter",
       option: { createdOn: { to: { daysAgo: 3 } } },
       param: "created_on",
-      expected: "<t-|3",
+      expected: "<t-3",
     },
     {
       name: '{ from: { daysAgo }, to: "today" } sends a bounded range filter',
       option: { createdOn: { from: { daysAgo: 3 }, to: "today" } },
       param: "created_on",
-      expected: "><t-|3",
+      expected: "><t-3",
     },
     {
       name: "{ daysFromNow } sends a relative exact-match filter",
       option: { dueDate: { daysFromNow: 5 } },
       param: "due_date",
-      expected: "t+|5",
+      expected: "t+5",
     },
     {
       name: "{ from: { daysFromNow } } sends a lower-bound filter",
       option: { dueDate: { from: { daysFromNow: 5 } } },
       param: "due_date",
-      expected: ">t+|5",
+      expected: ">t+5",
     },
     {
       name:
         "{ to: { daysFromNow } } sends an upper-bound filter with no lower bound",
       option: { dueDate: { to: { daysFromNow: 5 } } },
       param: "due_date",
-      expected: "<t+|5",
+      expected: "<t+5",
     },
     {
       name:
         '{ from: "today", to: { daysFromNow } } sends a bounded range filter',
       option: { dueDate: { from: "today", to: { daysFromNow: 5 } } },
       param: "due_date",
-      expected: "><t+|5",
+      expected: "><t+5",
     },
     {
       name: '"today" sends a named-period filter',

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -129,12 +129,15 @@ export type CreateIssueQuery = {
 
 export type ListIncludeValue = "attachments" | "relations";
 
-// `from`/`to` are both inclusive: Redmine's absolute date operators are
-// limited to `=`, `>=`, `<=`, `><` (no strict `>`/`<`), so every bound this
-// library exposes is inclusive too. This type omits future-looking
-// operators (e.g. `daysFromNow`) because Redmine's `:date_past` fields
-// (created_on/updated_on/closed_on) reject them with a 422; DateFilter below
-// is the wider type for fields that accept them.
+/**
+ * A date filter for the issue fields Redmine types as `:date_past`.
+ *
+ * Both `from` and `to` are inclusive, because Redmine's absolute date
+ * operators are limited to `=`, `>=`, `<=` and `><` with no strict `>` or `<`.
+ *
+ * Future-looking operators are absent: Redmine rejects them on these fields
+ * with a 422. {@link DateFilter} is the wider type that includes them.
+ */
 export type PastDateFilter =
   | Date
   | { daysAgo: number }
@@ -153,9 +156,10 @@ export type PastDateFilter =
   | { from: { daysAgo: number }; to?: "today" }
   | { to: { daysAgo: number } };
 
-// Widens PastDateFilter with future-looking operators, for the `:date`
-// fields (start_date/due_date) that accept them - unlike `:date_past` fields,
-// which reject them with a 422 (see PastDateFilter above).
+/**
+ * A date filter for the issue fields Redmine types as `:date`, which accept
+ * the future-looking operators {@link PastDateFilter} omits.
+ */
 export type DateFilter =
   | PastDateFilter
   | { daysFromNow: number }

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -138,6 +138,16 @@ export type ListIncludeValue = "attachments" | "relations";
 export type PastDateFilter =
   | Date
   | { daysAgo: number }
+  | "today"
+  | "yesterday"
+  | "thisWeek"
+  | "lastWeek"
+  | "lastTwoWeeks"
+  | "thisMonth"
+  | "lastMonth"
+  | "thisYear"
+  | "any"
+  | "none"
   | { from: Date; to?: Date }
   | { from?: Date; to: Date }
   | { from: { daysAgo: number }; to?: "today" }
@@ -149,6 +159,9 @@ export type PastDateFilter =
 export type DateFilter =
   | PastDateFilter
   | { daysFromNow: number }
+  | "tomorrow"
+  | "nextWeek"
+  | "nextMonth"
   | { from: { daysFromNow: number } }
   | { to: { daysFromNow: number } }
   | { from: "today"; to: { daysFromNow: number } };

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -131,18 +131,27 @@ export type ListIncludeValue = "attachments" | "relations";
 
 // `from`/`to` are both inclusive: Redmine's absolute date operators are
 // limited to `=`, `>=`, `<=`, `><` (no strict `>`/`<`), so every bound this
-// library exposes is inclusive too.
+// library exposes is inclusive too. This type omits future-looking
+// operators (e.g. `daysFromNow`) because Redmine's `:date_past` fields
+// (created_on/updated_on/closed_on) reject them with a 422; DateFilter below
+// is the wider type for fields that accept them.
 export type PastDateFilter =
   | Date
+  | { daysAgo: number }
   | { from: Date; to?: Date }
-  | { from?: Date; to: Date };
+  | { from?: Date; to: Date }
+  | { from: { daysAgo: number }; to?: "today" }
+  | { to: { daysAgo: number } };
 
-// Equal to PastDateFilter for now. Later increments widen this with
-// future-looking operators (e.g. `daysFromNow`), which Redmine's
-// `:date_past` fields (created_on/updated_on/closed_on) reject with a 422 -
-// that rejection is why PastDateFilter stays a separate, narrower type
-// rather than an alias collapsing into this one.
-export type DateFilter = PastDateFilter;
+// Widens PastDateFilter with future-looking operators, for the `:date`
+// fields (start_date/due_date) that accept them - unlike `:date_past` fields,
+// which reject them with a 422 (see PastDateFilter above).
+export type DateFilter =
+  | PastDateFilter
+  | { daysFromNow: number }
+  | { from: { daysFromNow: number } }
+  | { to: { daysFromNow: number } }
+  | { from: "today"; to: { daysFromNow: number } };
 
 export type ListIssueQuery =
   & {

--- a/issues/type.ts
+++ b/issues/type.ts
@@ -129,6 +129,21 @@ export type CreateIssueQuery = {
 
 export type ListIncludeValue = "attachments" | "relations";
 
+// `from`/`to` are both inclusive: Redmine's absolute date operators are
+// limited to `=`, `>=`, `<=`, `><` (no strict `>`/`<`), so every bound this
+// library exposes is inclusive too.
+export type PastDateFilter =
+  | Date
+  | { from: Date; to?: Date }
+  | { from?: Date; to: Date };
+
+// Equal to PastDateFilter for now. Later increments widen this with
+// future-looking operators (e.g. `daysFromNow`), which Redmine's
+// `:date_past` fields (created_on/updated_on/closed_on) reject with a 422 -
+// that rejection is why PastDateFilter stays a separate, narrower type
+// rather than an alias collapsing into this one.
+export type DateFilter = PastDateFilter;
+
 export type ListIssueQuery =
   & {
     limit?: number;
@@ -142,6 +157,11 @@ export type ListIssueQuery =
     assignedToId?: number | "me";
     authorId?: number | "me";
     parentId?: string;
+    startDate?: DateFilter;
+    dueDate?: DateFilter;
+    createdOn?: PastDateFilter;
+    updatedOn?: PastDateFilter;
+    closedOn?: PastDateFilter;
     customField?: {
       id: number;
       value: string;

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -325,8 +325,6 @@ const listInclude = pipe(
 // have no wire representation, so both are rejected at parse time.
 const dayOffset = pipe(number(), integer(), minValue(0));
 
-// Named periods and presence checks that every :date/:date_past field
-// accepts (see PastDateFilter's jsdoc in issues/type.ts).
 const namedPeriod = picklist([
   "today",
   "yesterday",
@@ -340,9 +338,6 @@ const namedPeriod = picklist([
   "none",
 ]);
 
-// Future-looking named periods, valid only on :date fields (start_date/
-// due_date) - :date_past fields reject them with a 422, same as
-// daysFromNow above.
 const futureNamedPeriod = picklist(["tomorrow", "nextWeek", "nextMonth"]);
 
 // strictObject (not object) is required for the from/to variants: object()
@@ -361,9 +356,6 @@ const pastDateFilter = union([
   strictObject({ to: strictObject({ daysAgo: dayOffset }) }),
 ]);
 
-// Widens pastDateFilter with future-looking operators that Redmine's
-// :date_past fields (created_on/updated_on/closed_on) reject with a 422 -
-// see PastDateFilter's jsdoc in issues/type.ts for why the split exists.
 const dateFilter = union([
   ...pastDateFilter.options,
   futureNamedPeriod,
@@ -449,10 +441,6 @@ const toCustomFieldOption = pipe(
   }),
 );
 
-// Named-period and presence literals map to a fixed operator with no
-// interpolation, unlike the daysAgo/daysFromNow branches below - see
-// PastDateFilter/DateFilter's jsdoc in issues/type.ts for which literals
-// each field accepts.
 const namedPeriodOperators: Record<string, string> = {
   today: "t",
   yesterday: "ld",
@@ -496,9 +484,7 @@ function toBoundValue(bound: DateBound): string {
   return `${"daysAgo" in bound ? bound.daysAgo : bound.daysFromNow}`;
 }
 
-// Which operator a range maps to depends only on the kind of each bound, not
-// on the values, so the nine combinations the schema admits are listed here
-// instead of being rediscovered by nested conditionals.
+// The operator depends only on the kind of each bound, never on its value.
 const rangeOperators: Record<string, string> = {
   "date/absent": ">=",
   "absent/date": "<=",
@@ -511,12 +497,10 @@ const rangeOperators: Record<string, string> = {
   "absent/future": "<t+",
 };
 
-// Redmine's short filter wire form: field=<operator><values joined by |>.
-// Nothing separates the operator from its first value: add_short_filter runs
-// `values.split('|')` on whatever follows the operator, so `t-|3` would split
-// to ["", "3"] and Redmine rejects the blank first value with a 422. Only the
-// two-date `><` form carries a pipe, because it really does pass two values.
-// There is no strict >/<, so absolute from/to bounds are always inclusive.
+// add_short_filter splits everything following the operator on "|", so `t-|3`
+// would yield the value list ["", "3"] and Redmine would reject the blank
+// first entry with a 422. Only the two-date `><` form takes a pipe, because
+// that one really does pass two values.
 function toDateFilterQueryValue(
   value: InferOutput<typeof dateFilter>,
 ): string {

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -331,11 +331,32 @@ const listInclude = pipe(
 // have no wire representation, so both are rejected at parse time.
 const dayOffset = pipe(number(), integer(), minValue(0));
 
+// Named periods and presence checks that every :date/:date_past field
+// accepts (see PastDateFilter's jsdoc in issues/type.ts).
+const namedPeriod = picklist([
+  "today",
+  "yesterday",
+  "thisWeek",
+  "lastWeek",
+  "lastTwoWeeks",
+  "thisMonth",
+  "lastMonth",
+  "thisYear",
+  "any",
+  "none",
+]);
+
+// Future-looking named periods, valid only on :date fields (start_date/
+// due_date) - :date_past fields reject them with a 422, same as
+// daysFromNow above.
+const futureNamedPeriod = picklist(["tomorrow", "nextWeek", "nextMonth"]);
+
 // strictObject (not object) is required for the from/to variants: object()
 // silently strips unknown keys, so object({ from: date() }) would also
 // match { from, to } and drop `to`, emitting `>=` where `><` was meant.
 const pastDateFilter = union([
   date(),
+  namedPeriod,
   strictObject({ from: date(), to: optional(date()) }),
   strictObject({ from: optional(date()), to: date() }),
   strictObject({ daysAgo: dayOffset }),
@@ -351,6 +372,7 @@ const pastDateFilter = union([
 // see PastDateFilter's jsdoc in issues/type.ts for why the split exists.
 const dateFilter = union([
   ...pastDateFilter.options,
+  futureNamedPeriod,
   strictObject({ daysFromNow: dayOffset }),
   strictObject({ from: strictObject({ daysFromNow: dayOffset }) }),
   strictObject({ to: strictObject({ daysFromNow: dayOffset }) }),
@@ -433,6 +455,26 @@ const toCustomFieldOption = pipe(
   }),
 );
 
+// Named-period and presence literals map to a fixed operator with no
+// interpolation, unlike the daysAgo/daysFromNow branches below - see
+// PastDateFilter/DateFilter's jsdoc in issues/type.ts for which literals
+// each field accepts.
+const namedPeriodOperators: Record<string, string> = {
+  today: "t",
+  yesterday: "ld",
+  thisWeek: "w",
+  lastWeek: "lw",
+  lastTwoWeeks: "l2w",
+  thisMonth: "m",
+  lastMonth: "lm",
+  thisYear: "y",
+  any: "*",
+  none: "!*",
+  tomorrow: "nd",
+  nextWeek: "nw",
+  nextMonth: "nm",
+};
+
 // Redmine's short filter wire form: field=<operator><values joined by |>.
 // Relative operators put a `|` between operator and value (t-|3); absolute
 // bounds do not (>=2026-07-01). There is no strict >/<, so absolute
@@ -442,6 +484,9 @@ function toDateFilterQueryValue(
 ): string {
   if (value instanceof Date) {
     return `=${toRedmineDateString(value)}`;
+  }
+  if (typeof value === "string") {
+    return namedPeriodOperators[value];
   }
   if ("daysAgo" in value) {
     return `t-|${value.daysAgo}`;

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -327,7 +327,7 @@ const listInclude = pipe(
   transform((value) => toUniqueArray(value)),
 );
 
-// Redmine accepts 0 (t-|0 means "today"); negatives and fractional counts
+// Redmine accepts 0 (t-0 means "today"); negatives and fractional counts
 // have no wire representation, so both are rejected at parse time.
 const dayOffset = pipe(number(), integer(), minValue(0));
 
@@ -476,9 +476,11 @@ const namedPeriodOperators: Record<string, string> = {
 };
 
 // Redmine's short filter wire form: field=<operator><values joined by |>.
-// Relative operators put a `|` between operator and value (t-|3); absolute
-// bounds do not (>=2026-07-01). There is no strict >/<, so absolute
-// from/to bounds are always inclusive.
+// Nothing separates the operator from its first value: add_short_filter runs
+// `values.split('|')` on whatever follows the operator, so `t-|3` would split
+// to ["", "3"] and Redmine rejects the blank first value with a 422. Only the
+// two-date `><` form carries a pipe, because it really does pass two values.
+// There is no strict >/<, so absolute from/to bounds are always inclusive.
 function toDateFilterQueryValue(
   value: InferOutput<typeof dateFilter>,
 ): string {
@@ -489,10 +491,10 @@ function toDateFilterQueryValue(
     return namedPeriodOperators[value];
   }
   if ("daysAgo" in value) {
-    return `t-|${value.daysAgo}`;
+    return `t-${value.daysAgo}`;
   }
   if ("daysFromNow" in value) {
-    return `t+|${value.daysFromNow}`;
+    return `t+${value.daysFromNow}`;
   }
 
   // Every remaining union member narrows from/to to Date, "today", or a
@@ -505,23 +507,23 @@ function toDateFilterQueryValue(
   };
 
   if (from !== undefined && typeof from === "object" && "daysAgo" in from) {
-    return to === "today" ? `><t-|${from.daysAgo}` : `>t-|${from.daysAgo}`;
+    return to === "today" ? `><t-${from.daysAgo}` : `>t-${from.daysAgo}`;
   }
   if (
     from !== undefined && typeof from === "object" && "daysFromNow" in from
   ) {
-    return `>t+|${from.daysFromNow}`;
+    return `>t+${from.daysFromNow}`;
   }
   if (from === "today") {
     // The dateFilter schema only pairs from: "today" with to: { daysFromNow }.
     const toOffset = to as { daysFromNow: number };
-    return `><t+|${toOffset.daysFromNow}`;
+    return `><t+${toOffset.daysFromNow}`;
   }
   if (to !== undefined && typeof to === "object" && "daysAgo" in to) {
-    return `<t-|${to.daysAgo}`;
+    return `<t-${to.daysAgo}`;
   }
   if (to !== undefined && typeof to === "object" && "daysFromNow" in to) {
-    return `<t+|${to.daysFromNow}`;
+    return `<t+${to.daysFromNow}`;
   }
   if (from !== undefined && to !== undefined) {
     return `><${toRedmineDateString(from as Date)}|${

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -327,13 +327,37 @@ const listInclude = pipe(
   transform((value) => toUniqueArray(value)),
 );
 
+// Redmine accepts 0 (t-|0 means "today"); negatives and fractional counts
+// have no wire representation, so both are rejected at parse time.
+const dayOffset = pipe(number(), integer(), minValue(0));
+
 // strictObject (not object) is required for the from/to variants: object()
 // silently strips unknown keys, so object({ from: date() }) would also
 // match { from, to } and drop `to`, emitting `>=` where `><` was meant.
-const dateFilter = union([
+const pastDateFilter = union([
   date(),
   strictObject({ from: date(), to: optional(date()) }),
   strictObject({ from: optional(date()), to: date() }),
+  strictObject({ daysAgo: dayOffset }),
+  strictObject({
+    from: strictObject({ daysAgo: dayOffset }),
+    to: optional(literal("today")),
+  }),
+  strictObject({ to: strictObject({ daysAgo: dayOffset }) }),
+]);
+
+// Widens pastDateFilter with future-looking operators that Redmine's
+// :date_past fields (created_on/updated_on/closed_on) reject with a 422 -
+// see PastDateFilter's jsdoc in issues/type.ts for why the split exists.
+const dateFilter = union([
+  ...pastDateFilter.options,
+  strictObject({ daysFromNow: dayOffset }),
+  strictObject({ from: strictObject({ daysFromNow: dayOffset }) }),
+  strictObject({ to: strictObject({ daysFromNow: dayOffset }) }),
+  strictObject({
+    from: literal("today"),
+    to: strictObject({ daysFromNow: dayOffset }),
+  }),
 ]);
 
 const listIssueQuery = partial(
@@ -353,9 +377,9 @@ const listIssueQuery = partial(
     parentId: string(),
     startDate: dateFilter,
     dueDate: dateFilter,
-    createdOn: dateFilter,
-    updatedOn: dateFilter,
-    closedOn: dateFilter,
+    createdOn: pastDateFilter,
+    updatedOn: pastDateFilter,
+    closedOn: pastDateFilter,
     customField: array(object({
       id: number(),
       value: string(),
@@ -410,22 +434,61 @@ const toCustomFieldOption = pipe(
 );
 
 // Redmine's short filter wire form: field=<operator><values joined by |>.
-// There is no strict >/<, so from/to are always inclusive.
-function toDateFilterQueryValue(value: InferOutput<typeof dateFilter>): string {
+// Relative operators put a `|` between operator and value (t-|3); absolute
+// bounds do not (>=2026-07-01). There is no strict >/<, so absolute
+// from/to bounds are always inclusive.
+function toDateFilterQueryValue(
+  value: InferOutput<typeof dateFilter>,
+): string {
   if (value instanceof Date) {
     return `=${toRedmineDateString(value)}`;
   }
-  if (value.from !== undefined && value.to !== undefined) {
-    return `><${toRedmineDateString(value.from)}|${
-      toRedmineDateString(value.to)
+  if ("daysAgo" in value) {
+    return `t-|${value.daysAgo}`;
+  }
+  if ("daysFromNow" in value) {
+    return `t+|${value.daysFromNow}`;
+  }
+
+  // Every remaining union member narrows from/to to Date, "today", or a
+  // relative offset; valibot's strictObject variants already guarantee the
+  // combination is one Redmine accepts, so this cast gives TS a single
+  // shape to switch on instead of re-deriving it from the full union.
+  const { from, to } = value as {
+    from?: Date | "today" | { daysAgo: number } | { daysFromNow: number };
+    to?: Date | "today" | { daysAgo: number } | { daysFromNow: number };
+  };
+
+  if (from !== undefined && typeof from === "object" && "daysAgo" in from) {
+    return to === "today" ? `><t-|${from.daysAgo}` : `>t-|${from.daysAgo}`;
+  }
+  if (
+    from !== undefined && typeof from === "object" && "daysFromNow" in from
+  ) {
+    return `>t+|${from.daysFromNow}`;
+  }
+  if (from === "today") {
+    // The dateFilter schema only pairs from: "today" with to: { daysFromNow }.
+    const toOffset = to as { daysFromNow: number };
+    return `><t+|${toOffset.daysFromNow}`;
+  }
+  if (to !== undefined && typeof to === "object" && "daysAgo" in to) {
+    return `<t-|${to.daysAgo}`;
+  }
+  if (to !== undefined && typeof to === "object" && "daysFromNow" in to) {
+    return `<t+|${to.daysFromNow}`;
+  }
+  if (from !== undefined && to !== undefined) {
+    return `><${toRedmineDateString(from as Date)}|${
+      toRedmineDateString(to as Date)
     }`;
   }
-  if (value.from !== undefined) {
-    return `>=${toRedmineDateString(value.from)}`;
+  if (from !== undefined) {
+    return `>=${toRedmineDateString(from as Date)}`;
   }
   // The dateFilter schema's strictObject variants guarantee at least one of
   // from/to is set, so reaching here means `to` is the one that is.
-  return `<=${toRedmineDateString(value.to!)}`;
+  return `<=${toRedmineDateString(to as Date)}`;
 }
 
 // Field names are listed explicitly (as toCustomFieldOption does) rather

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -441,6 +441,9 @@ const toCustomFieldOption = pipe(
   }),
 );
 
+// `satisfies` over the two picklists (rather than a bare Record<string,
+// string>) makes a period added to either schema without an operator here a
+// compile error instead of an `undefined` on the wire.
 const namedPeriodOperators: Record<string, string> = {
   today: "t",
   yesterday: "ld",
@@ -455,11 +458,16 @@ const namedPeriodOperators: Record<string, string> = {
   tomorrow: "nd",
   nextWeek: "nw",
   nextMonth: "nm",
-};
+} satisfies Record<
+  InferOutput<typeof namedPeriod> | InferOutput<typeof futureNamedPeriod>,
+  string
+>;
 
 type DateBound = Date | "today" | { daysAgo: number } | { daysFromNow: number };
 
-function toBoundKind(bound: DateBound | undefined): string {
+type BoundKind = "absent" | "today" | "date" | "past" | "future";
+
+function toBoundKind(bound: DateBound | undefined): BoundKind {
   if (bound === undefined) {
     return "absent";
   }
@@ -485,6 +493,14 @@ function toBoundValue(bound: DateBound): string {
 }
 
 // The operator depends only on the kind of each bound, never on its value.
+//
+// The annotation stays Record<string, string> so a RangeKey still indexes it;
+// `satisfies` only rejects a key that names no real pair of bound kinds. A
+// missing (rather than misspelled) entry stays uncaught: keying this totally
+// would mean writing all 25 combinations, 16 of which the filter unions
+// already forbid.
+type RangeKey = `${BoundKind}/${BoundKind}`;
+
 const rangeOperators: Record<string, string> = {
   "date/absent": ">=",
   "absent/date": "<=",
@@ -495,7 +511,7 @@ const rangeOperators: Record<string, string> = {
   "future/absent": ">t+",
   "today/future": "><t+",
   "absent/future": "<t+",
-};
+} satisfies Partial<Record<RangeKey, string>>;
 
 // add_short_filter splits everything following the operator on "|", so `t-|3`
 // would yield the value list ["", "3"] and Redmine would reject the blank

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -242,17 +242,11 @@ const listIssueSchema = pipe(
 // show() -> update() round-trip on the same calendar day. The trade-off:
 // a Date built from local calendar fields (e.g. new Date(2026, 6, 1) in
 // UTC+9) serializes to the previous day.
-const toRedmineDate = pipe(
-  date(),
-  transform((input: Date) => input.toISOString().slice(0, 10)),
-);
-
-// Same UTC-day truncation as toRedmineDate above, kept as a plain function
-// (rather than reusing the valibot pipe) because the date filter transform
-// below runs outside of parse() and needs a callable, not a schema.
 function toRedmineDateString(input: Date): string {
   return input.toISOString().slice(0, 10);
 }
+
+const toRedmineDate = pipe(date(), transform(toRedmineDateString));
 
 // The schema keys are camelCase to match the public UpdateIssueQuery input.
 // valibot's object() strips unknown keys, so a snake_case schema would drop
@@ -475,6 +469,48 @@ const namedPeriodOperators: Record<string, string> = {
   nextMonth: "nm",
 };
 
+type DateBound = Date | "today" | { daysAgo: number } | { daysFromNow: number };
+
+function toBoundKind(bound: DateBound | undefined): string {
+  if (bound === undefined) {
+    return "absent";
+  }
+  if (bound === "today") {
+    return "today";
+  }
+  if (bound instanceof Date) {
+    return "date";
+  }
+  return "daysAgo" in bound ? "past" : "future";
+}
+
+// "today" contributes no value of its own: it only tells Redmine which of the
+// bounded operators to use (><t- pins the upper end to today, ><t+ the lower).
+function toBoundValue(bound: DateBound): string {
+  if (bound === "today") {
+    return "";
+  }
+  if (bound instanceof Date) {
+    return toRedmineDateString(bound);
+  }
+  return `${"daysAgo" in bound ? bound.daysAgo : bound.daysFromNow}`;
+}
+
+// Which operator a range maps to depends only on the kind of each bound, not
+// on the values, so the nine combinations the schema admits are listed here
+// instead of being rediscovered by nested conditionals.
+const rangeOperators: Record<string, string> = {
+  "date/absent": ">=",
+  "absent/date": "<=",
+  "date/date": "><",
+  "past/absent": ">t-",
+  "past/today": "><t-",
+  "absent/past": "<t-",
+  "future/absent": ">t+",
+  "today/future": "><t+",
+  "absent/future": "<t+",
+};
+
 // Redmine's short filter wire form: field=<operator><values joined by |>.
 // Nothing separates the operator from its first value: add_short_filter runs
 // `values.split('|')` on whatever follows the operator, so `t-|3` would split
@@ -497,45 +533,14 @@ function toDateFilterQueryValue(
     return `t+${value.daysFromNow}`;
   }
 
-  // Every remaining union member narrows from/to to Date, "today", or a
-  // relative offset; valibot's strictObject variants already guarantee the
-  // combination is one Redmine accepts, so this cast gives TS a single
-  // shape to switch on instead of re-deriving it from the full union.
-  const { from, to } = value as {
-    from?: Date | "today" | { daysAgo: number } | { daysFromNow: number };
-    to?: Date | "today" | { daysAgo: number } | { daysFromNow: number };
-  };
-
-  if (from !== undefined && typeof from === "object" && "daysAgo" in from) {
-    return to === "today" ? `><t-${from.daysAgo}` : `>t-${from.daysAgo}`;
-  }
-  if (
-    from !== undefined && typeof from === "object" && "daysFromNow" in from
-  ) {
-    return `>t+${from.daysFromNow}`;
-  }
-  if (from === "today") {
-    // The dateFilter schema only pairs from: "today" with to: { daysFromNow }.
-    const toOffset = to as { daysFromNow: number };
-    return `><t+${toOffset.daysFromNow}`;
-  }
-  if (to !== undefined && typeof to === "object" && "daysAgo" in to) {
-    return `<t-${to.daysAgo}`;
-  }
-  if (to !== undefined && typeof to === "object" && "daysFromNow" in to) {
-    return `<t+${to.daysFromNow}`;
-  }
-  if (from !== undefined && to !== undefined) {
-    return `><${toRedmineDateString(from as Date)}|${
-      toRedmineDateString(to as Date)
-    }`;
-  }
-  if (from !== undefined) {
-    return `>=${toRedmineDateString(from as Date)}`;
-  }
-  // The dateFilter schema's strictObject variants guarantee at least one of
-  // from/to is set, so reaching here means `to` is the one that is.
-  return `<=${toRedmineDateString(to as Date)}`;
+  const from = "from" in value ? value.from : undefined;
+  const to = "to" in value ? value.to : undefined;
+  const operator = rangeOperators[`${toBoundKind(from)}/${toBoundKind(to)}`];
+  const values = [from, to]
+    .filter((bound) => bound !== undefined)
+    .map(toBoundValue)
+    .filter((serialized) => serialized !== "");
+  return `${operator}${values.join("|")}`;
 }
 
 // Field names are listed explicitly (as toCustomFieldOption does) rather

--- a/issues/validator.ts
+++ b/issues/validator.ts
@@ -2,6 +2,7 @@ import {
   array,
   boolean,
   date,
+  type InferOutput,
   integer,
   literal,
   minValue,
@@ -14,6 +15,7 @@ import {
   partial,
   picklist,
   pipe,
+  strictObject,
   string,
   transform,
   union,
@@ -245,6 +247,13 @@ const toRedmineDate = pipe(
   transform((input: Date) => input.toISOString().slice(0, 10)),
 );
 
+// Same UTC-day truncation as toRedmineDate above, kept as a plain function
+// (rather than reusing the valibot pipe) because the date filter transform
+// below runs outside of parse() and needs a callable, not a schema.
+function toRedmineDateString(input: Date): string {
+  return input.toISOString().slice(0, 10);
+}
+
 // The schema keys are camelCase to match the public UpdateIssueQuery input.
 // valibot's object() strips unknown keys, so a snake_case schema would drop
 // every camelCase-only field before objectToSnake could convert it.
@@ -318,6 +327,15 @@ const listInclude = pipe(
   transform((value) => toUniqueArray(value)),
 );
 
+// strictObject (not object) is required for the from/to variants: object()
+// silently strips unknown keys, so object({ from: date() }) would also
+// match { from, to } and drop `to`, emitting `>=` where `><` was meant.
+const dateFilter = union([
+  date(),
+  strictObject({ from: date(), to: optional(date()) }),
+  strictObject({ from: optional(date()), to: date() }),
+]);
+
 const listIssueQuery = partial(
   object({
     limit: pipe(number(), integer(), minValue(1)),
@@ -333,6 +351,11 @@ const listIssueQuery = partial(
     assignedToId: union([number(), literal("me")]),
     authorId: union([number(), literal("me")]),
     parentId: string(),
+    startDate: dateFilter,
+    dueDate: dateFilter,
+    createdOn: dateFilter,
+    updatedOn: dateFilter,
+    closedOn: dateFilter,
     customField: array(object({
       id: number(),
       value: string(),
@@ -346,12 +369,21 @@ export const toListOption = pipe(
     return {
       ...parse(toQueryObject, input),
       ...parse(toCustomFieldOption, input.customField),
+      ...toDateFilterOption(input),
     };
   }),
 );
 
 const toQueryObject = pipe(
-  omit(listIssueQuery, ["customField", "limit"]),
+  omit(listIssueQuery, [
+    "customField",
+    "limit",
+    "startDate",
+    "dueDate",
+    "createdOn",
+    "updatedOn",
+    "closedOn",
+  ]),
   transform((input) => {
     return objectToSnake(input);
   }),
@@ -376,3 +408,50 @@ const toCustomFieldOption = pipe(
     );
   }),
 );
+
+// Redmine's short filter wire form: field=<operator><values joined by |>.
+// There is no strict >/<, so from/to are always inclusive.
+function toDateFilterQueryValue(value: InferOutput<typeof dateFilter>): string {
+  if (value instanceof Date) {
+    return `=${toRedmineDateString(value)}`;
+  }
+  if (value.from !== undefined && value.to !== undefined) {
+    return `><${toRedmineDateString(value.from)}|${
+      toRedmineDateString(value.to)
+    }`;
+  }
+  if (value.from !== undefined) {
+    return `>=${toRedmineDateString(value.from)}`;
+  }
+  // The dateFilter schema's strictObject variants guarantee at least one of
+  // from/to is set, so reaching here means `to` is the one that is.
+  return `<=${toRedmineDateString(value.to!)}`;
+}
+
+// Field names are listed explicitly (as toCustomFieldOption does) rather
+// than run through objectToSnake, because objectToSnake deep-converts
+// nested object keys and would reach into the from/to Date instances.
+const dateFilterFields = [
+  ["startDate", "start_date"],
+  ["dueDate", "due_date"],
+  ["createdOn", "created_on"],
+  ["updatedOn", "updated_on"],
+  ["closedOn", "closed_on"],
+] as const;
+
+function toDateFilterOption(
+  input: Partial<
+    Record<
+      typeof dateFilterFields[number][0],
+      InferOutput<typeof dateFilter>
+    >
+  >,
+): Record<string, string> {
+  return Object.fromEntries(
+    dateFilterFields
+      .filter(([key]) => input[key] !== undefined)
+      .map((
+        [key, param],
+      ) => [param, toDateFilterQueryValue(input[key]!)]),
+  );
+}


### PR DESCRIPTION
## Summary

Adds date filters to the issue list for `startDate`, `dueDate`, `createdOn`, `updatedOn`, and `closedOn`.

## Details

Redmine has no strict `>` / `<` for dates, so every bound is inclusive and the type exposes only what the API can express: a bare `Date`, `{ from, to }`, `{ daysAgo }` / `{ daysFromNow }`, and named periods such as `"lastWeek"` or `"none"`.

`createdOn`, `updatedOn`, and `closedOn` take a narrower type than the other two, because Redmine's `:date_past` filters reject future-looking operators with a 422.

## Confirmation

`nix run .#check-deno` passes, and the e2e suite passes against Redmine 5.1 and 7.0 with all 25 wire forms exercised.

## Limitation

Day granularity only. Second precision on `created_on` / `updated_on` would need a separate input type.

Generated with: Claude

https://claude.ai/code/session_016JX6NcqUwDWjaEJEL6tUf9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive date filtering for issue lists, including exact dates, bounded ranges, relative day offsets, and named periods.
  - Enabled future-looking date filters for start and due dates.
  - Updated query parameter behavior so date filters serialize consistently across supported fields.
- **Bug Fixes**
  - Improved validation and Redmine-compatible date formatting, including correct handling of bounds and period operators.
- **Tests**
  - Expanded E2E and unit coverage for issue date filter handling to prevent invalid 422 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->